### PR TITLE
bsp: imx8: UUU-Tool USB port rephrase

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -195,7 +195,7 @@ Prepare Target
 ..............
 
 For UUU boot, set the |ref-bootswitch| to **Serial downloader (USB boot)** (Boot
-Configuration Options). Also, connect **USB OTG** |ref-usb-otg| to your host.
+Configuration Options). Also, connect USB port |ref-usb-otg| to your host.
 
 Starting bootloader via UUU-Tool
 ................................


### PR DESCRIPTION
To run USB Boot for Polis Mini and Nano we have to connect our USB micro port to the host. As the USB mirco port is used also for USB device functionality we use the phrase USB OTG in the documentation.

But for Pollux there is no USB micro port and no USB device functionality. Never the less we can make use of UUU boot and flashing the eMMC. So make the naming more generic.