### PR TITLE
BSPIMX8M-3177: Wip/tremmet/i2c eeprom erase

### DIFF
--- a/source/bsp/imx8/peripherals/eeprom.rsti
+++ b/source/bsp/imx8/peripherals/eeprom.rsti
@@ -23,11 +23,11 @@ execute:
 
    target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1 count=1024  | od -x
 
-To fill the whole EEPROM with zeros, use:
+To fill the 4KiB EEPROM (bus: I2C-0 addr: 0x51) with zeros leaving out the EEPROM data use:
 
 .. code-block:: console
 
-   target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=4096 count=1
+   target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom seek=1 bs=256 count=15
 
 
 EEPROM SoM Detection

--- a/source/bsp/imx8/peripherals/eeprom.rsti
+++ b/source/bsp/imx8/peripherals/eeprom.rsti
@@ -1,6 +1,14 @@
 I2C EEPROM on |som|
 ...........................
 
+.. warning::
+
+   The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 265 bytes of the
+   normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or
+   overwritten. As this will influence the behavior of the bootloader. The board
+   might not boot correctly anymore.
+
+
 The I2C EEPROM on the |som| SoM is connected to I2C address 0x51 on the I2C-0
 bus. It is possible to read and write directly to the device populated:
 
@@ -21,9 +29,6 @@ To fill the whole EEPROM with zeros, use:
 
    target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=4096 count=1
 
-.. warning::
-
-   The first 256 bytes are reserved for future purposes!
 
 EEPROM SoM Detection
 ....................


### PR DESCRIPTION
Fix a documentation issue reported by the customer the when filling the EEPROM with zeros. The EEPROM data should not be overwritten. Also extend and move the EEPROM data warning to the start of the "I2C EEPROM on |som|" chapter.

@cstoidner I see that you have your own imx9 eeprom chapter. But you have basically the same issue. Should I fix it, too?