### PR TITLE
Repair Yocto manual indexes

### DIFF
--- a/source/yocto/L-813e.A10_Yocto_Reference_Manual_Zeus_.rst
+++ b/source/yocto/L-813e.A10_Yocto_Reference_Manual_Zeus_.rst
@@ -43,239 +43,206 @@ This manual applies to all *zeus* based PHYTEC releases:
 | octo-FSL-i.MX8MP-PD21.1.3 |               |               | eleased |
 +---------------------------+---------------+---------------+---------+
 
--  1 `The Yocto
-   Project <#L813e.A10YoctoReferenceManual(Zeus)-TheYoctoProject>`__
+-  1 `L-813e.A10 Yocto Reference Manual (Zeus)`_
 
-   -  1.1 `PHYTEC
-      Documentation <#L813e.A10YoctoReferenceManual(Zeus)-PHYTECDocumentation>`__
-   -  1.2 `Yocto
-      Introduction <#L813e.A10YoctoReferenceManual(Zeus)-YoctoIntroduction>`__
-   -  1.3 `Core
-      Components <#L813e.A10YoctoReferenceManual(Zeus)-CoreComponents>`__
-   -  1.4
-      `Vocabulary <#L813e.A10YoctoReferenceManual(Zeus)-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.4.1
-         `Recipes <#L813e.A10YoctoReferenceManual(Zeus)-Recipes>`__
-      -  1.4.2
-         `Classes <#L813e.A10YoctoReferenceManual(Zeus)-Classes>`__
-      -  1.4.3 `Layers <#L813e.A10YoctoReferenceManual(Zeus)-Layers>`__
-      -  1.4.4
-         `Machine <#L813e.A10YoctoReferenceManual(Zeus)-Machine>`__
-      -  1.4.5 `Distribution
-         (Distro) <#L813e.A10YoctoReferenceManual(Zeus)-Distribution(Distro)>`__
+   -  2.1 `PHYTEC Documentation`_
 
-   -  1.5 `Poky <#L813e.A10YoctoReferenceManual(Zeus)-Poky>`__
+   -  2.2 `Yocto Introduction`_
 
-      -  1.5.1
-         `Bitbake <#L813e.A10YoctoReferenceManual(Zeus)-Bitbake>`__
-      -  1.5.2
-         `Toaster <#L813e.A10YoctoReferenceManual(Zeus)-Toaster>`__
+   -  2.3 `Core Components`_
 
-   -  1.6 `Official
-      Documentation <#L813e.A10YoctoReferenceManual(Zeus)-OfficialDocumentation>`__
+   -  2.4 `Vocabulary`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.A10YoctoReferenceManual(Zeus)-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.A10YoctoReferenceManual(Zeus)-PHYTECBSPIntroduction>`__
+      -  2.4.1 `Recipes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.A10YoctoReferenceManual(Zeus)-BSPStructure>`__
+      -  2.4.2 `Classes`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.A10YoctoReferenceManual(Zeus)-BSPManagement>`__
+      -  2.4.3 `Layers`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.A10YoctoReferenceManual(Zeus)-phyLinux>`__
-         -  3.1.1.2 `Repo <#L813e.A10YoctoReferenceManual(Zeus)-Repo>`__
+      -  2.4.4 `Machine`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.A10YoctoReferenceManual(Zeus)-BSPMetadata>`__
+      -  2.4.5 `Distribution (Distro)`_
 
-         -  3.1.2.1
-            `Poky <#L813e.A10YoctoReferenceManual(Zeus)-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.A10YoctoReferenceManual(Zeus)-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.A10YoctoReferenceManual(Zeus)-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.A10YoctoReferenceManual(Zeus)-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.A10YoctoReferenceManual(Zeus)-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.A10YoctoReferenceManual(Zeus)-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.A10YoctoReferenceManual(Zeus)-meta-phytec>`__
-         -  3.1.2.8
-            `meta-yogurt <#L813e.A10YoctoReferenceManual(Zeus)-meta-yogurt>`__
-         -  3.1.2.9
-            `meta-virtualization <#L813e.A10YoctoReferenceManual(Zeus)-meta-virtualization>`__
-         -  3.1.2.10
-            `meta-security <#L813e.A10YoctoReferenceManual(Zeus)-meta-security>`__
-         -  3.1.2.11
-            `meta-browser <#L813e.A10YoctoReferenceManual(Zeus)-meta-browser>`__
-         -  3.1.2.12
-            `meta-rust <#L813e.A10YoctoReferenceManual(Zeus)-meta-rust>`__
-         -  3.1.2.13
-            `meta-timesys <#L813e.A10YoctoReferenceManual(Zeus)-meta-timesys>`__
-         -  3.1.2.14
-            `meta-freescale <#L813e.A10YoctoReferenceManual(Zeus)-meta-freescale>`__
-         -  3.1.2.15
-            `meta-freescale-3rdparty <#L813e.A10YoctoReferenceManual(Zeus)-meta-freescale-3rdparty>`__
-         -  3.1.2.16
-            `meta-freescale-distro <#L813e.A10YoctoReferenceManual(Zeus)-meta-freescale-distro>`__
-         -  3.1.2.17 `base
-            (fsl-community-bsp-base) <#L813e.A10YoctoReferenceManual(Zeus)-base(fsl-community-bsp-base)>`__
-         -  3.1.2.18
-            `meta-fsl-bsp-release <#L813e.A10YoctoReferenceManual(Zeus)-meta-fsl-bsp-release>`__
+   -  2.5 `Poky`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.A10YoctoReferenceManual(Zeus)-BSPContent>`__
+      -  2.5.1 `Bitbake`_
 
-   -  3.2 `Build
-      Configuration <#L813e.A10YoctoReferenceManual(Zeus)-BuildConfiguration>`__
+      -  2.5.2 `Toaster`_
 
--  4 `Prebuild
-   Images <#L813e.A10YoctoReferenceManual(Zeus)-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.A10YoctoReferenceManual(Zeus)-BSPWorkspaceInstallation>`__
+   -  2.6 `Official Documentation`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.A10YoctoReferenceManual(Zeus)-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.A10YoctoReferenceManual(Zeus)-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.A10YoctoReferenceManual(Zeus)-site.confSetup>`__
+-  3 `Compatible Linux Distributions`_
 
--  6 `phyLinux
-   Documentation <#L813e.A10YoctoReferenceManual(Zeus)-phyLinuxDocumentation>`__
+-  4 `PHYTEC BSP Introduction`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.A10YoctoReferenceManual(Zeus)-GetphyLinux>`__
-   -  6.2 `Basic
-      Usage <#L813e.A10YoctoReferenceManual(Zeus)-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.A10YoctoReferenceManual(Zeus)-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.A10YoctoReferenceManual(Zeus)-AdvancedUsage>`__
+   -  4.1 `BSP Structure`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.A10YoctoReferenceManual(Zeus)-WorkingwithPokyandBitbake>`__
+      -  4.1.1 `BSP Management`_
 
-   -  7.1 `Start the
-      Build <#L813e.A10YoctoReferenceManual(Zeus)-StarttheBuild>`__
-   -  7.2 `Images <#L813e.A10YoctoReferenceManual(Zeus)-imagesImages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.A10YoctoReferenceManual(Zeus)-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.A10YoctoReferenceManual(Zeus)-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-yogurt <#L813e.A10YoctoReferenceManual(Zeus)-BSPFeaturesofmeta-phytecandmeta-yogurt>`__
+         -  4.1.1.1 `phyLinux`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.A10YoctoReferenceManual(Zeus)-Buildinfo>`__
+         -  4.1.1.2 `Repo`_
 
-   -  7.6 `BSP
-      Customization <#L813e.A10YoctoReferenceManual(Zeus)-BSPCustomization>`__
+      -  4.1.2 `BSP Metadata`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.A10YoctoReferenceManual(Zeus)-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.A10YoctoReferenceManual(Zeus)-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.A10YoctoReferenceManual(Zeus)-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.1 `poky-1`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.A10YoctoReferenceManual(Zeus)-RAMBenchmark>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.A10YoctoReferenceManual(Zeus)-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.3 `meta-qt5`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.A10YoctoReferenceManual(Zeus)-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.A10YoctoReferenceManual(Zeus)-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.A10YoctoReferenceManual(Zeus)-CreateyourownLayercreatelayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.A10YoctoReferenceManual(Zeus)-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.A10YoctoReferenceManual(Zeus)-KernelandBootloaderConfiguration>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.A10YoctoReferenceManual(Zeus)-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.A10YoctoReferenceManual(Zeus)-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.6 `meta-rauc`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.A10YoctoReferenceManual(Zeus)-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.A10YoctoReferenceManual(Zeus)-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.A10YoctoReferenceManual(Zeus)-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.A10YoctoReferenceManual(Zeus)-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.A10YoctoReferenceManual(Zeus)-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.A10YoctoReferenceManual(Zeus)-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.7 `meta-phytec`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.A10YoctoReferenceManual(Zeus)-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.A10YoctoReferenceManual(Zeus)-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.A10YoctoReferenceManual(Zeus)-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+         -  4.1.2.8 `meta-yogurt`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.A10YoctoReferenceManual(Zeus)-ChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.A10YoctoReferenceManual(Zeus)-ChangingtheWirelessNetworkConfiguration>`__
+         -  4.1.2.9 `meta-virtualization`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.A10YoctoReferenceManual(Zeus)-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.A10YoctoReferenceManual(Zeus)-CreatingaWLANAccessPoint>`__
+         -  4.1.2.10 `meta-security`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.A10YoctoReferenceManual(Zeus)-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.A10YoctoReferenceManual(Zeus)-AddMinimalphpwebruntimewithlightpd>`__
+         -  4.1.2.11 `meta-browser`_
 
-   -  7.7 `Common
-      Tasks <#L813e.A10YoctoReferenceManual(Zeus)-CommonTasks>`__
+         -  4.1.2.12 `meta-rust`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.A10YoctoReferenceManual(Zeus)-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.A10YoctoReferenceManual(Zeus)-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.A10YoctoReferenceManual(Zeus)-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.A10YoctoReferenceManual(Zeus)-DifferentToolchains>`__
+         -  4.1.2.13 `meta-timesys`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.A10YoctoReferenceManual(Zeus)-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.A10YoctoReferenceManual(Zeus)-UsingtheSDKwithGNUAutotools>`__
+         -  4.1.2.14 `meta-freescale`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.A10YoctoReferenceManual(Zeus)-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.A10YoctoReferenceManual(Zeus)-Workingwithudev>`__
+         -  4.1.2.15 `meta-freescale-3rdparty`_
 
--  8
-   `Troubleshooting <#L813e.A10YoctoReferenceManual(Zeus)-Troubleshooting>`__
+         -  4.1.2.16 `meta-freescale-distro`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.A10YoctoReferenceManual(Zeus)-SetsceneTaskWarning>`__
+         -  4.1.2.17 `base (fsl-community-bsp-base)`_
 
--  9 `Yocto
-   Documentation <#L813e.A10YoctoReferenceManual(Zeus)-YoctoDocumentation>`__
+         -  4.1.2.18 `meta-fsl-bsp-release`_
+
+      -  4.1.3 `BSP Content`_
+
+   -  4.2 `Build Configuration`_
+
+-  5 `Prebuild Images`_
+
+-  6 `BSP Workspace Installation`_
+
+   -  6.1 `Setting Up the Host`_
+
+   -  6.2 `Git Configuration`_
+
+   -  6.3 `site.conf Setup`_
+
+-  7 `phyLinux Documentation`_
+
+   -  7.1 `Get phyLinux`_
+
+   -  7.2 `Basic Usage`_
+
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-yogurt`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
+
 
 The Yocto Project
 =================
@@ -433,8 +400,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:

--- a/source/yocto/L-813e.A11_Yocto_Reference_Manual_Dunfell_.rst
+++ b/source/yocto/L-813e.A11_Yocto_Reference_Manual_Dunfell_.rst
@@ -32,244 +32,207 @@ L-813e.A11 Yocto Reference Manual (Dunfell)
 
 This manual applies to all *dunfell* based PHYTEC releases:
 
--  1 `The Yocto
-   Project <#L813e.A11YoctoReferenceManual(Dunfell)-TheYoctoProject>`__
+-  1 `L-813e.A11 Yocto Reference Manual (Dunfell)`_
 
-   -  1.1 `PHYTEC
-      Documentation <#L813e.A11YoctoReferenceManual(Dunfell)-PHYTECDocumentation>`__
-   -  1.2 `Yocto
-      Introduction <#L813e.A11YoctoReferenceManual(Dunfell)-YoctoIntroduction>`__
-   -  1.3 `Core
-      Components <#L813e.A11YoctoReferenceManual(Dunfell)-CoreComponents>`__
-   -  1.4
-      `Vocabulary <#L813e.A11YoctoReferenceManual(Dunfell)-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.4.1
-         `Recipes <#L813e.A11YoctoReferenceManual(Dunfell)-Recipes>`__
-      -  1.4.2
-         `Classes <#L813e.A11YoctoReferenceManual(Dunfell)-Classes>`__
-      -  1.4.3
-         `Layers <#L813e.A11YoctoReferenceManual(Dunfell)-Layers>`__
-      -  1.4.4
-         `Machine <#L813e.A11YoctoReferenceManual(Dunfell)-Machine>`__
-      -  1.4.5 `Distribution
-         (Distro) <#L813e.A11YoctoReferenceManual(Dunfell)-Distribution(Distro)>`__
+   -  2.1 `PHYTEC Documentation`_
 
-   -  1.5 `Poky <#L813e.A11YoctoReferenceManual(Dunfell)-Poky>`__
+   -  2.2 `Yocto Introduction`_
 
-      -  1.5.1
-         `Bitbake <#L813e.A11YoctoReferenceManual(Dunfell)-Bitbake>`__
-      -  1.5.2
-         `Toaster <#L813e.A11YoctoReferenceManual(Dunfell)-Toaster>`__
+   -  2.3 `Core Components`_
 
-   -  1.6 `Official
-      Documentation <#L813e.A11YoctoReferenceManual(Dunfell)-OfficialDocumentation>`__
+   -  2.4 `Vocabulary`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.A11YoctoReferenceManual(Dunfell)-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.A11YoctoReferenceManual(Dunfell)-PHYTECBSPIntroduction>`__
+      -  2.4.1 `Recipes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.A11YoctoReferenceManual(Dunfell)-BSPStructure>`__
+      -  2.4.2 `Classes`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.A11YoctoReferenceManual(Dunfell)-BSPManagement>`__
+      -  2.4.3 `Layers`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.A11YoctoReferenceManual(Dunfell)-phyLinux>`__
-         -  3.1.1.2
-            `Repo <#L813e.A11YoctoReferenceManual(Dunfell)-Repo>`__
+      -  2.4.4 `Machine`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.A11YoctoReferenceManual(Dunfell)-BSPMetadata>`__
+      -  2.4.5 `Distribution (Distro)`_
 
-         -  3.1.2.1
-            `Poky <#L813e.A11YoctoReferenceManual(Dunfell)-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.A11YoctoReferenceManual(Dunfell)-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.A11YoctoReferenceManual(Dunfell)-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.A11YoctoReferenceManual(Dunfell)-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.A11YoctoReferenceManual(Dunfell)-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.A11YoctoReferenceManual(Dunfell)-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.A11YoctoReferenceManual(Dunfell)-meta-phytec>`__
-         -  3.1.2.8
-            `meta-yogurt <#L813e.A11YoctoReferenceManual(Dunfell)-meta-yogurt>`__
-         -  3.1.2.9
-            `meta-virtualization <#L813e.A11YoctoReferenceManual(Dunfell)-meta-virtualization>`__
-         -  3.1.2.10
-            `meta-security <#L813e.A11YoctoReferenceManual(Dunfell)-meta-security>`__
-         -  3.1.2.11
-            `meta-selinux <#L813e.A11YoctoReferenceManual(Dunfell)-meta-selinux>`__
-         -  3.1.2.12
-            `meta-browser <#L813e.A11YoctoReferenceManual(Dunfell)-meta-browser>`__
-         -  3.1.2.13
-            `meta-rust <#L813e.A11YoctoReferenceManual(Dunfell)-meta-rust>`__
-         -  3.1.2.14
-            `meta-timesys <#L813e.A11YoctoReferenceManual(Dunfell)-meta-timesys>`__
-         -  3.1.2.15
-            `meta-freescale <#L813e.A11YoctoReferenceManual(Dunfell)-meta-freescale>`__
-         -  3.1.2.16
-            `meta-freescale-3rdparty <#L813e.A11YoctoReferenceManual(Dunfell)-meta-freescale-3rdparty>`__
-         -  3.1.2.17
-            `meta-freescale-distro <#L813e.A11YoctoReferenceManual(Dunfell)-meta-freescale-distro>`__
-         -  3.1.2.18 `base
-            (fsl-community-bsp-base) <#L813e.A11YoctoReferenceManual(Dunfell)-base(fsl-community-bsp-base)>`__
-         -  3.1.2.19
-            `meta-fsl-bsp-release <#L813e.A11YoctoReferenceManual(Dunfell)-meta-fsl-bsp-release>`__
+   -  2.5 `Poky`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.A11YoctoReferenceManual(Dunfell)-BSPContent>`__
+      -  2.5.1 `Bitbake`_
 
-   -  3.2 `Build
-      Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-BuildConfiguration>`__
+      -  2.5.2 `Toaster`_
 
--  4 `Prebuild
-   Images <#L813e.A11YoctoReferenceManual(Dunfell)-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.A11YoctoReferenceManual(Dunfell)-BSPWorkspaceInstallation>`__
+   -  2.6 `Official Documentation`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.A11YoctoReferenceManual(Dunfell)-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.A11YoctoReferenceManual(Dunfell)-site.confSetup>`__
+-  3 `Compatible Linux Distributions`_
 
--  6 `phyLinux
-   Documentation <#L813e.A11YoctoReferenceManual(Dunfell)-phyLinuxDocumentation>`__
+-  4 `PHYTEC BSP Introduction`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.A11YoctoReferenceManual(Dunfell)-GetphyLinux>`__
-   -  6.2 `Basic
-      Usage <#L813e.A11YoctoReferenceManual(Dunfell)-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.A11YoctoReferenceManual(Dunfell)-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.A11YoctoReferenceManual(Dunfell)-AdvancedUsage>`__
+   -  4.1 `BSP Structure`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.A11YoctoReferenceManual(Dunfell)-WorkingwithPokyandBitbake>`__
+      -  4.1.1 `BSP Management`_
 
-   -  7.1 `Start the
-      Build <#L813e.A11YoctoReferenceManual(Dunfell)-StarttheBuild>`__
-   -  7.2
-      `Images <#L813e.A11YoctoReferenceManual(Dunfell)-Imagesimages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.A11YoctoReferenceManual(Dunfell)-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-yogurt <#L813e.A11YoctoReferenceManual(Dunfell)-BSPFeaturesofmeta-phytecandmeta-yogurt>`__
+         -  4.1.1.1 `phyLinux`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.A11YoctoReferenceManual(Dunfell)-Buildinfo>`__
+         -  4.1.1.2 `Repo`_
 
-   -  7.6 `BSP
-      Customization <#L813e.A11YoctoReferenceManual(Dunfell)-BSPCustomization>`__
+      -  4.1.2 `BSP Metadata`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.A11YoctoReferenceManual(Dunfell)-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.A11YoctoReferenceManual(Dunfell)-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.A11YoctoReferenceManual(Dunfell)-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.1 `poky-1`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.A11YoctoReferenceManual(Dunfell)-RAMBenchmark>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.A11YoctoReferenceManual(Dunfell)-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.3 `meta-qt5`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.A11YoctoReferenceManual(Dunfell)-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.A11YoctoReferenceManual(Dunfell)-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.A11YoctoReferenceManual(Dunfell)-CreateyourownLayercreatelayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.A11YoctoReferenceManual(Dunfell)-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-KernelandBootloaderConfiguration>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.A11YoctoReferenceManual(Dunfell)-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.A11YoctoReferenceManual(Dunfell)-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.6 `meta-rauc`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.A11YoctoReferenceManual(Dunfell)-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.A11YoctoReferenceManual(Dunfell)-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.A11YoctoReferenceManual(Dunfell)-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.A11YoctoReferenceManual(Dunfell)-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.A11YoctoReferenceManual(Dunfell)-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.A11YoctoReferenceManual(Dunfell)-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.7 `meta-phytec`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.A11YoctoReferenceManual(Dunfell)-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.A11YoctoReferenceManual(Dunfell)-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.A11YoctoReferenceManual(Dunfell)-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+         -  4.1.2.8 `meta-yogurt`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-ChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.A11YoctoReferenceManual(Dunfell)-ChangingtheWirelessNetworkConfiguration>`__
+         -  4.1.2.9 `meta-virtualization`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.A11YoctoReferenceManual(Dunfell)-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.A11YoctoReferenceManual(Dunfell)-CreatingaWLANAccessPoint>`__
+         -  4.1.2.10 `meta-security`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.A11YoctoReferenceManual(Dunfell)-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.A11YoctoReferenceManual(Dunfell)-AddMinimalphpwebruntimewithlightpd>`__
+         -  4.1.2.11 `meta-selinux`_
 
-   -  7.7 `Common
-      Tasks <#L813e.A11YoctoReferenceManual(Dunfell)-CommonTasks>`__
+         -  4.1.2.12 `meta-browser`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.A11YoctoReferenceManual(Dunfell)-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.A11YoctoReferenceManual(Dunfell)-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.A11YoctoReferenceManual(Dunfell)-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.A11YoctoReferenceManual(Dunfell)-DifferentToolchains>`__
+         -  4.1.2.13 `meta-rust`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.A11YoctoReferenceManual(Dunfell)-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.A11YoctoReferenceManual(Dunfell)-UsingtheSDKwithGNUAutotools>`__
+         -  4.1.2.14 `meta-timesys`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.A11YoctoReferenceManual(Dunfell)-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.A11YoctoReferenceManual(Dunfell)-Workingwithudev>`__
+         -  4.1.2.15 `meta-freescale`_
 
--  8
-   `Troubleshooting <#L813e.A11YoctoReferenceManual(Dunfell)-Troubleshooting>`__
+         -  4.1.2.16 `meta-freescale-3rdparty`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.A11YoctoReferenceManual(Dunfell)-SetsceneTaskWarning>`__
+         -  4.1.2.17 `meta-freescale-distro`_
 
--  9 `Yocto
-   Documentation <#L813e.A11YoctoReferenceManual(Dunfell)-YoctoDocumentation>`__
+         -  4.1.2.18 `base (fsl-community-bsp-base)`_
+
+         -  4.1.2.19 `meta-fsl-bsp-release`_
+
+      -  4.1.3 `BSP Content`_
+
+   -  4.2 `Build Configuration`_
+
+-  5 `Prebuild Images`_
+
+-  6 `BSP Workspace Installation`_
+
+   -  6.1 `Setting Up the Host`_
+
+   -  6.2 `Git Configuration`_
+
+   -  6.3 `site.conf Setup`_
+
+-  7 `phyLinux Documentation`_
+
+   -  7.1 `Get phyLinux`_
+
+   -  7.2 `Basic Usage`_
+
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-yogurt`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
 
 The Yocto Project
 =================
@@ -427,8 +390,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:

--- a/source/yocto/L-813e.A12_Yocto_Reference_Manual_Head_Hardknott_.rst
+++ b/source/yocto/L-813e.A12_Yocto_Reference_Manual_Head_Hardknott_.rst
@@ -44,244 +44,207 @@ L-813e.A12 Yocto Reference Manual Head (Hardknott)
 
 This manual applies to all *hardknott* based PHYTEC releases:
 
--  1 `The Yocto
-   Project <#L813e.A12YoctoReferenceManualHead(Hardknott)-TheYoctoProject>`__
+-  1 `L-813e.A12 Yocto Reference Manual Head (Hardknott)`_
 
-   -  1.1 `PHYTEC
-      Documentation <#L813e.A12YoctoReferenceManualHead(Hardknott)-PHYTECDocumentation>`__
-   -  1.2 `Yocto
-      Introduction <#L813e.A12YoctoReferenceManualHead(Hardknott)-YoctoIntroduction>`__
-   -  1.3 `Core
-      Components <#L813e.A12YoctoReferenceManualHead(Hardknott)-CoreComponents>`__
-   -  1.4
-      `Vocabulary <#L813e.A12YoctoReferenceManualHead(Hardknott)-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.4.1
-         `Recipes <#L813e.A12YoctoReferenceManualHead(Hardknott)-Recipes>`__
-      -  1.4.2
-         `Classes <#L813e.A12YoctoReferenceManualHead(Hardknott)-Classes>`__
-      -  1.4.3
-         `Layers <#L813e.A12YoctoReferenceManualHead(Hardknott)-Layers>`__
-      -  1.4.4
-         `Machine <#L813e.A12YoctoReferenceManualHead(Hardknott)-Machine>`__
-      -  1.4.5 `Distribution
-         (Distro) <#L813e.A12YoctoReferenceManualHead(Hardknott)-Distribution(Distro)>`__
+   -  2.1 `PHYTEC Documentation`_
 
-   -  1.5 `Poky <#L813e.A12YoctoReferenceManualHead(Hardknott)-Poky>`__
+   -  2.2 `Yocto Introduction`_
 
-      -  1.5.1
-         `Bitbake <#L813e.A12YoctoReferenceManualHead(Hardknott)-Bitbake>`__
-      -  1.5.2
-         `Toaster <#L813e.A12YoctoReferenceManualHead(Hardknott)-Toaster>`__
+   -  2.3 `Core Components`_
 
-   -  1.6 `Official
-      Documentation <#L813e.A12YoctoReferenceManualHead(Hardknott)-OfficialDocumentation>`__
+   -  2.4 `Vocabulary`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.A12YoctoReferenceManualHead(Hardknott)-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.A12YoctoReferenceManualHead(Hardknott)-PHYTECBSPIntroduction>`__
+      -  2.4.1 `Recipes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPStructure>`__
+      -  2.4.2 `Classes`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPManagement>`__
+      -  2.4.3 `Layers`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.A12YoctoReferenceManualHead(Hardknott)-phyLinux>`__
-         -  3.1.1.2
-            `Repo <#L813e.A12YoctoReferenceManualHead(Hardknott)-Repo>`__
+      -  2.4.4 `Machine`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPMetadata>`__
+      -  2.4.5 `Distribution (Distro)`_
 
-         -  3.1.2.1
-            `Poky <#L813e.A12YoctoReferenceManualHead(Hardknott)-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-phytec>`__
-         -  3.1.2.8
-            `meta-ampliphy <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-ampliphy>`__
-         -  3.1.2.9
-            `meta-virtualization <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-virtualization>`__
-         -  3.1.2.10
-            `meta-security <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-security>`__
-         -  3.1.2.11
-            `meta-selinux <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-selinux>`__
-         -  3.1.2.12
-            `meta-browser <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-browser>`__
-         -  3.1.2.13
-            `meta-rust <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-rust>`__
-         -  3.1.2.14
-            `meta-timesys <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-timesys>`__
-         -  3.1.2.15
-            `meta-freescale <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-freescale>`__
-         -  3.1.2.16
-            `meta-freescale-3rdparty <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-freescale-3rdparty>`__
-         -  3.1.2.17
-            `meta-freescale-distro <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-freescale-distro>`__
-         -  3.1.2.18 `base
-            (fsl-community-bsp-base) <#L813e.A12YoctoReferenceManualHead(Hardknott)-base(fsl-community-bsp-base)>`__
-         -  3.1.2.19
-            `meta-fsl-bsp-release <#L813e.A12YoctoReferenceManualHead(Hardknott)-meta-fsl-bsp-release>`__
+   -  2.5 `Poky Overview`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPContent>`__
+      -  2.5.1 `Bitbake`_
 
-   -  3.2 `Build
-      Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-BuildConfiguration>`__
+      -  2.5.2 `Toaster`_
 
--  4 `Prebuild
-   Images <#L813e.A12YoctoReferenceManualHead(Hardknott)-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPWorkspaceInstallation>`__
+   -  2.6 `Official Documentation`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.A12YoctoReferenceManualHead(Hardknott)-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.A12YoctoReferenceManualHead(Hardknott)-site.confSetup>`__
+-  3 `Compatible Linux Distributions`_
 
--  6 `phyLinux
-   Documentation <#L813e.A12YoctoReferenceManualHead(Hardknott)-phyLinuxDocumentation>`__
+-  4 `PHYTEC BSP Introduction`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.A12YoctoReferenceManualHead(Hardknott)-GetphyLinux>`__
-   -  6.2 `Basic
-      Usage <#L813e.A12YoctoReferenceManualHead(Hardknott)-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.A12YoctoReferenceManualHead(Hardknott)-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.A12YoctoReferenceManualHead(Hardknott)-AdvancedUsage>`__
+   -  4.1 `BSP Structure`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.A12YoctoReferenceManualHead(Hardknott)-WorkingwithPokyandBitbake>`__
+      -  4.1.1 `BSP Management`_
 
-   -  7.1 `Start the
-      Build <#L813e.A12YoctoReferenceManualHead(Hardknott)-StarttheBuild>`__
-   -  7.2
-      `Images <#L813e.A12YoctoReferenceManualHead(Hardknott)-imagesImages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.A12YoctoReferenceManualHead(Hardknott)-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-ampliphy <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPFeaturesofmeta-phytecandmeta-ampliphy>`__
+         -  4.1.1.1 `phyLinux`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.A12YoctoReferenceManualHead(Hardknott)-Buildinfo>`__
+         -  4.1.1.2 `Repo`_
 
-   -  7.6 `BSP
-      Customization <#L813e.A12YoctoReferenceManualHead(Hardknott)-BSPCustomization>`__
+      -  4.1.2 `BSP Metadata`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.A12YoctoReferenceManualHead(Hardknott)-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.A12YoctoReferenceManualHead(Hardknott)-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.A12YoctoReferenceManualHead(Hardknott)-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.1 `poky-1`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.A12YoctoReferenceManualHead(Hardknott)-RAMBenchmark>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.3 `meta-qt5`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.A12YoctoReferenceManualHead(Hardknott)-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.A12YoctoReferenceManualHead(Hardknott)-CreateyourownLayercreatelayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.A12YoctoReferenceManualHead(Hardknott)-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-KernelandBootloaderConfiguration>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.6 `meta-rauc`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.A12YoctoReferenceManualHead(Hardknott)-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.A12YoctoReferenceManualHead(Hardknott)-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.A12YoctoReferenceManualHead(Hardknott)-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.A12YoctoReferenceManualHead(Hardknott)-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.7 `meta-phytec`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.A12YoctoReferenceManualHead(Hardknott)-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.A12YoctoReferenceManualHead(Hardknott)-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.A12YoctoReferenceManualHead(Hardknott)-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+         -  4.1.2.8 `meta-ampliphy`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-ChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.A12YoctoReferenceManualHead(Hardknott)-ChangingtheWirelessNetworkConfiguration>`__
+         -  4.1.2.9 `meta-virtualization`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.A12YoctoReferenceManualHead(Hardknott)-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.A12YoctoReferenceManualHead(Hardknott)-CreatingaWLANAccessPoint>`__
+         -  4.1.2.10 `meta-security`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.A12YoctoReferenceManualHead(Hardknott)-AddMinimalphpwebruntimewithlightpd>`__
+         -  4.1.2.11 `meta-selinux`_
 
-   -  7.7 `Common
-      Tasks <#L813e.A12YoctoReferenceManualHead(Hardknott)-CommonTasks>`__
+         -  4.1.2.12 `meta-browser`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.A12YoctoReferenceManualHead(Hardknott)-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.A12YoctoReferenceManualHead(Hardknott)-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.A12YoctoReferenceManualHead(Hardknott)-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.A12YoctoReferenceManualHead(Hardknott)-DifferentToolchains>`__
+         -  4.1.2.13 `meta-rust`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.A12YoctoReferenceManualHead(Hardknott)-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.A12YoctoReferenceManualHead(Hardknott)-UsingtheSDKwithGNUAutotools>`__
+         -  4.1.2.14 `meta-timesys`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.A12YoctoReferenceManualHead(Hardknott)-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.A12YoctoReferenceManualHead(Hardknott)-Workingwithudev>`__
+         -  4.1.2.15 `meta-freescale`_
 
--  8
-   `Troubleshooting <#L813e.A12YoctoReferenceManualHead(Hardknott)-Troubleshooting>`__
+         -  4.1.2.16 `meta-freescale-3rdparty`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.A12YoctoReferenceManualHead(Hardknott)-SetsceneTaskWarning>`__
+         -  4.1.2.17 `meta-freescale-distro`_
 
--  9 `Yocto
-   Documentation <#L813e.A12YoctoReferenceManualHead(Hardknott)-YoctoDocumentation>`__
+         -  4.1.2.18 `base (fsl-community-bsp-base)`_
+
+         -  4.1.2.19 `meta-fsl-bsp-release`_
+
+      -  4.1.3 `BSP Content`_
+
+   -  4.2 `Build Configuration`_
+
+-  5 `Prebuild Images`_
+
+-  6 `BSP Workspace Installation`_
+
+   -  6.1 `Setting Up the Host`_
+
+   -  6.2 `Git Configuration`_
+
+   -  6.3 `site.conf Setup`_
+
+-  7 `phyLinux Documentation`_
+
+   -  7.1 `Get phyLinux`_
+
+   -  7.2 `Basic Usage`_
+
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-ampliphy`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
 
 The Yocto Project
 =================
@@ -439,8 +402,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:

--- a/source/yocto/L-813e.A8_Yocto_Reference_Manual_Sumo_.rst
+++ b/source/yocto/L-813e.A8_Yocto_Reference_Manual_Sumo_.rst
@@ -210,212 +210,183 @@ L-813e.Ax Yocto Head
 
 This manual applies to all *sumo* based PHYTEC releases:
 
--  1 `The Yocto
-   Project <#L813e.A8YoctoReferenceManual(Sumo)-TheYoctoProject>`__
+-  1 `L-813e.A8 Yocto Reference Manual (Sumo)`_
 
-   -  1.1
-      `Introduction <#L813e.A8YoctoReferenceManual(Sumo)-Introduction>`__
-   -  1.2 `Core
-      Components <#L813e.A8YoctoReferenceManual(Sumo)-CoreComponents>`__
-   -  1.3
-      `Vocabulary <#L813e.A8YoctoReferenceManual(Sumo)-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.3.1 `Recipes <#L813e.A8YoctoReferenceManual(Sumo)-Recipes>`__
-      -  1.3.2 `Classes <#L813e.A8YoctoReferenceManual(Sumo)-Classes>`__
-      -  1.3.3 `Layers <#L813e.A8YoctoReferenceManual(Sumo)-Layers>`__
-      -  1.3.4 `Machine <#L813e.A8YoctoReferenceManual(Sumo)-Machine>`__
-      -  1.3.5 `Distribution
-         (Distro) <#L813e.A8YoctoReferenceManual(Sumo)-Distribution(Distro)>`__
+   -  2.1 `Introduction`_
 
-   -  1.4 `Poky <#L813e.A8YoctoReferenceManual(Sumo)-Poky>`__
+   -  2.2 `Core Components`_
 
-      -  1.4.1 `Bitbake <#L813e.A8YoctoReferenceManual(Sumo)-Bitbake>`__
-      -  1.4.2 `Toaster <#L813e.A8YoctoReferenceManual(Sumo)-Toaster>`__
+   -  2.3 `Vocabulary`_
 
-   -  1.5 `Official
-      Documentation <#L813e.A8YoctoReferenceManual(Sumo)-OfficialDocumentation>`__
+      -  2.3.1 `Recipes`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.A8YoctoReferenceManual(Sumo)-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.A8YoctoReferenceManual(Sumo)-PHYTECBSPIntroduction>`__
+      -  2.3.2 `Classes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.A8YoctoReferenceManual(Sumo)-BSPStructure>`__
+      -  2.3.3 `Layers`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.A8YoctoReferenceManual(Sumo)-BSPManagement>`__
+      -  2.3.4 `Machine`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.A8YoctoReferenceManual(Sumo)-phyLinux>`__
-         -  3.1.1.2 `Repo <#L813e.A8YoctoReferenceManual(Sumo)-Repo>`__
+      -  2.3.5 `Distribution (Distro)`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.A8YoctoReferenceManual(Sumo)-BSPMetadata>`__
+   -  2.4 `Poky Overview`_
 
-         -  3.1.2.1
-            `Poky <#L813e.A8YoctoReferenceManual(Sumo)-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.A8YoctoReferenceManual(Sumo)-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.A8YoctoReferenceManual(Sumo)-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.A8YoctoReferenceManual(Sumo)-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.A8YoctoReferenceManual(Sumo)-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.A8YoctoReferenceManual(Sumo)-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.A8YoctoReferenceManual(Sumo)-meta-phytec>`__
-         -  3.1.2.8
-            `meta-yogurt <#L813e.A8YoctoReferenceManual(Sumo)-meta-yogurt>`__
+      -  2.4.1 `Bitbake`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.A8YoctoReferenceManual(Sumo)-BSPContent>`__
+      -  2.4.2 `Toaster`_
 
-   -  3.2 `Build
-      Configuration <#L813e.A8YoctoReferenceManual(Sumo)-BuildConfiguration>`__
+   -  2.5 `Official Documentation`_
 
--  4 `Prebuild
-   Images <#L813e.A8YoctoReferenceManual(Sumo)-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.A8YoctoReferenceManual(Sumo)-BSPWorkspaceInstallation>`__
+-  3 `Compatible Linux Distributions`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.A8YoctoReferenceManual(Sumo)-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.A8YoctoReferenceManual(Sumo)-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.A8YoctoReferenceManual(Sumo)-site.confSetup>`__
+-  4 `PHYTEC BSP Introduction`_
 
--  6 `phyLinux
-   Documentation <#L813e.A8YoctoReferenceManual(Sumo)-phyLinuxDocumentation>`__
+   -  4.1 `BSP Structure`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.A8YoctoReferenceManual(Sumo)-GetphyLinux>`__
-   -  6.2 `Basic
-      Usage <#L813e.A8YoctoReferenceManual(Sumo)-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.A8YoctoReferenceManual(Sumo)-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.A8YoctoReferenceManual(Sumo)-AdvancedUsage>`__
+      -  4.1.1 `BSP Management`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.A8YoctoReferenceManual(Sumo)-WorkingwithPokyandBitbake>`__
+         -  4.1.1.1 `phyLinux`_
 
-   -  7.1 `Start the
-      Build <#L813e.A8YoctoReferenceManual(Sumo)-StarttheBuild>`__
-   -  7.2 `Images <#L813e.A8YoctoReferenceManual(Sumo)-imagesImages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.A8YoctoReferenceManual(Sumo)-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.A8YoctoReferenceManual(Sumo)-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-yogurt <#L813e.A8YoctoReferenceManual(Sumo)-BSPFeaturesofmeta-phytecandmeta-yogurt>`__
+         -  4.1.1.2 `Repo`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.A8YoctoReferenceManual(Sumo)-Buildinfo>`__
+      -  4.1.2 `BSP Metadata`_
 
-   -  7.6 `BSP
-      Customization <#L813e.A8YoctoReferenceManual(Sumo)-BSPCustomization>`__
+         -  4.1.2.1 `poky-1`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.A8YoctoReferenceManual(Sumo)-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.A8YoctoReferenceManual(Sumo)-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.A8YoctoReferenceManual(Sumo)-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.A8YoctoReferenceManual(Sumo)-RAMBenchmark>`__
+         -  4.1.2.3 `meta-qt5`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.A8YoctoReferenceManual(Sumo)-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.A8YoctoReferenceManual(Sumo)-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.A8YoctoReferenceManual(Sumo)-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.A8YoctoReferenceManual(Sumo)-createlayerCreateyourownLayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.A8YoctoReferenceManual(Sumo)-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.A8YoctoReferenceManual(Sumo)-KernelandBootloaderConfiguration>`__
+         -  4.1.2.6 `meta-rauc`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.A8YoctoReferenceManual(Sumo)-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.A8YoctoReferenceManual(Sumo)-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.7 `meta-phytec`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.A8YoctoReferenceManual(Sumo)-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.A8YoctoReferenceManual(Sumo)-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.A8YoctoReferenceManual(Sumo)-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.A8YoctoReferenceManual(Sumo)-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.A8YoctoReferenceManual(Sumo)-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.A8YoctoReferenceManual(Sumo)-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.8 `meta-yogurt`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.A8YoctoReferenceManual(Sumo)-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.A8YoctoReferenceManual(Sumo)-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.A8YoctoReferenceManual(Sumo)-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+      -  4.1.3 `BSP Content`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.A8YoctoReferenceManual(Sumo)-ChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.A8YoctoReferenceManual(Sumo)-ChangingtheWirelessNetworkConfiguration>`__
+   -  4.2 `Build Configuration`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.A8YoctoReferenceManual(Sumo)-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.A8YoctoReferenceManual(Sumo)-CreatingaWLANAccessPoint>`__
+-  5 `Prebuild Images`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.A8YoctoReferenceManual(Sumo)-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.A8YoctoReferenceManual(Sumo)-AddMinimalphpwebruntimewithlightpd>`__
+-  6 `BSP Workspace Installation`_
 
-   -  7.7 `Common
-      Tasks <#L813e.A8YoctoReferenceManual(Sumo)-CommonTasks>`__
+   -  6.1 `Setting Up the Host`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.A8YoctoReferenceManual(Sumo)-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.A8YoctoReferenceManual(Sumo)-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.A8YoctoReferenceManual(Sumo)-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.A8YoctoReferenceManual(Sumo)-DifferentToolchains>`__
+   -  6.2 `Git Configuration`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.A8YoctoReferenceManual(Sumo)-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.A8YoctoReferenceManual(Sumo)-UsingtheSDKwithGNUAutotools>`__
+   -  6.3 `site.conf Setup`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.A8YoctoReferenceManual(Sumo)-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.A8YoctoReferenceManual(Sumo)-Workingwithudev>`__
+-  7 `phyLinux Documentation`_
 
--  8
-   `Troubleshooting <#L813e.A8YoctoReferenceManual(Sumo)-Troubleshooting>`__
+   -  7.1 `Get phyLinux`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.A8YoctoReferenceManual(Sumo)-SetsceneTaskWarning>`__
+   -  7.2 `Basic Usage`_
 
--  9 `Yocto
-   Documentation <#L813e.A8YoctoReferenceManual(Sumo)-YoctoDocumentation>`__
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-yogurt`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
 
 The Yocto Project
 =================
@@ -535,8 +506,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:

--- a/source/yocto/L-813e.A9_Yocto_Reference_Manual_Warrior_.rst
+++ b/source/yocto/L-813e.A9_Yocto_Reference_Manual_Warrior_.rst
@@ -208,242 +208,205 @@ L-813e.Ax Yocto Head
 
 This manual applies to all *warrior* based PHYTEC releases:
 
--  1 `The Yocto
-   Project <#L813e.A9YoctoReferenceManual(Warrior)-TheYoctoProject>`__
+-  1 `L-813e.A9 Yocto Reference Manual (Warrior)`_
 
-   -  1.1 `PHYTEC
-      Documentation <#L813e.A9YoctoReferenceManual(Warrior)-PHYTECDocumentation>`__
-   -  1.2 `Yocto
-      Introduction <#L813e.A9YoctoReferenceManual(Warrior)-YoctoIntroduction>`__
-   -  1.3 `Core
-      Components <#L813e.A9YoctoReferenceManual(Warrior)-CoreComponents>`__
-   -  1.4
-      `Vocabulary <#L813e.A9YoctoReferenceManual(Warrior)-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.4.1
-         `Recipes <#L813e.A9YoctoReferenceManual(Warrior)-Recipes>`__
-      -  1.4.2
-         `Classes <#L813e.A9YoctoReferenceManual(Warrior)-Classes>`__
-      -  1.4.3
-         `Layers <#L813e.A9YoctoReferenceManual(Warrior)-Layers>`__
-      -  1.4.4
-         `Machine <#L813e.A9YoctoReferenceManual(Warrior)-Machine>`__
-      -  1.4.5 `Distribution
-         (Distro) <#L813e.A9YoctoReferenceManual(Warrior)-Distribution(Distro)>`__
+   -  2.1 `PHYTEC Documentation`_
 
-   -  1.5 `Poky <#L813e.A9YoctoReferenceManual(Warrior)-Poky>`__
+   -  2.2 `Yocto Introduction`_
 
-      -  1.5.1
-         `Bitbake <#L813e.A9YoctoReferenceManual(Warrior)-Bitbake>`__
-      -  1.5.2
-         `Toaster <#L813e.A9YoctoReferenceManual(Warrior)-Toaster>`__
+   -  2.3 `Core Components`_
 
-   -  1.6 `Official
-      Documentation <#L813e.A9YoctoReferenceManual(Warrior)-OfficialDocumentation>`__
+   -  2.4 `Vocabulary`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.A9YoctoReferenceManual(Warrior)-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.A9YoctoReferenceManual(Warrior)-PHYTECBSPIntroduction>`__
+      -  2.4.1 `Recipes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.A9YoctoReferenceManual(Warrior)-BSPStructure>`__
+      -  2.4.2 `Classes`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.A9YoctoReferenceManual(Warrior)-BSPManagement>`__
+      -  2.4.3 `Layers`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.A9YoctoReferenceManual(Warrior)-phyLinux>`__
-         -  3.1.1.2
-            `Repo <#L813e.A9YoctoReferenceManual(Warrior)-Repo>`__
+      -  2.4.4 `Machine`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.A9YoctoReferenceManual(Warrior)-BSPMetadata>`__
+      -  2.4.5 `Distribution (Distro)`_
 
-         -  3.1.2.1
-            `Poky <#L813e.A9YoctoReferenceManual(Warrior)-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.A9YoctoReferenceManual(Warrior)-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.A9YoctoReferenceManual(Warrior)-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.A9YoctoReferenceManual(Warrior)-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.A9YoctoReferenceManual(Warrior)-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.A9YoctoReferenceManual(Warrior)-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.A9YoctoReferenceManual(Warrior)-meta-phytec>`__
-         -  3.1.2.8
-            `meta-yogurt <#L813e.A9YoctoReferenceManual(Warrior)-meta-yogurt>`__
-         -  3.1.2.9
-            `meta-virtualization <#L813e.A9YoctoReferenceManual(Warrior)-meta-virtualization>`__
-         -  3.1.2.10
-            `meta-security <#L813e.A9YoctoReferenceManual(Warrior)-meta-security>`__
-         -  3.1.2.11
-            `meta-browser <#L813e.A9YoctoReferenceManual(Warrior)-meta-browser>`__
-         -  3.1.2.12
-            `meta-rust <#L813e.A9YoctoReferenceManual(Warrior)-meta-rust>`__
-         -  3.1.2.13
-            `meta-timesys <#L813e.A9YoctoReferenceManual(Warrior)-meta-timesys>`__
-         -  3.1.2.14
-            `meta-freescale <#L813e.A9YoctoReferenceManual(Warrior)-meta-freescale>`__
-         -  3.1.2.15
-            `meta-freescale-3rdparty <#L813e.A9YoctoReferenceManual(Warrior)-meta-freescale-3rdparty>`__
-         -  3.1.2.16
-            `meta-freescale-distro <#L813e.A9YoctoReferenceManual(Warrior)-meta-freescale-distro>`__
-         -  3.1.2.17 `base
-            (fsl-community-bsp-base) <#L813e.A9YoctoReferenceManual(Warrior)-base(fsl-community-bsp-base)>`__
-         -  3.1.2.18
-            `meta-fsl-bsp-release <#L813e.A9YoctoReferenceManual(Warrior)-meta-fsl-bsp-release>`__
+   -  2.5 `Poky Overview`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.A9YoctoReferenceManual(Warrior)-BSPContent>`__
+      -  2.5.1 `Bitbake`_
 
-   -  3.2 `Build
-      Configuration <#L813e.A9YoctoReferenceManual(Warrior)-BuildConfiguration>`__
+      -  2.5.2 `Toaster`_
 
--  4 `Prebuild
-   Images <#L813e.A9YoctoReferenceManual(Warrior)-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.A9YoctoReferenceManual(Warrior)-BSPWorkspaceInstallation>`__
+   -  2.6 `Official Documentation`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.A9YoctoReferenceManual(Warrior)-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.A9YoctoReferenceManual(Warrior)-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.A9YoctoReferenceManual(Warrior)-site.confSetup>`__
+-  3 `Compatible Linux Distributions`_
 
--  6 `phyLinux
-   Documentation <#L813e.A9YoctoReferenceManual(Warrior)-phyLinuxDocumentation>`__
+-  4 `PHYTEC BSP Introduction`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.A9YoctoReferenceManual(Warrior)-GetphyLinux>`__
-   -  6.2 `Basic
-      Usage <#L813e.A9YoctoReferenceManual(Warrior)-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.A9YoctoReferenceManual(Warrior)-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.A9YoctoReferenceManual(Warrior)-AdvancedUsage>`__
+   -  4.1 `BSP Structure`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.A9YoctoReferenceManual(Warrior)-WorkingwithPokyandBitbake>`__
+      -  4.1.1 `BSP Management`_
 
-   -  7.1 `Start the
-      Build <#L813e.A9YoctoReferenceManual(Warrior)-StarttheBuild>`__
-   -  7.2
-      `Images <#L813e.A9YoctoReferenceManual(Warrior)-imagesImages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.A9YoctoReferenceManual(Warrior)-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.A9YoctoReferenceManual(Warrior)-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-yogurt <#L813e.A9YoctoReferenceManual(Warrior)-BSPFeaturesofmeta-phytecandmeta-yogurt>`__
+         -  4.1.1.1 `phyLinux`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.A9YoctoReferenceManual(Warrior)-Buildinfo>`__
+         -  4.1.1.2 `Repo`_
 
-   -  7.6 `BSP
-      Customization <#L813e.A9YoctoReferenceManual(Warrior)-BSPCustomization>`__
+      -  4.1.2 `BSP Metadata`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.A9YoctoReferenceManual(Warrior)-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.A9YoctoReferenceManual(Warrior)-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.A9YoctoReferenceManual(Warrior)-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.1 `poky-1`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.A9YoctoReferenceManual(Warrior)-RAMBenchmark>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.A9YoctoReferenceManual(Warrior)-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.3 `meta-qt5`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.A9YoctoReferenceManual(Warrior)-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.A9YoctoReferenceManual(Warrior)-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.A9YoctoReferenceManual(Warrior)-createlayerCreateyourownLayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.A9YoctoReferenceManual(Warrior)-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.A9YoctoReferenceManual(Warrior)-KernelandBootloaderConfiguration>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.A9YoctoReferenceManual(Warrior)-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.A9YoctoReferenceManual(Warrior)-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.6 `meta-rauc`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.A9YoctoReferenceManual(Warrior)-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.A9YoctoReferenceManual(Warrior)-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.A9YoctoReferenceManual(Warrior)-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.A9YoctoReferenceManual(Warrior)-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.A9YoctoReferenceManual(Warrior)-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.A9YoctoReferenceManual(Warrior)-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.7 `meta-phytec`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.A9YoctoReferenceManual(Warrior)-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.A9YoctoReferenceManual(Warrior)-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.A9YoctoReferenceManual(Warrior)-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+         -  4.1.2.8 `meta-yogurt`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.A9YoctoReferenceManual(Warrior)-ChangingtheNetworkConfigurationChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.A9YoctoReferenceManual(Warrior)-ChangingtheWirelessNetworkConfiguration>`__
+         -  4.1.2.9 `meta-virtualization`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.A9YoctoReferenceManual(Warrior)-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.A9YoctoReferenceManual(Warrior)-CreatingaWLANAccessPoint>`__
+         -  4.1.2.10 `meta-security`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.A9YoctoReferenceManual(Warrior)-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.A9YoctoReferenceManual(Warrior)-AddMinimalphpwebruntimewithlightpd>`__
+         -  4.1.2.11 `meta-browser`_
 
-   -  7.7 `Common
-      Tasks <#L813e.A9YoctoReferenceManual(Warrior)-CommonTasks>`__
+         -  4.1.2.12 `meta-rust`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.A9YoctoReferenceManual(Warrior)-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.A9YoctoReferenceManual(Warrior)-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.A9YoctoReferenceManual(Warrior)-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.A9YoctoReferenceManual(Warrior)-DifferentToolchains>`__
+         -  4.1.2.13 `meta-timesys`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.A9YoctoReferenceManual(Warrior)-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.A9YoctoReferenceManual(Warrior)-UsingtheSDKwithGNUAutotools>`__
+         -  4.1.2.14 `meta-freescale`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.A9YoctoReferenceManual(Warrior)-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.A9YoctoReferenceManual(Warrior)-Workingwithudev>`__
+         -  4.1.2.15 `meta-freescale-3rdparty`_
 
--  8
-   `Troubleshooting <#L813e.A9YoctoReferenceManual(Warrior)-Troubleshooting>`__
+         -  4.1.2.16 `meta-freescale-distro`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.A9YoctoReferenceManual(Warrior)-SetsceneTaskWarning>`__
+         -  4.1.2.17 `base (fsl-community-bsp-base)`_
 
--  9 `Yocto
-   Documentation <#L813e.A9YoctoReferenceManual(Warrior)-YoctoDocumentation>`__
+         -  4.1.2.18 `meta-fsl-bsp-release`_
+
+      -  4.1.3 `BSP Content`_
+
+   -  4.2 `Build Configuration`_
+
+-  5 `Prebuild Images`_
+
+-  6 `BSP Workspace Installation`_
+
+   -  6.1 `Setting Up the Host`_
+
+   -  6.2 `Git Configuration`_
+
+   -  6.3 `site.conf Setup`_
+
+-  7 `phyLinux Documentation`_
+
+   -  7.1 `Get phyLinux`_
+
+   -  7.2 `Basic Usage`_
+
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-yogurt`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
 
 The Yocto Project
 =================
@@ -601,8 +564,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:

--- a/source/yocto/L-813e.Ax_Yocto_Reference_Manual_Head.rst
+++ b/source/yocto/L-813e.Ax_Yocto_Reference_Manual_Head.rst
@@ -565,233 +565,207 @@ released
 
 This manual applies to all *kirkstone* based PHYTEC releases:
 
--  1 `The Yocto
-   Project <#L813e.AxYoctoReferenceManualHead-TheYoctoProject>`__
+-  1 `L-813e.Ax Yocto Reference Manual Head`_
 
-   -  1.1 `PHYTEC
-      Documentation <#L813e.AxYoctoReferenceManualHead-PHYTECDocumentation>`__
-   -  1.2 `Yocto
-      Introduction <#L813e.AxYoctoReferenceManualHead-YoctoIntroduction>`__
-   -  1.3 `Core
-      Components <#L813e.AxYoctoReferenceManualHead-CoreComponents>`__
-   -  1.4 `Vocabulary <#L813e.AxYoctoReferenceManualHead-Vocabulary>`__
+-  2 `The Yocto Project`_
 
-      -  1.4.1 `Recipes <#L813e.AxYoctoReferenceManualHead-Recipes>`__
-      -  1.4.2 `Classes <#L813e.AxYoctoReferenceManualHead-Classes>`__
-      -  1.4.3 `Layers <#L813e.AxYoctoReferenceManualHead-Layers>`__
-      -  1.4.4 `Machine <#L813e.AxYoctoReferenceManualHead-Machine>`__
-      -  1.4.5 `Distribution
-         (Distro) <#L813e.AxYoctoReferenceManualHead-Distribution(Distro)>`__
+   -  2.1 `PHYTEC Documentation`_
 
-   -  1.5 `Poky <#L813e.AxYoctoReferenceManualHead-Poky>`__
+   -  2.2 `Yocto Introduction`_
 
-      -  1.5.1 `Bitbake <#L813e.AxYoctoReferenceManualHead-Bitbake>`__
-      -  1.5.2 `Toaster <#L813e.AxYoctoReferenceManualHead-Toaster>`__
+   -  2.3 `Core Components`_
 
-   -  1.6 `Official
-      Documentation <#L813e.AxYoctoReferenceManualHead-OfficialDocumentation>`__
+   -  2.4 `Vocabulary`_
 
--  2 `Compatible Linux
-   Distributions <#L813e.AxYoctoReferenceManualHead-CompatibleLinuxDistributions>`__
--  3 `PHYTEC BSP
-   Introduction <#L813e.AxYoctoReferenceManualHead-PHYTECBSPIntroduction>`__
+      -  2.4.1 `Recipes`_
 
-   -  3.1 `BSP
-      Structure <#L813e.AxYoctoReferenceManualHead-BSPStructure>`__
+      -  2.4.2 `Classes`_
 
-      -  3.1.1 `BSP
-         Management <#L813e.AxYoctoReferenceManualHead-BSPManagement>`__
+      -  2.4.3 `Layers`_
 
-         -  3.1.1.1
-            `phyLinux <#L813e.AxYoctoReferenceManualHead-phyLinux>`__
-         -  3.1.1.2 `Repo <#L813e.AxYoctoReferenceManualHead-Repo>`__
+      -  2.4.4 `Machine`_
 
-      -  3.1.2 `BSP
-         Metadata <#L813e.AxYoctoReferenceManualHead-BSPMetadata>`__
+      -  2.4.5 `Distribution (Distro)`_
 
-         -  3.1.2.1 `Poky <#L813e.AxYoctoReferenceManualHead-Poky.1>`__
-         -  3.1.2.2
-            `meta-openembedded <#L813e.AxYoctoReferenceManualHead-meta-openembedded>`__
-         -  3.1.2.3
-            `meta-qt5 <#L813e.AxYoctoReferenceManualHead-meta-qt5>`__
-         -  3.1.2.4
-            `meta-nodejs <#L813e.AxYoctoReferenceManualHead-meta-nodejs>`__
-         -  3.1.2.5
-            `meta-gstreamer1.0 <#L813e.AxYoctoReferenceManualHead-meta-gstreamer1.0>`__
-         -  3.1.2.6
-            `meta-rauc <#L813e.AxYoctoReferenceManualHead-meta-rauc>`__
-         -  3.1.2.7
-            `meta-phytec <#L813e.AxYoctoReferenceManualHead-meta-phytec>`__
-         -  3.1.2.8
-            `meta-ampliphy <#L813e.AxYoctoReferenceManualHead-meta-ampliphy>`__
-         -  3.1.2.9
-            `meta-virtualization <#L813e.AxYoctoReferenceManualHead-meta-virtualization>`__
-         -  3.1.2.10
-            `meta-security <#L813e.AxYoctoReferenceManualHead-meta-security>`__
-         -  3.1.2.11
-            `meta-selinux <#L813e.AxYoctoReferenceManualHead-meta-selinux>`__
-         -  3.1.2.12
-            `meta-browser <#L813e.AxYoctoReferenceManualHead-meta-browser>`__
-         -  3.1.2.13
-            `meta-rust <#L813e.AxYoctoReferenceManualHead-meta-rust>`__
-         -  3.1.2.14
-            `meta-timesys <#L813e.AxYoctoReferenceManualHead-meta-timesys>`__
-         -  3.1.2.15
-            `meta-freescale <#L813e.AxYoctoReferenceManualHead-meta-freescale>`__
-         -  3.1.2.16
-            `meta-freescale-3rdparty <#L813e.AxYoctoReferenceManualHead-meta-freescale-3rdparty>`__
-         -  3.1.2.17
-            `meta-freescale-distro <#L813e.AxYoctoReferenceManualHead-meta-freescale-distro>`__
-         -  3.1.2.18 `base
-            (fsl-community-bsp-base) <#L813e.AxYoctoReferenceManualHead-base(fsl-community-bsp-base)>`__
-         -  3.1.2.19
-            `meta-fsl-bsp-release <#L813e.AxYoctoReferenceManualHead-meta-fsl-bsp-release>`__
+   -  2.5 `Poky Overview`_
 
-      -  3.1.3 `BSP
-         Content <#L813e.AxYoctoReferenceManualHead-BSPContent>`__
+      -  2.5.1 `Bitbake`_
 
-   -  3.2 `Build
-      Configuration <#L813e.AxYoctoReferenceManualHead-BuildConfiguration>`__
+      -  2.5.2 `Toaster`_
 
--  4 `Prebuild
-   Images <#L813e.AxYoctoReferenceManualHead-PrebuildImages>`__
--  5 `BSP Workspace
-   Installation <#L813e.AxYoctoReferenceManualHead-BSPWorkspaceInstallation>`__
+   -  2.6 `Official Documentation`_
 
-   -  5.1 `Setting Up the
-      Host <#L813e.AxYoctoReferenceManualHead-SettingUptheHost>`__
-   -  5.2 `Git
-      Configuration <#L813e.AxYoctoReferenceManualHead-GitConfiguration>`__
-   -  5.3 `site.conf
-      Setup <#L813e.AxYoctoReferenceManualHead-site.confSetup>`__
+-  3 `Compatible Linux Distributions`_
 
--  6 `phyLinux
-   Documentation <#L813e.AxYoctoReferenceManualHead-phyLinuxDocumentation>`__
+-  4 `PHYTEC BSP Introduction`_
 
-   -  6.1 `Get
-      phyLinux <#L813e.AxYoctoReferenceManualHead-GetphyLinux>`__
-   -  6.2 `Basic Usage <#L813e.AxYoctoReferenceManualHead-BasicUsage>`__
-   -  6.3
-      `Initialization <#L813e.AxYoctoReferenceManualHead-Initialization>`__
-   -  6.4 `Advanced
-      Usage <#L813e.AxYoctoReferenceManualHead-AdvancedUsage>`__
+   -  4.1 `BSP Structure`_
 
--  7 `Working with Poky and
-   Bitbake <#L813e.AxYoctoReferenceManualHead-WorkingwithPokyandBitbake>`__
+      -  4.1.1 `BSP Management`_
 
-   -  7.1 `Start the
-      Build <#L813e.AxYoctoReferenceManualHead-StarttheBuild>`__
-   -  7.2 `Images <#L813e.AxYoctoReferenceManualHead-Imagesimages>`__
-   -  7.3 `Accessing Development States between
-      Releases <#L813e.AxYoctoReferenceManualHead-AccessingDevelopmentStatesbetweenReleases>`__
-   -  7.4 `Inspect your Build
-      Configuration <#L813e.AxYoctoReferenceManualHead-InspectyourBuildConfiguration>`__
-   -  7.5 `BSP Features of meta-phytec and
-      meta-ampliphy <#L813e.AxYoctoReferenceManualHead-BSPFeaturesofmeta-phytecandmeta-ampliphy>`__
+         -  4.1.1.1 `phyLinux`_
 
-      -  7.5.1
-         `Buildinfo <#L813e.AxYoctoReferenceManualHead-Buildinfo>`__
+         -  4.1.1.2 `Repo`_
 
-   -  7.6 `BSP
-      Customization <#L813e.AxYoctoReferenceManualHead-BSPCustomization>`__
+      -  4.1.2 `BSP Metadata`_
 
-      -  7.6.1 `Disable Qt
-         Demo <#L813e.AxYoctoReferenceManualHead-DisableQtDemo>`__
-      -  7.6.2 `Framebuffer
-         Console <#L813e.AxYoctoReferenceManualHead-FramebufferConsole>`__
-      -  7.6.3 `Tools Provided in the Prebuild
-         Image <#L813e.AxYoctoReferenceManualHead-ToolsProvidedinthePrebuildImage>`__
+         -  4.1.2.1 `poky`_
 
-         -  7.6.3.1 `RAM
-            Benchmark <#L813e.AxYoctoReferenceManualHead-RAMBenchmark>`__
+         -  4.1.2.2 `meta-openembedded`_
 
-      -  7.6.4 `Add Additional Software for the BSP
-         Image <#L813e.AxYoctoReferenceManualHead-AddAdditionalSoftwarefortheBSPImage>`__
+         -  4.1.2.3 `meta-qt5`_
 
-         -  7.6.4.1 `Notes about Packages and
-            Recipes <#L813e.AxYoctoReferenceManualHead-NotesaboutPackagesandRecipes>`__
+         -  4.1.2.4 `meta-nodejs`_
 
-      -  7.6.5 `Add an Additional
-         Layer <#L813e.AxYoctoReferenceManualHead-AddanAdditionalLayer>`__
-      -  7.6.6 `Create your own
-         Layer <#L813e.AxYoctoReferenceManualHead-CreateyourownLayercreatelayer>`__
-      -  7.6.7 `Kernel and Bootloader Recipe and
-         Version <#L813e.AxYoctoReferenceManualHead-KernelandBootloaderRecipeandVersion>`__
-      -  7.6.8 `Kernel and Bootloader
-         Configuration <#L813e.AxYoctoReferenceManualHead-KernelandBootloaderConfiguration>`__
+         -  4.1.2.5 `meta-gstreamer1.0`_
 
-         -  7.6.8.1 `Add a Configuration Fragment to a
-            Recipe <#L813e.AxYoctoReferenceManualHead-AddaConfigurationFragmenttoaRecipe>`__
-         -  7.6.8.2 `Add a Complete Default Configuration (defconfig) to
-            a
-            Recipe <#L813e.AxYoctoReferenceManualHead-AddaCompleteDefaultConfiguration(defconfig)toaRecipe>`__
+         -  4.1.2.6 `meta-rauc`_
 
-      -  7.6.9 `Patch the Kernel or Bootloader with
-         devtool <#L813e.AxYoctoReferenceManualHead-PatchtheKernelorBootloaderwithdevtool>`__
-      -  7.6.10 `Patch the Kernel or Bootloader using “Temporary
-         Method” <#L813e.AxYoctoReferenceManualHead-PatchtheKernelorBootloaderusing%22TemporaryMethod%22>`__
-      -  7.6.11 `Working with the Kernel and Bootloader using SRC_URI in
-         local.conf <#L813e.AxYoctoReferenceManualHead-WorkingwiththeKernelandBootloaderusingSRC_URIinlocal.conf>`__
-      -  7.6.12 `Add Existing Software with “Sustainable
-         Method” <#L813e.AxYoctoReferenceManualHead-AddExistingSoftwarewith%22SustainableMethod%22>`__
-      -  7.6.13 `Add Linux Firmware Files to the Root
-         Filesystem <#L813e.AxYoctoReferenceManualHead-AddLinuxFirmwareFilestotheRootFilesystem>`__
-      -  7.6.14 `Change the barebox Environment via bbappend
-         Files <#L813e.AxYoctoReferenceManualHead-ChangethebareboxEnvironmentviabbappendFiles>`__
+         -  4.1.2.7 `meta-phytec`_
 
-         -  7.6.14.1 `Debugging the
-            Environment <#L813e.AxYoctoReferenceManualHead-DebuggingtheEnvironment>`__
-         -  7.6.14.2 `Changing the Environment (depending on
-            Machines) <#L813e.AxYoctoReferenceManualHead-ChangingtheEnvironment(dependingonMachines)>`__
-         -  7.6.14.3 `Upgrading the barebox Environment from Previous
-            BSP
-            Releases <#L813e.AxYoctoReferenceManualHead-UpgradingthebareboxEnvironmentfromPreviousBSPReleases>`__
+         -  4.1.2.8 `meta-ampliphy`_
 
-      -  7.6.15 `Changing the Network
-         Configuration <#L813e.AxYoctoReferenceManualHead-ChangingtheNetworkConfiguration>`__
-      -  7.6.16 `Changing the Wireless Network
-         Configuration <#L813e.AxYoctoReferenceManualHead-ChangingtheWirelessNetworkConfiguration>`__
+         -  4.1.2.9 `meta-virtualization`_
 
-         -  7.6.16.1 `Connecting to a WLAN
-            Network <#L813e.AxYoctoReferenceManualHead-ConnectingtoaWLANNetwork>`__
-         -  7.6.16.2 `Creating a WLAN Access
-            Point <#L813e.AxYoctoReferenceManualHead-CreatingaWLANAccessPoint>`__
+         -  4.1.2.10 `meta-security`_
 
-      -  7.6.17 `Add OpenCV Libraries and
-         Examples <#L813e.AxYoctoReferenceManualHead-AddOpenCVLibrariesandExamples>`__
-      -  7.6.18 `Add Minimal php web runtime with
-         lightpd <#L813e.AxYoctoReferenceManualHead-AddMinimalphpwebruntimewithlightpd>`__
+         -  4.1.2.11 `meta-selinux`_
 
-   -  7.7 `Common
-      Tasks <#L813e.AxYoctoReferenceManualHead-CommonTasks>`__
+         -  4.1.2.12 `meta-browser`_
 
-      -  7.7.1 `Debugging a User Space
-         Application <#L813e.AxYoctoReferenceManualHead-DebuggingaUserSpaceApplication>`__
-      -  7.7.2 `Generating Source Mirrors, working
-         Offline <#L813e.AxYoctoReferenceManualHead-GeneratingSourceMirrors,workingOffline>`__
-      -  7.7.3 `Compiling on the
-         Target <#L813e.AxYoctoReferenceManualHead-CompilingontheTarget>`__
-      -  7.7.4 `Different
-         Toolchains <#L813e.AxYoctoReferenceManualHead-DifferentToolchains>`__
+         -  4.1.2.13 `meta-rust`_
 
-         -  7.7.4.1 `Using the
-            SDK <#L813e.AxYoctoReferenceManualHead-UsingtheSDK>`__
-         -  7.7.4.2 `Using the SDK with GNU
-            Autotools <#L813e.AxYoctoReferenceManualHead-UsingtheSDKwithGNUAutotools>`__
+         -  4.1.2.14 `meta-timesys`_
 
-      -  7.7.5 `Working with Kernel
-         Modules <#L813e.AxYoctoReferenceManualHead-WorkingwithKernelModules>`__
-      -  7.7.6 `Working with
-         udev <#L813e.AxYoctoReferenceManualHead-Workingwithudev>`__
+         -  4.1.2.15 `meta-freescale`_
 
--  8
-   `Troubleshooting <#L813e.AxYoctoReferenceManualHead-Troubleshooting>`__
+         -  4.1.2.16 `meta-freescale-3rdparty`_
 
-   -  8.1 `Setscene Task
-      Warning <#L813e.AxYoctoReferenceManualHead-SetsceneTaskWarning>`__
+         -  4.1.2.17 `meta-freescale-distro`_
 
--  9 `Yocto
-   Documentation <#L813e.AxYoctoReferenceManualHead-YoctoDocumentation>`__
+         -  4.1.2.18 `base (fsl-community-bsp-base)`_
+
+         -  4.1.2.19 `meta-fsl-bsp-release`_
+
+      -  4.1.3 `BSP Content`_
+
+   -  4.2 `Build Configuration`_
+
+-  5 `Prebuild Images`_
+
+-  6 `BSP Workspace Installation`_
+
+   -  6.1 `Setting Up the Host`_
+
+   -  6.2 `Git Configuration`_
+
+   -  6.3 `site.conf Setup`_
+
+-  7 `phyLinux Documentation`_
+
+   -  7.1 `Get phyLinux`_
+
+   -  7.2 `Basic Usage`_
+
+   -  7.3 `Initialization`_
+
+   -  7.4 `Advanced Usage`_
+
+-  8 `Working with Poky and Bitbake`_
+
+   -  8.1 `Start the Build`_
+
+   -  8.2 `Images`_
+
+   -  8.3 `Accessing Development States between Releases`_
+
+   -  8.4 `Inspect your Build Configuration`_
+
+   -  8.5 `BSP Features of meta-phytec and meta-ampliphy`_
+
+      -  8.5.1 `Buildinfo`_
+
+   -  8.6 `BSP Customization`_
+
+      -  8.6.1 `Disable Qt Demo`_
+
+      -  8.6.2 `Framebuffer Console`_
+
+      -  8.6.3 `Tools Provided in the Prebuild Image`_
+
+         -  8.6.3.1 `RAM Benchmark`_
+
+      -  8.6.4 `Add Additional Software for the BSP Image`_
+
+         -  8.6.4.1 `Notes about Packages and Recipes`_
+
+      -  8.6.5 `Add an Additional Layer`_
+
+      -  8.6.6 `Create your own Layer`_
+
+      -  8.6.7 `Kernel and Bootloader Recipe and Version`_
+
+      -  8.6.8 `Kernel and Bootloader Configuration`_
+
+         -  8.6.8.1 `Add a Configuration Fragment to a Recipe`_
+
+         -  8.6.8.2 `Add a Complete Default Configuration (defconfig) to a Recipe`_
+
+      -  8.6.9 `Patch the Kernel or Bootloader with devtool`_
+
+      -  8.6.10 `Patch the Kernel or Bootloader using “Temporary Method”`_
+
+      -  8.6.11 `Working with the Kernel and Bootloader using SRC_URI in local.conf`_
+
+      -  8.6.12 `Add Existing Software with “Sustainable Method”`_
+
+      -  8.6.13 `Add Linux Firmware Files to the Root Filesystem`_
+
+      -  8.6.14 `Change the barebox Environment via bbappend Files`_
+
+         -  8.6.14.1 `Debugging the Environment`_
+
+         -  8.6.14.2 `Changing the Environment (depending on Machines)`_
+
+         -  8.6.14.3 `Upgrading the barebox Environment from Previous BSP Releases`_
+
+      -  8.6.15 `Changing the Network Configuration`_
+
+      -  8.6.16 `Changing the Wireless Network Configuration`_
+
+         -  8.6.16.1 `Connecting to a WLAN Network`_
+
+         -  8.6.16.2 `Creating a WLAN Access Point`_
+
+      -  8.6.17 `Add OpenCV Libraries and Examples`_
+
+      -  8.6.18 `Add Minimal php web runtime with lightpd`_
+
+   -  8.7 `Common Tasks`_
+
+      -  8.7.1 `Debugging a User Space Application`_
+
+      -  8.7.2 `Generating Source Mirrors, working Offline`_
+
+      -  8.7.3 `Compiling on the Target`_
+
+      -  8.7.4 `Different Toolchains`_
+
+         -  8.7.4.1 `Using the SDK`_
+
+         -  8.7.4.2 `Using the SDK with GNU Autotools`_
+
+      -  8.7.5 `Working with Kernel Modules`_
+
+      -  8.7.6 `Working with udev`_
+
+-  9 `Troubleshooting`_
+
+   -  9.1 `Setscene Task Warning`_
+
+-  10 `Yocto Documentation`_
+
+
 
 The Yocto Project
 =================
@@ -949,8 +923,8 @@ Distribution (Distro)
 Distribution describes the software configuration and comes with a set
 of software features.
 
-Poky
-----
+Poky Overview
+-------------
 
 *Poky* is the reference system to define *Yocto* Project compatibility.
 It combines several subprojects into releases:


### PR DESCRIPTION
Old indexes dind't work correct because Confluence headings were
linked through converting. The indexes are now completely new
generated and the links are working.

Signed-off-by: Peter Fecher <p.fecher@phytec.de>