### PR TITLE
BSPIMX8M-2720 bsp: imx8mm: add SD voltage switch disable note

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -379,6 +379,8 @@ Or you can download the files here: |link-boot-tools|
 Build U-Boot
 ~~~~~~~~~~~~
 
+.. build-uboot-marker
+
 *  Get the U-Boot sources:
 
 ::

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -203,6 +203,20 @@ select the phyCORE-|soc| default bootsource.
 
 .. _imx8mm-head-development:
 .. include:: /bsp/imx8/development.rsti
+   :end-before: .. build-uboot-marker
+
+.. note::
+   The regulator for the SD card reset pin has been disabled to ensure
+   compatibility with 1532.1 revision baseboards. If you have a revision
+   1532.2(a) or higher baseboard, you may enable the device tree nodes for
+   highest performance. In the imx8mm-phyboard-polis-rdk-u-boot.dtsi file,
+   remove the following lines::
+
+      /delete-node/ &reg_usdhc2_vmmc;
+      /delete-property/ vmmc-supply;
+
+.. include:: /bsp/imx8/development.rsti
+   :start-after: .. build-uboot-marker
 
 .. +---------------------------------------------------------------------------+
 ..                               DEVICE TREE


### PR DESCRIPTION
Add note highlighting to users the possibility to modify U-Boot device tree to unlock highest performance for SD card when using newer phyBOARD-Polis hardware.