### PR TITLE
bsp: imx8: spi-master: Remove wrong output

### DIFF
--- a/source/bsp/imx8/peripherals/spi-master.rsti
+++ b/source/bsp/imx8/peripherals/spi-master.rsti
@@ -37,9 +37,6 @@ for a partition, run on the target:
 
 .. parsed-literal::
 
-   Count of MTD devices:           4
-   Present MTD devices:            mtd0, mtd1, mtd2, mtd3
-   Sysfs interface supported:      yes
    root@\ |yocto-machinename|:~# mtdinfo --all
    Count of MTD devices:           4
    Present MTD devices:            mtd0, mtd1, mtd2, mtd3


### PR DESCRIPTION
The mtdinfo --all example is messed up as a partially duplicated output is printed before the command call. Fix that.