### PR TITLE
gh action: checkout tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,10 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
-    - name: Clone repo
-      uses: actions/checkout@v3
+    - name: Clone repo with all tags (required for git describe)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
           sudo apt update

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install ripgrep
       run: |
           sudo apt update

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,8 +9,10 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 5
     steps:
-    - name: Clone repo
-      uses: actions/checkout@v3
+    - name: Clone repo with all tags (required for git describe)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
           sudo apt update

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
           sudo apt update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,10 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     steps:
-    - name: Clone repo
-      uses: actions/checkout@v3
+    - name: Clone repo with all tags (required for git describe)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Initialize Problem Matcher
       uses: codespell-project/codespell-problem-matcher@v1
     - name: Check Spelling


### PR DESCRIPTION
In order for git describe to work in the github actions, we have to checkout the repository with all history and all tags. This commit adds this requirement wherever git describe is used in the action.

In addition this commit moves the checkout action to v4.