### PR TITLE
contribute: rephrase contributing section

### DIFF
--- a/source/contributing_links.rst
+++ b/source/contributing_links.rst
@@ -7,5 +7,9 @@ contributions to our Yocto BSPs and this documentation. Please check the Git
 repositories for the individual projects and layers for contribution
 guidelines.
 
--  `BSP and Yocto Documentation <https://github.com/phytec/doc-bsp-yocto>`__
-   (will be published soon)
+If you have a **question related to our Yocto BSPs** or notice **issues with
+this documentation**, we encourage you to open an Issue or Pull-Request on the
+Github repository `doc-bsp-yocto <https://github.com/phytec/doc-bsp-yocto>`__.
+Have a look at the `Contributing guide
+<https://github.com/phytec/doc-bsp-yocto/blob/main/CONTRIBUTING.rst>`__ for
+more information.


### PR DESCRIPTION
The repository is now public and the contributing section was lacking some information and pointers to the right places.