### PR TITLE
source: bsp: imx8: add u-boot-offset substitution

### DIFF
--- a/source/bsp/development.rsti
+++ b/source/bsp/development.rsti
@@ -421,9 +421,9 @@ Set this environment variable before building the Image:
 The flash.bin can be found at u-boot-imx/ directory and now can be flashed. A
 chip-specific offset is needed. E.g. flash SD card:
 
-::
+.. parsed-literal::
 
-   host$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=32 conv=sync
+   host$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=\ |u-boot-offset| conv=sync
 
 Build Kernel
 ............

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -28,6 +28,10 @@
 .. |kernel-tag| replace:: v5.10.72_2.2.0-phy9
 
 
+.. Bootloader
+.. |u-boot-offset| replace:: 33
+
+
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mm-phyboard-polis-rdk
 .. |dt-som| replace:: imx8mm-phycore-som

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -28,6 +28,10 @@
 .. |kernel-tag| replace:: v5.10.72_2.2.0-phy9
 
 
+.. Bootloader
+.. |u-boot-offset| replace:: 32
+
+
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mn-phyboard-polis-rdk
 .. |dt-som| replace:: imx8mn-phycore-som

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -28,6 +28,10 @@
 .. |kernel-tag| replace:: v5.10.72_2.2.0-phy9
 
 
+.. Bootloader
+.. |u-boot-offset| replace:: 32
+
+
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som


### PR DESCRIPTION
When copying the bootloader to the sdcard, a chip specific offset is required. Define a new substitution to implement this.