### PR TITLE
BSPIMX8M-3080 BSPIMX8M-3078 Update documentation on uuu and netboot

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -206,46 +206,52 @@ Working with UUU-Tool
 
 The Universal Update Utility Tool (UUU-Tool) from NXP is software to execute
 from the host to load and run the bootloader on the board through SDP. For
-detailed information visit https://github.com/NXPmicro/mfgtools or download the
+detailed information visit https://github.com/nxp-imx/mfgtools or download the
 `Official UUU-tool documentation
 <https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-processors/140261/1/UUU.pdf>`_.
 
 Host preparations for UUU-Tool Usage
 ....................................
 
-::
+*  Follow the instructions from https://github.com/nxp-imx/mfgtools#linux.
 
-   host$ sudo apt-get install libusb-1.0-0-dev libzstd-dev libzip-dev libbz2-dev pkg-config cmake
-   host$ git clone https://github.com/NXPmicro/mfgtools.git
-   host$ cd mfgtools
-   host$ cmake .
-   host$ make
+*  If you built UUU from source, add it to ``PATH``:
 
-Get _flash.bin
-..............
+   This BASH command adds UUU only temporarily to ``PATH``. To add it permanently, add this line to
+   ``~/.bashrc``.
+
+   .. code-block:: console
+
+      export PATH=~/mfgtools/uuu/:"$PATH"
+
+*  Set udev rules (documented in ``uuu -udev``):
+
+   .. code-block:: console
+
+      host:~$ sudo sh -c "uuu -udev >> /etc/udev/rules.d/70-uuu.rules"
+      host:~$ sudo udevadm control --reload
+
+Get Images
+..........
 
 Download imx-boot from our server or get it from your Yocto build directory at
-../build/deploy/images/|yocto-machinename|/ and copy the U-boot image (imx-boot) to
-the UUU directory::
-
-   host$ cd mfgtools
-   host$ cp -v imx-boot uuu/_flash.bin
+../build/deploy/images/|yocto-machinename|/. For flashing a wic image to eMMC,
+you will also need |yocto-imagename|-|yocto-machinename|.wic.
 
 Prepare Target
 ..............
 
-For UUU boot, set the |ref-bootswitch| to **Serial downloader (USB boot)** (Boot
+Set the |ref-bootswitch| to **Serial downloader (USB boot)** (Boot
 Configuration Options). Also, connect USB port |ref-usb-otg| to your host.
 
 Starting bootloader via UUU-Tool
 ................................
 
-*  Execute and  Power up the board:
+Execute and power up the board:
 
-::
+.. code-block:: console
 
-   host$ cd mfgtools/uuu
-   host$ sudo ./uuu _flash.bin
+   host:~$ sudo uuu -b spl imx-boot
 
 You can see the bootlog on the console via the debug USB
 |ref-debugusbconnector|, as usual.
@@ -261,49 +267,20 @@ You can see the bootlog on the console via the debug USB
 Flashing U-boot Image to eMMC via UUU-Tool
 ...........................................
 
-Set the |ref-bootswitch| to Serial downloader (USB boot) (Boot
-Configuration Options). Also, connect USB OTG |ref-usb-otg| to your host.
-
-Download the imx-boot image from
-our server or get them from your Yocto build directory at
-../build/deploy/images/|yocto-machinename|/ and copy them to the UUU directory:
+Execute and power up the board:
 
 .. code-block:: console
-   :substitutions:
 
-   host:~$ cd mfgtools
-   host:~$ cp -v imx-boot uuu/_flash.bin
-
-*  Execute and power up the board:
-
-::
-
-   host$ cd mfgtools/uuu
-   host$ sudo ./uuu -b emmc_burn_loader.lst _flash.bin
+   host:~$ sudo uuu -b emmc imx-boot
 
 Flashing wic Image to eMMC via UUU-Tool
 ...........................................
 
-Set the |ref-bootswitch| to Serial downloader (USB boot) (Boot
-Configuration Options). Also, connect USB OTG |ref-usb-otg| to your host.
-
-Download |yocto-imagename|-|yocto-machinename|.wic and imx-boot image from
-our server or get them from your Yocto build directory at
-../build/deploy/images/|yocto-machinename|/ and copy them to the UUU directory:
+Execute and power up the board:
 
 .. code-block:: console
-   :substitutions:
 
-   host:~$ cd mfgtools
-   host:~$ cp -v imx-boot uuu/_flash.bin
-   host:~$ cp -v |yocto-imagename|-|yocto-machinename|.wic uuu/_rootfs.wic
-
-*  Execute and power up the board:
-
-::
-
-   host$ cd mfgtools/uuu
-   host$ sudo ./uuu -b emmc_burn_loader.lst _flash.bin _rootfs.wic
+   host:~$ sudo uuu -b emmc_all imx-boot |yocto-imagename|-|yocto-machinename|.wic
 
 Standalone Build
 ----------------


### PR DESCRIPTION
Update package dependencies for uuu.
Add notice on how to set the required udev rules for uuu.
Update the command on how to start the bootloader with uuu.
Update the command on how to flash the wic image onto emmc.
Add notice to copy the overlays to /tftpboot.
Add notice to set the bootenv.txt in /tftpboot.