### PR TITLE
static: change teal color to darker Phytec color

### DIFF
--- a/source/sphinx/static/css/phytec-theme.css
+++ b/source/sphinx/static/css/phytec-theme.css
@@ -34,12 +34,12 @@
 
 .wy-menu-vertical header,
 .wy-menu-vertical p.caption {
-    color: var(--teal3);
+    color: var(--teal4);
 
     /* Improves the appearance of uppercase text */
     letter-spacing: 0.75px;
 }
 
 .wy-side-nav-search {
-    background-color: var(--teal3);
+    background-color: var(--teal4);
 }


### PR DESCRIPTION
The darker color is already used by the documentation of modules developed in US. In addition it looks more elegant. This commit adapts the color scheme (logo background and chapter-headings).

The Chapter-Headings in HTML are not very ergonomic in terms of contrast, but there is no useful information in them anyway (Contents, Contribute) and the immediate focus falls on the headings (Yocto Reference Manuals, i.MX 8 Manuals).

Reference US Modules:
https://docs.phytec.com/latest/phycore-am62x/developingwithyocto/index.html

Old:
![image](https://github.com/phytec/doc-bsp-yocto/assets/9881210/5a94b622-e8b2-4c8b-aeab-c7af87259179)


US Docs color:
![image](https://github.com/phytec/doc-bsp-yocto/assets/9881210/dff1318b-3917-4ced-bd21-edf5d3f4ff03)

New "teal4"
![image](https://github.com/phytec/doc-bsp-yocto/assets/9881210/309aabc1-1255-4e05-a5cb-28bf1fb770d0)
