### PR TITLE
bsp: imx8: dt-overlays: fix u-boot environment command

### DIFF
--- a/source/bsp/imx8/dt-overlays.rsti
+++ b/source/bsp/imx8/dt-overlays.rsti
@@ -125,7 +125,7 @@ Print the u-boot environment using the following command::
 
 Modify a u-boot environment variable using the following command::
 
-   Modify a u-boot environment variable using the following command:
+   target$ fw_setenv <variable-you-want-to-modify>
 
 .. caution::
    Libubootenv takes the environment selected in a configuration file. The


### PR DESCRIPTION
Due to copying an erroneous document, a command specifying how to manipulate the u-boot environment from linux was missing and instead replaced with the explanation. Add the command

closes #97 