### PR TITLE
Minor improvements to yocto manual

### DIFF
--- a/source/yocto/head.rst
+++ b/source/yocto/head.rst
@@ -2253,7 +2253,6 @@ You should see::
 Further information about AP settings and the userspace daemon
 *hostapd* can be found at::
 
-   http://processors.wiki.ti.com/index.php/OMAP_Wireless_Connectivity_NLCP_WLAN_AP_Configuration_Scripts
    https://wireless.wiki.kernel.org/en/users/documentation/hostapd
    https://w1.fi/hostapd/
 


### PR DESCRIPTION
This includes:
 - Remove duplicate backslashes from auto-conversion
 - Update all links to use https
 - Set all links to yocto documentation to point-release 4.0.6
 - Delete dead link to TI processors wiki