### PR TITLE
gh actions: Check for filesize and invalid names

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -1,0 +1,18 @@
+# This workflow will check for various agreements such as filesize, filenames.
+name: Compliance
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v3
+    - name: Check file sizes
+      run: scripts/check_filesize.sh
+    - name: Check file names
+      # Run all checks so that the user can address errors after one run.
+      if: always()
+      run: scripts/check_filenames.sh

--- a/scripts/check_filenames.sh
+++ b/scripts/check_filenames.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Check for whitespaces in filesnames. Exit with error, if found.
+
+DIR=source
+
+files_with_whitespace=$(find $DIR -type f -name "* *" -exec du -h {} \;)
+
+if [ -n "$files_with_whitespace" ]; then
+  echo "Error: The following files have a whitespace in the name:"
+  echo "$files_with_whitespace"
+  exit 1
+fi

--- a/scripts/check_filesize.sh
+++ b/scripts/check_filesize.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Find files that are larger than the maximum size.
+
+MAX_SIZE=300k
+DIR=source
+
+large_files=$(find $DIR -type f -size +"$MAX_SIZE" -exec du -h {} \;)
+
+if [ -n "$large_files" ]; then
+  echo -e "Error: Large files were found: \n$large_files"
+  exit 1
+fi


### PR DESCRIPTION
This compliance check introduces a Github Action to check filesize and filenames.

1. Keep image sizes small (<300 kb) to not bloat the repository. For bigger images we should save the files on a seperate server.
2. Do not allow whitespaces in filenames.

I thought small shell/python scripts are easy to maintain, and can also be run offline or being executed by the github action. Comments how to optimize the CI-Pipeline are welcome.

Signed-off-by: Jonas Remmert <j.remmert@phytec.de>