### PR TITLE
BSPIMX8M-3059 bsp: imx8: peripherals: pm: resume from suspend with on/off button

### DIFF
--- a/source/bsp/imx8/peripherals/pm.rsti
+++ b/source/bsp/imx8/peripherals/pm.rsti
@@ -117,7 +117,7 @@ The |som| supports basic suspend and resume. Different wake-up sources can be
 used. Suspend/resume is possible with::
 
    target$ echo mem > /sys/power/state
-   #resume with pressing reset button
+   #resume with pressing on/off button
 
 To wake up with serial console run
 


### PR DESCRIPTION
imx8 boards can be resumed from suspend into RAM with the on/off button, not with the reset button.