### PR TITLE
BSPIMX8M-2702: add U-Boot build with fix RAM size section

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -423,6 +423,30 @@ chip-specific offset is needed. E.g. flash SD card:
 
    host$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=\ |u-boot-offset| conv=sync
 
+Build a U-Boot with a Fixed RAM Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you cannot boot your system anymore because the hardware introspection in the
+EEPROM is damaged or deleted, you can create a flash.bin with a fixed ram size.
+You should still contact support and flash the correct EEPROM data, as this
+could lead to unexpected behavior.
+
+Follow the steps to get the U-boot sources and check the correct branch in the
+**Build U-Boot** section.
+
+Choose the correct RAM size as populated on the board.
+
+.. parsed-literal::
+
+   CONFIG_TARGET_PHYCORE\_\ |u-boot-socname-config|\=y
+   # CONFIG_PHYTEC_IMX8M_SOM_DETECTION is not set
+   CONFIG_PHYCORE\_\ |u-boot-socname-config|\_RAM_SIZE_FIX=y
+   # CONFIG_PHYCORE\_\ |u-boot-socname-config|\_RAM_SIZE_1GB=y
+   # CONFIG_PHYCORE\_\ |u-boot-socname-config|\_RAM_SIZE_2GB=y
+   # CONFIG_PHYCORE\_\ |u-boot-socname-config|\_RAM_SIZE_4GB=y
+
+After saving the changes, follow the remaining steps from Build U-Boot.
+
 Build Kernel
 ............
 

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -34,6 +34,8 @@
 .. |u-boot-offset| replace:: 33
 .. |u-boot-mmc-flash-offset| replace:: 0x42
 
+.. IMX8(MM) specific
+.. |u-boot-socname-config| replace:: IMX8MM
 
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mm-phyboard-polis-rdk

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -34,6 +34,8 @@
 .. |u-boot-offset| replace:: 32
 .. |u-boot-mmc-flash-offset| replace:: 0x40
 
+.. IMX8(MN) specific
+.. |u-boot-socname-config| replace:: IMX8MN
 
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mn-phyboard-polis-rdk

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -34,6 +34,8 @@
 .. |u-boot-offset| replace:: 32
 .. |u-boot-mmc-flash-offset| replace:: 0x40
 
+.. IMX8(MP) specific
+.. |u-boot-socname-config| replace:: IMX8MP
 
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk


### PR DESCRIPTION
When eeprom is not flashed or cannot be flashed on imx8m boards, eeprom detection may now be disabled in U-Boot. This requires changing the CONFIG. Add a guide on what to change and how to change it when building U-Boot with SOM detection disabled. 

Depends on #64 