### PR TITLE
ci: timeout: Increase all timeouts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
     - name: Clone repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Sometimes Github actions are running into timeouts. This commit increases the timeout to 15 min from 5 min.