### PR TITLE
bsp: imx8mp: add HDMI/PEB-AV-10 audio note to display section

### DIFF
--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -18,6 +18,7 @@ MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo
 .. note::
 
    *  HDMI will not work if LVDS1 (onboard) is enabled.
+   *  When changing Weston output, make sure to match the audio output as well.
    *  LVDS0 (PEB-AV-10) and LVDS1 (onboard)can not be used at the same time.
 
 HDMI is always enabled in the devicetree. The other interfaces can be enabled


### PR DESCRIPTION
commit 355b55 introduced a note regarding supported audio/video output combination, also add a note to the display section.

Depends on #60 (fix linkcheck)