### PR TITLE
linkcheck: fix broken link to Zephyr documentation

### DIFF
--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -85,7 +85,6 @@
 .. M-Core specific
 .. |mcore| replace:: M33 Core
 .. |ref-m-core-connections| replace:: :ref:`X16 <imx93-pd24.1.0-components>`
-.. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/arm/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
 


### PR DESCRIPTION
The link is currently not used in the imx93 documentation, but it causes the linkcheck to fail.