### PR TITLE
Fix for the upcoming release yocto codename

### DIFF
--- a/source/bsp/development.rsti
+++ b/source/bsp/development.rsti
@@ -476,7 +476,7 @@ command line:
 
 .. parsed-literal::
 
-   host$ ./phyLinux init -p |kernel-socname| -r |yocto-codename|
+   host$ ./phyLinux init -p |kernel-socname| -r |yocto-manifestname-y|
 
 This will initialize a BSP that will track the latest development state. From
 now on *repo sync* in this folder will pull all the latest changes from
@@ -493,7 +493,7 @@ development state on a regular basis.
 
 .. parsed-literal::
 
-   host$ ./phyLinux init -p |kernel-socname| -r |yocto-codename|
+   host$ ./phyLinux init -p |kernel-socname| -r |yocto-manifestname-y-upcoming|
 
 Accessing the Latest Upstream Support
 -------------------------------------

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -47,6 +47,8 @@
 .. |yocto-imagename| replace:: phytec-qt5demo-image
 .. |yocto-machinename| replace:: phyboard-polis-imx8mm-5
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+.. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.y
+.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A13 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=PoDEHw
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -47,6 +47,8 @@
 .. |yocto-imagename| replace:: phytec-headless-image
 .. |yocto-machinename| replace:: phyboard-polis-imx8mn-2
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+.. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.y
+.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A13 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=PoDEHw
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -47,6 +47,8 @@
 .. |yocto-imagename| replace:: phytec-qt5demo-image
 .. |yocto-machinename| replace:: phyboard-pollux-imx8mp-3
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.y
+.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MP-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A13 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=PoDEHw
 

--- a/source/bsp/template.rst
+++ b/source/bsp/template.rst
@@ -79,6 +79,11 @@
    release images
 .. |yocto-manifestname| replace::
 .. Name of the Yocto Reference manual accompanying this BSP release.
+.. |yocto-manifestname-y| replace::
+.. Name of the existing y manifest of the current development state of
+   Yocto BSP.
+.. |yocto-manifestname-y-upcoming| replace::
+.. Name of the upcoming y manifest of the upcoming release of Yocto BSP.
 .. |yocto-ref-manual| replace::
 .. _yocto-ref-manual:
 


### PR DESCRIPTION
As we have the current and upcoming release states mentioned in the documentation, the same yocto current codename is used in both the sections of current and upcoming releases. So, adding a missing replacement yocto codename variable for the upcoming release section, along with the current in the documentation. 