### PR TITLE
BSPIMX8M-2680 add note for unsupported video-audio combo

### DIFF
--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -379,6 +379,11 @@ codec on the PEB-AV-10 connector. On the AV-Connector there is a 3.5mm headset
 jack with OMTP-standard and an 8-pin header. The 8-pin header contains a mono
 speaker, headphones, and line in signals.
 
+.. note::
+
+   Using the PEB-AV-10 connector for display output along HDMI as audio output
+   is not supported. The audio output device must match the video output device.
+
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:


### PR DESCRIPTION
Simultaneously using HDMI for audio and PEB-AV-10 for video is not supported and will not work. Add a note in the manual.