### PR TITLE
github actions: run on local runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,14 +5,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 5
     steps:
     - name: Clone repo
       uses: actions/checkout@v3
     - name: Install dependencies
       run: |
           sudo apt update
-          sudo apt install texlive-latex-extra texlive-xetex latexmk python3-pip -y
+          sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
           pip3 install -r requirements/setup.txt
           pip3 install -r requirements/build.txt
     - name: Render HTML Documentation

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   compliance:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 5
     steps:
     - name: Checkout the code
       uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,12 +6,16 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 5
     steps:
     - name: Clone repo
       uses: actions/checkout@v3
     - name: Install dependencies
-      run: pip3 install -r requirements/setup.txt
+      run: |
+          sudo apt update
+          sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
+          pip3 install -r requirements/setup.txt
     - name: Render Documentation
       run: tox -e py3-html
     - name: Deploy

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -5,14 +5,15 @@ on:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 5
     steps:
     - name: Clone repo
       uses: actions/checkout@v2
     - name: Install dependencies
       run: |
           sudo apt update
-          sudo apt install python3-pip -y
+          sudo apt install python3-pip tox -y
           pip3 install -r requirements/setup.txt
     - name: Check External Links
       run: tox -e py3-linkcheck

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -5,7 +5,8 @@ on:
 
 jobs:
   codespell:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    timeout-minutes: 5
     steps:
     - name: Checkout the code
       uses: actions/checkout@v3


### PR DESCRIPTION
Local runners are cheaper than the github Cloud-hosted runners so we can move our ci there.