### PR TITLE
releases: automatically generate release tag

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -11,7 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
+import re
 
 # -- Project information -----------------------------------------------------
 
@@ -19,8 +19,11 @@ project = 'PHYTEC BSP Documentation'
 copyright = '2024, PHYTEC Messtechnik GmbH'
 author = 'PHYTEC'
 
-# The full version, including alpha/beta/rc tags
-release = '0.1.0'
+# Use git describe to get the version e.g.: imx8-pd23.1.0-1-gb1830e
+release = re.sub('', '', os.popen('git describe --tags').read().strip())
+
+# Assign to the version variable, to list the version in the html as well.
+version = release
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Each document should have a unique release tag or version to be identified. Git provides a unique, useful tag with "git describe --tag". This tag will automatically be assigned to the "release" variable for the pdf files and the "version" variable for the html version.

![Screenshot from 2024-01-19 11-35-24](https://github.com/phytec/doc-bsp-yocto/assets/9881210/67d6a171-bf7d-4a0a-8943-c1d34e42836c)
Generated pdf for the pd23.1 release.

![Screenshot from 2024-01-19 11-26-27](https://github.com/phytec/doc-bsp-yocto/assets/9881210/d1b7e77c-ef6d-439f-9cdc-fc405928fc89)
The release tag in the html output for a pd23.1 + 1 Commit.