### PR TITLE
bsp: imx8mm: Update M4 core documentation

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -404,7 +404,7 @@ The device tree of PEB-AV-10 can be found here:
 .. include:: ../peripherals/ocotp-ctrl.rsti
 
 .. +---------------------------------------------------------------------------+
-..                                M Core
+..                                i.MX 8M Mini M4 Core
 .. +---------------------------------------------------------------------------+
 
 .. include:: mcu.rsti

--- a/source/bsp/imx8/imx8mm/mcu.rsti
+++ b/source/bsp/imx8/imx8mm/mcu.rsti
@@ -84,6 +84,12 @@ Once a micro-USB cable is connected to the USB-debug port on the |sbc|, two
 ttyUSB devices are registered. One prints messages from A53-Core's debug UART
 and the other one from the |mcore|'s debug UART.
 
+.. Hint::
+
+   Only the newer revision (1532.2) of the phyBOARD-Polis-MINI registers the
+   debug UART as ttyUSB on the USB-debug port. With the older revision (1532.1)
+   the debug UART is on the X8 connector.
+
 Running Examples from U-Boot
 ............................
 


### PR DESCRIPTION
Add a hint about the dependency of the whereabouts of the UART interface and the board revision.