### PR TITLE
hosttools: remove Development Host Setup

### DIFF
--- a/source/devtools/hostsetup.rst
+++ b/source/devtools/hostsetup.rst
@@ -1,9 +1,0 @@
-======================
-Development Host Setup
-======================
-
-This part of the documentation focuses on how to set up your system to develop
-with and contribute to this package.
-
-Linux basics
-============

--- a/source/index.rst
+++ b/source/index.rst
@@ -7,7 +7,6 @@ Welcome to the Documentation for our Yocto BSPs.
    :maxdepth: 1
    :caption: Contents
 
-   devtools/hostsetup
    yocto/manual-index
    bsp/imx8/imx8
 


### PR DESCRIPTION
Development Host Setup is a separate manual that is currently hosted in Confluence. This PR removes the stub that was added as a placeholder. This placeholder is confusing as long as there is no actual content.