### PR TITLE
source: yocto: head. Add search registires

### DIFF
--- a/source/yocto/head.rst
+++ b/source/yocto/head.rst
@@ -875,6 +875,18 @@ duckerhub space:
 If you try to run a container, which is not pulled/downloaded, it will be
 pulled/downloaded automatically.
 
+On some distributions, you may need to add search registries on your own.
+
+:: 
+
+    /etc/containers/registries.conf
+    unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.redhat.com", "docker.io", "quay.io"]
+
+At least docker.io needs to be added, so our container can be found and pulled.
+
+
+    
+
 Run container
 -------------
 


### PR DESCRIPTION
Adding step, how to add searching registries.

Signed-off-by: Norbert Wesp <n.wesp@phytec.de>