### PR TITLE
BSPIMX8M-1789 bsp: imx8: development: remove accessing state of upcoming release

### DIFF
--- a/source/bsp/imx8/development.rsti
+++ b/source/bsp/imx8/development.rsti
@@ -603,17 +603,17 @@ our Git repositories:
 
    host:~$ repo sync
 
-Accessing Development State of Upcoming Major Release
------------------------------------------------------
+.. tip::
 
-We are already working on the next major release update based on NXP BSP
-rel_imx_5.15.52_2.1.0 (kirkstone). We are trying to update the public
-development state on a regular basis.
+   Also development states of upcoming releases can be accessed this way.
+   For this execute the following command and look for a release with a higher
+   PDXX.Y number than the latest one (|yocto-manifestname|) and ``.y`` at the
+   end:
 
-.. code-block:: console
-   :substitutions:
+   .. code-block:: console
+      :substitutions:
 
-   host:~$ ./phyLinux init -p |kernel-socname| -r |yocto-manifestname-y-upcoming|
+      host:~$ ./phyLinux init -p |kernel-socname|
 
 Accessing the Latest Upstream Support
 -------------------------------------

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -61,7 +61,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.0
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MM-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A14 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=IoBHIw
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -60,7 +60,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.1
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MM-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A13 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=PoDEHw
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -60,7 +60,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.0
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MM-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A14 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=IoBHIw
 

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -59,7 +59,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.1
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MM-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MM-PD22.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MM-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A12 Yocto Reference Manual (Hardknott)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=UIHsG
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -61,7 +61,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD23.1.0
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD23.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MP-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A14 Yocto Reference Manual (kirkstone)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=IoBHIw
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -60,7 +60,6 @@
 .. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.y
-.. |yocto-manifestname-y-upcoming| replace:: BSP-Yocto-NXP-i.MX8MP-PD23.1.y
 .. |yocto-ref-manual| replace:: L-813e.A12 Yocto Reference Manual (Hardknott)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=UIHsG
 

--- a/source/bsp/template.rst
+++ b/source/bsp/template.rst
@@ -89,8 +89,6 @@
 .. |yocto-manifestname-y| replace::
 .. Name of the existing y manifest of the current development state of
    Yocto BSP.
-.. |yocto-manifestname-y-upcoming| replace::
-.. Name of the upcoming y manifest of the upcoming release of Yocto BSP.
 .. |yocto-ref-manual| replace::
 .. _yocto-ref-manual:
 


### PR DESCRIPTION
Remove the chapter Accessing the Development States between Releases, because at the current time there is no development state of an upcoming release. The previous chapter already describes how to access development state. Add a note that development states of upcoming releases can also be accessed that way, without mentioning a specific release.