### PR TITLE
Update M7 core documentation of pollux

### DIFF
--- a/source/bsp/imx8/imx8mp/mcu.rsti
+++ b/source/bsp/imx8/imx8mp/mcu.rsti
@@ -68,6 +68,15 @@ to build the firmware for the |mcore|'s TCM. The output will be placed under
 release/ in the armgcc directory. .bin files and can be run in U-Boot and .elf
 files within Linux.
 
+To build the firmware for the DRAM, run the script build_ddr_release.
+The script of the firmware that is supposed to run, e.g. ::
+
+   $ ./build_ddr_release.sh
+
+The output will be placed under ddr_release/ in the armgcc
+directory. .bin files and can be run in U-Boot and .elf
+files within Linux.
+
 Running |mcore| Examples
 ------------------------
 


### PR DESCRIPTION
Building the firmware for M7's TCM and DRAM are from different build scripts. To build the firmware for the DRAM, need to use build_ddr_release shell script. So, a section regarding it is updated.