### PR TITLE
source: yocto: head: fix broken link

### DIFF
--- a/source/yocto/head.rst
+++ b/source/yocto/head.rst
@@ -841,7 +841,7 @@ to run.
 Installation
 ------------
 
-How to install podman: https://podman.io/getting-started/installation
+How to install podman: https://podman.io
 
 How to install docker: https://docs.docker.com/engine/install/
 


### PR DESCRIPTION
Podman.io changed their website and the old link was broken.