### PR TITLE
gh actions: move to github runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
     - name: Clone repo with all tags (required for git describe)

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -5,7 +5,7 @@ on: pull_request
 
 jobs:
   compliance:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - name: Checkout the code

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - name: Clone repo with all tags (required for git describe)

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linkcheck:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - name: Clone repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
     - name: Clone repo with all tags (required for git describe)

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   codespell:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - name: Checkout the code


### PR DESCRIPTION
Since the repository is now public, we can activate github runners instead of self-hosted runners.