### PR TITLE
Wip/c.tenruh@phytec.de/can datarate

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -362,6 +362,12 @@ documentation:  https://www.kernel.org/doc/html/latest/networking/can.html
 
 .. Hint::
 
+   phyBOARD-Polis has an external CANFD chip MCP2518FD connected over SPI.
+   There are different interfaces involved, which limits the datarate
+   capabilities of CANFD.
+
+.. Hint::
+
    On phyBOARD-Polis-i.MX8MM a terminating resistor can be enabled by setting
    S5 to ON if required.
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -362,6 +362,12 @@ documentation:  https://www.kernel.org/doc/html/latest/networking/can.html
 
 .. Hint::
 
+   phyBOARD-Polis has an external CANFD chip MCP2518FD connected over SPI.
+   There are different interfaces involved, which limits the datarate
+   capabilities of CANFD.
+
+.. Hint::
+
    On phyBOARD-Polis-i.MX8MN a terminating resistor can be enabled by setting
    S5 to ON if required.
 


### PR DESCRIPTION
 Since we can not fully utilize the datarate capabilities of the MCP2518FD chip we need to note that in the documentation.
I am a little unsure about the position of the hint, i welcome suggestions.