### PR TITLE
tox: add argument to rebuild sphinx environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
 
 [testenv:py3-html]
 commands =
-    sphinx-build -W --keep-going -b html source build/html
+    sphinx-build -E -W --keep-going -b html source build/html
 
 [testenv:py3-pdf]
 commands =


### PR DESCRIPTION
To fix a problem where links to new html pages are not included in already built files, add an option to rebuild the sphinx environment via tox. Specifically, when adding a page between builds, only the changed files are updated (and their toctrees). See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-E