### PR TITLE
BSPIMX8M-2712: standalone kernel module handling

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -493,6 +493,10 @@ Build Kernel
    host$ make imx_v8_defconfig imx8_phytec_distro.config imx8_phytec_platform.config
    host$ make -j16
 
+*  Install kernel modules to e.g. NFS directory::
+
+      host$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
+
 *  The Image can be found at ~/linux-imx/arch/arm64/boot/Image
 *  The dtb can be found at
    ~/linux-imx/arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb
@@ -510,6 +514,19 @@ Build Kernel
    .. parsed-literal::
 
       sudo apt install libghc-libyaml-dev
+
+Copy Kernel to SD Card
+......................
+
+When one-time boot via netboot is not sufficient, the kernel along with its
+modules and the corresponding device tree blob may be copied directly to a
+mounted SD card.
+
+.. parsed-literal::
+
+   cp arch/arm64/boot/Image /path/to/sdcard/boot/
+   cp arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb /path/to/sdcard/boot/oftree
+   make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install
 
 Accessing the Development States between Releases
 -------------------------------------------------


### PR DESCRIPTION
When building standalone kernel, the kernel modules need to be copied to nfs aswell so that the standalone kernel loads them. Add a bullet on how to install kernel modules.
Also add a guide on copying the standalone kernel to mounted SD card.