### PR TITLE
tox: silence latex and build in parallel

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,15 +8,20 @@ deps =
 
 [testenv:py3-html]
 commands =
-    sphinx-build -E -W --keep-going -b html source build/html
+    sphinx-build -E -W --keep-going -b html source build/html -j auto
 
 [testenv:py3-pdf]
+allowlist_externals =
+    sh
 commands =
-    sphinx-build -M latexpdf source build/pdf -W --keep-going
+    # Builds are not only handled by sphinx, so we need to clean the build dir.
+    sh -c 'find build/latex -type f -delete 2>/dev/null || true'
+    sphinx-build -M latex source build -W --keep-going -j auto
+    sh -c 'make -C build/latex -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
 
 [testenv:py3-linkcheck]
 commands =
-    sphinx-build -b linkcheck source build/linkcheck
+    sphinx-build -b linkcheck source build/linkcheck -j auto
 
 [testenv:py3-spellcheck]
 deps =


### PR DESCRIPTION
We can let sphinx create only the latex files, but not compile them. Once the latex files exist, we can build them in parallel with make.

#147 

resolves #147 