### PR TITLE
Rework peripherals video chapter

### DIFF
--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -408,7 +408,27 @@ speaker, headphones, and line in signals.
 Device Tree Audio configuration:
 :imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.15.71_2.2.2-phy3#n58`
 
-.. include:: /bsp/peripherals/video.rsti
+Video
+-----
+
+Videos with Gstreamer
+.....................
+
+One example video is installed by default in the BSP at `/usr/share/qtphy/videos/`.
+Start the video playback with one of these commands:
+
+.. code-block:: console
+
+   target:~$ gst-launch-1.0 -v filesrc location=/usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm ! decodebin name=decoder decoder. ! videoconvert ! waylandsink fullscreen=true
+
+*  Or:
+
+.. code-block:: console
+
+   target:~$ gst-play-1.0 /usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm --videosink waylandsink
+
+.. note::
+   The mainline BSP currently only supports software rendering.
 
 Display
 -------

--- a/source/bsp/peripherals/video.rsti
+++ b/source/bsp/peripherals/video.rsti
@@ -4,7 +4,8 @@ Video
 Videos with Gstreamer
 .....................
 
-The video is installed by default in the BSP:
+One example video is installed by default in the BSP at `/usr/share/qtphy/videos/`.
+Start the video playback with one of these commands:
 
 .. code-block:: console
 
@@ -14,56 +15,10 @@ The video is installed by default in the BSP:
 
 .. code-block:: console
 
-   target:~$ gst-launch-1.0 -v filesrc location=<video.mp4> \
-   \! qtdemux  \! h264parse \! queue \! vpudec \! waylandsink async=false enable-last-sample=false \
-   qos=false sync=false
+   target:~$ gst-launch-1.0 -v filesrc location=/usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm ! decodebin name=decoder decoder. ! videoconvert ! waylandsink
 
 *  Or:
 
 .. code-block:: console
 
-   target:~$ gplay-1.0 /usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm
-
-kmssink Plugin ID Evaluation
-............................
-
-The kmssink plugin needs a connector ID. To get the connector ID, you can use
-the tool modetest.
-
-.. code-block:: console
-
-   target:~$ modetest -c imx-drm
-
-The output will show something like:
-
-.. code-block::
-
-   Connectors:
-   id  encoder status      name        size (mm)   modes   encoders
-   35  34  connected   LVDS-1          216x135     1   34
-     modes:
-       index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot
-     #0 1280x800 59.07 1280 1380 1399 1440 800 804 808 823 70000 flags: phsync, pvsync; type: preferred, driver
-     props:
-       1 EDID:
-           flags: immutable blob
-           blobs:
-
-           value:
-       2 DPMS:
-           flags: enum
-           enums: On=0 Standby=1 Suspend=2 Off=3
-           value: 0
-       5 link-status:
-           flags: enum
-           enums: Good=0 Bad=1
-           value: 0
-       6 non-desktop:
-           flags: immutable range
-           values: 0 1
-           value: 0
-       4 TILE:
-           flags: immutable blob
-           blobs:
-
-           value:
+   target:~$ gst-play-1.0 /usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm --videosink waylandsink


### PR DESCRIPTION
Rework peripherals video chapter.

use gst-play-1.0 instead of gplay-1.0, because gplay-1.0 is only in nxp-bsp. And gst-play is the same as gplay, but is also present upstream.

Change the gst-launch example with filesrc, because this was only working for h264 videos and the sync=false option causes the video to play too fast. Replace it with an option that works for all videos and will play the video at normal speed.

Remove kmssink chapter, because kmssink is not working.

Dissolve the chapter into the mainline-bsp manual and add mainline-bsp specific parameter.
Add note, that mainline BSP only supports software rendering at the moment.
