### PR TITLE
bsp: imx8mn/imx8mm: Add hint about terminating resistor in CANFD chapter

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -360,6 +360,11 @@ device, with some additional features special to CAN. More information can be
 found in the Linux Kernel
 documentation:  https://www.kernel.org/doc/html/latest/networking/can.html
 
+.. Hint::
+
+   On phyBOARD-Polis-i.MX8MM a terminating resistor can be enabled by setting
+   S5 to ON if required.
+
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of imx8mm-phyboard-polis.dtsi:

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -360,6 +360,11 @@ device, with some additional features special to CAN. More information can be
 found in the Linux Kernel
 documentation:  https://www.kernel.org/doc/html/latest/networking/can.html
 
+.. Hint::
+
+   On phyBOARD-Polis-i.MX8MN a terminating resistor can be enabled by setting
+   S5 to ON if required.
+
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of imx8mm-phyboard-polis.dtsi:


### PR DESCRIPTION
Add hint that the terminating resistor has to be set to ON for CAN to work correctly.