### PR TITLE
BSPIMX8M-2364: add notice for imx8 family

### DIFF
--- a/source/bsp/imx8/installing-os.rsti
+++ b/source/bsp/imx8/installing-os.rsti
@@ -5,15 +5,15 @@ To boot from eMMC, make sure that the BSP image is flashed correctly to the eMMC
 and the |ref-bootswitch| is set to **Default SOM boot**. 
 
 .. warning::
-   When eMMC and SD Card are flashed with the same (identical) image, the UUIDs
-   of the boot partitions are also identical. If the SD Card is connected when
-   booting, this leads to non-deterministic behaviour as linux mounts the boot
+   When eMMC and SD card are flashed with the same (identical) image, the UUIDs
+   of the boot partitions are also identical. If the SD card is connected when
+   booting, this leads to non-deterministic behavior as Linux mounts the boot
    partition based on UUID. ::
 
       target:~# blkid
 
-   can be run to inspect whether the current setup is affected (mmcblk2p1 and
-   mmcblk1p1 have an identical UUID).
+   can be run to inspect whether the current setup is affected. If ``mmcblk2p1``
+   and ``mmcblk1p1`` have an identical UUID, the setup is affected.
 
 Flash eMMC from Network
 .......................

--- a/source/yocto/head.rst
+++ b/source/yocto/head.rst
@@ -1780,7 +1780,7 @@ kernel. If you do not have one, use the commands::
 Add the following snippet to the file build/conf/local.conf::
 
    # Use your own path to the git repository
-   # NOTE: Branche name in variable "BRANCH_pn-barebox" should be the same as the
+   # NOTE: Branch name in variable "BRANCH_pn-barebox" should be the same as the
    # branch which is used in the repository folder. Otherwise your commits won't be recognized later.
    BRANCH:pn-barebox = "v2019.11.0-phy"
    SRC_URI:pn-barebox = "git:///${HOME}/git/barebox;branch=${BRANCH}"


### PR DESCRIPTION
Add warning in imx8 bsp manuals regarding non-deterministic automount behaviour in linux. Also add instruction on how to check whether ones setup is affected.