### PR TITLE
BSPIMX8M-2660 Wip/tremmet/gpio fan

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -59,6 +59,7 @@
 
 .. IMX8(MM) specific replacements
 .. |pollux-sbc-network| replace:: \
+.. |pollux-fan-note| replace:: Only GPIO fan supported.
 .. |uboot-tag| replace:: v2021.04_2.2.0-phy5
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mm-head-ubootexternalenv>`

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -59,6 +59,7 @@
 
 .. IMX8(MN) specific replacements
 .. |pollux-sbc-network| replace:: \
+.. |pollux-fan-note| replace:: Only GPIO fan supported.
 .. |uboot-tag| replace:: v2021.04_2.2.0-phy5
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mn-head-ubootexternalenv>`

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -62,6 +62,11 @@
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
    :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy9#n149`.
+.. |pollux-fan-note| replace::
+   Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
+   to GPIO fan due to availability. The PWM fan will not be supported
+   anymore and will not function with the new release.
+
 .. |ref-jp3| replace:: :ref:`JP3 <imx8mp-head-components>`
 .. |ref-jp4| replace:: :ref:`JP4 <imx8mp-head-components>`
 .. |uboot-tag| replace:: v2021.04_2.2.0-phy7

--- a/source/bsp/imx8/peripherals/tm.rsti
+++ b/source/bsp/imx8/peripherals/tm.rsti
@@ -64,6 +64,10 @@ trip_point_0 again, the throttling is released.
 GPIO Fan
 ........
 
+.. note::
+
+   |pollux-fan-note|
+
 A GPIO fan can be connected to the |sbc|-|soc|. The SoC only contains one
 temperature sensor which is already used by the thermal frequency scaling. The
 fan can not be controlled by the kernel. We use lmsensors with hwmon for this


### PR DESCRIPTION
Update imx8 documentation to mention only GPIO fan as this is now used on all i.MX8M boards.
Add a Pollux specific note as we have a break in functionality not supporting PWM fan anymore.