### PR TITLE
imx8: installing-os: Fix flashing u-boot image example

### DIFF
--- a/source/bsp/imx8/installing-os.rsti
+++ b/source/bsp/imx8/installing-os.rsti
@@ -128,8 +128,9 @@ can be used if the bootloader on eMMC is located in the eMMC user area.
 .. parsed-literal::
 
    u-boot=> tftp ${loadaddr} imx-boot
+   u-boot=> setexpr nblk ${filesize} / 0x200
    u-boot=> mmc dev 2
-   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${filesize}
+   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${nblk}
 
 .. hint::
    The hexadecimal value represents the offset as a multiple of 512 byte


### PR DESCRIPTION
The last parameter of mmc write is "cnt" which is the number of 512byte blocks and not the number ob bytes passed by ${filesize}. Using ${filesize} results in writing more data to flash then wanted and needed.

Fix this by calculating the number of blocks from ${filesize} and pass this to mmc write command.