### PR TITLE
Update M4 core documentation for Mini/Nano

### DIFF
--- a/source/bsp/imx8/imx8mm/mcu.rsti
+++ b/source/bsp/imx8/imx8mm/mcu.rsti
@@ -70,6 +70,16 @@ To build the firmware for the |mcore|'s TCM. The output will be placed under
 release/ in the armgcc directory. .bin files and can be run in U-Boot and .elf
 files within Linux.
 
+To build the firmware for the DRAM, run the script
+build_ddr_release.
+Script to build the firmware::
+
+   host$ ./build_ddr_release.sh
+
+The output will be placed under ddr_release/ in the armgcc
+directory. .bin files and can be run in U-Boot and .elf
+files within Linux.
+
 Running |mcore| Examples
 ------------------------
 


### PR DESCRIPTION
Building the firmware for M4's TCM and DRAM are from different build scripts. To build the firmware for the DRAM, need to use build_ddr_release shell script. So, a section regarding it is updated.