### PR TITLE
requirements: upgrade to sphinx-rtd-theme 2.0.0

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,3 @@
 Sphinx==7.2.6
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
 Sphinx-Substitution-Extensions==2022.2.16.0


### PR DESCRIPTION
It looks like the search function had a bug in the old sphinx-rtd-theme version and did not show text excerpts in the search results. Moving to 2.0.0 should solve this problem.

Should fix #131 (we will know for sure once it has been deployed to github pages). 