### PR TITLE
bsp: imx8m: Use lower eraseblocks number for spi-nor

### DIFF
--- a/source/bsp/imx8/installing-os.rsti
+++ b/source/bsp/imx8/installing-os.rsti
@@ -488,7 +488,7 @@ Flash SPI NOR from SD Card in kernel on Target
    Name:                           u-boot
    Type:                           nor
    Eraseblock size:                65536 bytes, 64.0 KiB
-   Amount of eraseblocks:          64 (4194304 bytes, 4.0 MiB)
+   Amount of eraseblocks:          60 (3932160 bytes, 3.7 MiB)
    Minimum input/output unit size: 1 byte
    Sub-page size:                  1 byte
    Character device major/minor:   90:0
@@ -499,7 +499,7 @@ Erase the u-boot partition and flash it:
 
 .. parsed-literal::
 
-   target$ flash_erase /dev/mtd0 0x0 64
+   target$ flash_erase /dev/mtd0 0x0 60
    target$ flashcp /mnt/imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi /dev/mtd0
 
 RAUC


### PR DESCRIPTION
When flashing the spi-nor, only erase 60 blocks. Even if some boards have 64 erase blocks, bootloader does not need that much space so it does not break anything. But for boards that have 60 eraseblocks only, the flash_erase command returns an error when trying to erase more blocks (64).