### PR TITLE
gh actions: release: fix latex path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # The release tag should be in the following format: imx8mx-pd23.1.0
 #
 # This action generates a draft release with generated pdfs for all platforms
-# and versions. The release has to be converted to a final release manuall via
+# and versions. The release has to be converted to a final release manually via
 # GitHub:
 # - remove not required PDF files
 # - convert to final release
@@ -44,4 +44,4 @@ jobs:
         draft: true
         prerelease: false
         name: ${{ env.TAG_NAME }}
-        files: build/pdf/latex/*.pdf
+        files: build/latex/*.pdf


### PR DESCRIPTION
The release action builds and uploads all pdf that have been generated. This commit corrects the path to the build directory for the pdf files.

Linkcheck should pass after rebase once #160 got merged.