### PR TITLE
bugfix stuck sidebar: add sphinx_rtd_theme to config.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -30,6 +30,7 @@ release = '0.1.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
+    'sphinx_rtd_theme',
 ]
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
There is a known issue that jQuery is not loaded in combination with Sphinx 6 when using rtd_theme. The fix is to add sphinx_rtd_theme to config.py