### PR TITLE
BSPIMX8M-2698: bsp: imx8: imx8mm: Fix flash offset

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -32,6 +32,7 @@
 
 .. Bootloader
 .. |u-boot-offset| replace:: 33
+.. |u-boot-mmc-flash-offset| replace:: 0x42
 
 
 .. Devicetree

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -32,6 +32,7 @@
 
 .. Bootloader
 .. |u-boot-offset| replace:: 32
+.. |u-boot-mmc-flash-offset| replace:: 0x40
 
 
 .. Devicetree

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -32,6 +32,7 @@
 
 .. Bootloader
 .. |u-boot-offset| replace:: 32
+.. |u-boot-mmc-flash-offset| replace:: 0x40
 
 
 .. Devicetree

--- a/source/bsp/imx8/installing-os.rsti
+++ b/source/bsp/imx8/installing-os.rsti
@@ -129,7 +129,7 @@ can be used if the bootloader on eMMC is located in the eMMC user area.
 
    u-boot=> tftp ${loadaddr} imx-boot
    u-boot=> mmc dev 2
-   u-boot=> mmc write ${loadaddr} 0x40 ${filesize}
+   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${filesize}
 
 Flash eMMC from USB
 ...................


### PR DESCRIPTION
the offset used in the mmc write command depends on the i.MX8M* platform used.