### PR TITLE
BSPIMX8M-2638: bsp: imx8mp: Remove phyboard-pollux-imx8mp-2 hint

### DIFF
--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -240,10 +240,6 @@ select the phyCORE-|soc| default bootsource.
    imx8mp-vm017-csi2.dtbo
    imx8mp-vm017-csi2-fpdlink.dtbo
 
-.. hint::
-   There is one more overlay available for phyboard-pollux-imx8mp-2.conf:
-   imx8mp-phyboard-pollux-1552.1.dtbo
-
 .. _imx8mp-head-ubootexternalenv:
 .. include:: ../dt-overlays.rsti
 


### PR DESCRIPTION
We discontinue support for phyboard-pollux-imx8mp-2. So remove the existing hint to the also removed device tree overlay.