### PR TITLE
Update the standalone build sections

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -348,7 +348,7 @@ the following::
 To create this branch, use ``checkout`` and specify the remote ``main`` branch
 to be the base of your changes::
 
-   git checkout -b WIP/your-github-account-name/feature-description origin/main
+   git switch --create WIP/your-github-account-name/feature-description origin/main
 
 Push your changes regularly to the remote repository. When pushing the branch
 for first time, you have to specify the upstream using ``-u``::

--- a/source/bsp/imx-common/development/standalone_build.rsti
+++ b/source/bsp/imx-common/development/standalone_build.rsti
@@ -204,6 +204,11 @@ Build Kernel
       host:~$ cd ~/linux-imx/
       host:~$ git fetch --all --tags
       host:~$ git checkout tags/|kernel-tag|
+
+*  For committing changes, it is highly recommended to switch to a new branch:
+
+   .. code-block:: console
+
       host:~$ git checkout -b <new-branch>
 
 *  Set up a build environment:
@@ -229,6 +234,11 @@ Build Kernel
 *  The Image can be found at ~/linux-imx/arch/arm64/boot/Image
 *  The dtb can be found at
    ~/linux-imx/arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb
+*  For (re-)building only Devicetrees and -overlays, it is sufficient to run
+
+   .. code-block:: console
+
+      host:~$ make dtbs
 
 .. note::
 

--- a/source/bsp/imx-common/development/standalone_build.rsti
+++ b/source/bsp/imx-common/development/standalone_build.rsti
@@ -146,7 +146,7 @@ Build U-Boot
 
       .. code-block:: console
 
-         host:~$ git checkout -b <new-branch>
+         host:~$ git switch --create <new-branch>
 
       .. note::
 
@@ -209,7 +209,7 @@ Build Kernel
 
    .. code-block:: console
 
-      host:~$ git checkout -b <new-branch>
+      host:~$ git switch --create <new-branch>
 
 *  Set up a build environment:
 

--- a/source/bsp/imx-common/development/standalone_build.rsti
+++ b/source/bsp/imx-common/development/standalone_build.rsti
@@ -136,8 +136,8 @@ Build U-Boot
    :substitutions:
 
    host:~$ cd ~/u-boot-imx/
-   host:~$ git fetch --all --tags
-   host:~$ git checkout tags/|u-boot-tag|
+   host:~/u-boot-imx$ git fetch --all --tags
+   host:~/u-boot-imx$ git checkout tags/|u-boot-tag|
 
 *  Technically, you can now build the U-Boot, but practically there are some
    further steps necessary:
@@ -146,7 +146,7 @@ Build U-Boot
 
       .. code-block:: console
 
-         host:~$ git switch --create <new-branch>
+         host:~/u-boot-imx$ git switch --create <new-branch>
 
       .. note::
 
@@ -158,15 +158,15 @@ Build U-Boot
    .. code-block:: console
       :substitutions:
 
-      host:~$ source /opt/|yocto-distro|/4.2.2/environment-setup-cortexa55-phytec-linux
+      host:~/u-boot-imx$ source /opt/|yocto-distro|/4.2.2/environment-setup-cortexa55-phytec-linux
 
 *  build flash.bin (imx-boot):
 
    .. code-block:: console
       :substitutions:
 
-      host:~$ make phycore-|kernel-socname|_defconfig
-      host:~$ make flash.bin
+      host:~/u-boot-imx$ make phycore-|kernel-socname|_defconfig
+      host:~/u-boot-imx$ make flash.bin
 
 The flash.bin can be found at u-boot-imx/ directory and now can be flashed. A
 chip-specific offset is needed:
@@ -184,7 +184,7 @@ E.g. flash SD card:
 .. code-block:: console
    :substitutions:
 
-   host:~$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
+   host:~/u-boot-imx$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
 
 .. hint::
    The specific offset values are also declared in the Yocto variables "BOOTLOADER_SEEK" and "BOOTLOADER_SEEK_EMMC"
@@ -202,34 +202,34 @@ Build Kernel
 
       host:~$ git clone git://git.phytec.de/linux-imx
       host:~$ cd ~/linux-imx/
-      host:~$ git fetch --all --tags
-      host:~$ git checkout tags/|kernel-tag|
+      host:~/linux-imx$ git fetch --all --tags
+      host:~/linux-imx$ git checkout tags/|kernel-tag|
 
 *  For committing changes, it is highly recommended to switch to a new branch:
 
    .. code-block:: console
 
-      host:~$ git switch --create <new-branch>
+      host:~/linux-imx$ git switch --create <new-branch>
 
 *  Set up a build environment:
 
    .. code-block:: console
       :substitutions:
 
-      host:~$ source /opt/|yocto-distro|/4.2.2/environment-setup-cortexa55-phytec-linux
+      host:~/linux-imx$ source /opt/|yocto-distro|/4.2.2/environment-setup-cortexa55-phytec-linux
 
 *  Build the linux kernel:
 
    .. code-block:: console
 
-      host:~$ make imx_v8_defconfig imx9_phytec_distro.config imx9_phytec_platform.config
-      host:~$ make -j${nproc}
+      host:~/linux-imx$ make imx_v8_defconfig imx9_phytec_distro.config imx9_phytec_platform.config
+      host:~/linux-imx$ make -j${nproc}
 
 *  Install kernel modules to e.g. NFS directory:
 
   .. code-block:: console
 
-      host:~$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
+      host:~/linux-imx$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
 
 *  The Image can be found at ~/linux-imx/arch/arm64/boot/Image
 *  The dtb can be found at
@@ -238,7 +238,7 @@ Build Kernel
 
    .. code-block:: console
 
-      host:~$ make dtbs
+      host:~/linux-imx$ make dtbs
 
 .. note::
 
@@ -264,6 +264,6 @@ mounted SD card.
 .. code-block:: console
    :substitutions:
 
-   host:~$ cp arch/arm64/boot/Image /path/to/sdcard/boot/
-   host:~$ cp arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb /path/to/sdcard/boot/oftree
-   host:~$ make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install
+   host:~/linux-imx$ cp arch/arm64/boot/Image /path/to/sdcard/boot/
+   host:~/linux-imx$ cp arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb /path/to/sdcard/boot/oftree
+   host:~/linux-imx$ make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install

--- a/source/bsp/imx8/development/standalone_build.rsti
+++ b/source/bsp/imx8/development/standalone_build.rsti
@@ -232,6 +232,11 @@ Build Kernel
       host:~$ cd ~/linux-imx/
       host:~$ git fetch --all --tags
       host:~$ git checkout tags/|kernel-tag|
+
+*  For committing changes, it is highly recommended to switch to a new branch:
+
+   .. code-block:: console
+
       host:~$ git checkout -b <new-branch>
 
 *  Set up a build environment:
@@ -257,6 +262,11 @@ Build Kernel
 *  The Image can be found at ~/linux-imx/arch/arm64/boot/Image
 *  The dtb can be found at
    ~/linux-imx/arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb
+*  For (re-)building only Devicetrees and -overlays, it is sufficient to run
+
+   .. code-block:: console
+
+      host:~$ make dtbs
 
 .. note::
 

--- a/source/bsp/imx8/development/standalone_build.rsti
+++ b/source/bsp/imx8/development/standalone_build.rsti
@@ -134,8 +134,8 @@ Build U-Boot
    :substitutions:
 
    host:~$ cd ~/u-boot-imx/
-   host:~$ git fetch --all --tags
-   host:~$ git checkout tags/|u-boot-tag|
+   host:~/u-boot-imx$ git fetch --all --tags
+   host:~/u-boot-imx$ git checkout tags/|u-boot-tag|
 
 *  Technically, you can now build the U-Boot, but practically there are some
    further steps necessary:
@@ -144,7 +144,7 @@ Build U-Boot
 
       .. code-block:: console
 
-         host:~$ git switch --create <new-branch>
+         host:~/u-boot-imx$ git switch --create <new-branch>
 
       .. note::
 
@@ -156,15 +156,15 @@ Build U-Boot
    .. code-block:: console
       :substitutions:
 
-      host:~$ source /opt/|yocto-distro|/|yocto-manifestname|/environment-setup-cortexa53-crypto-phytec-linux
+      host:~/u-boot-imx$ source /opt/|yocto-distro|/|yocto-manifestname|/environment-setup-cortexa53-crypto-phytec-linux
 
 *  build flash.bin (imx-boot):
 
    .. code-block:: console
       :substitutions:
 
-      host:~$ make phycore-|kernel-socname|_defconfig
-      host:~$ make flash.bin
+      host:~/u-boot-imx$ make phycore-|kernel-socname|_defconfig
+      host:~/u-boot-imx$ make flash.bin
 
 The flash.bin can be found at u-boot-imx/ directory and now can be flashed. A
 chip-specific offset is needed:
@@ -182,7 +182,7 @@ E.g. flash SD card:
 .. code-block:: console
    :substitutions:
 
-   host:~$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
+   host:~/u-boot-imx$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
 
 .. hint::
    The specific offset values are also declared in the Yocto variables "BOOTLOADER_SEEK" and "BOOTLOADER_SEEK_EMMC"
@@ -230,8 +230,8 @@ Build Kernel
 
       host:~$ git clone git://git.phytec.de/linux-imx
       host:~$ cd ~/linux-imx/
-      host:~$ git fetch --all --tags
-      host:~$ git checkout tags/|kernel-tag|
+      host:~/linux-imx$ git fetch --all --tags
+      host:~/linux-imx$ git checkout tags/|kernel-tag|
 
 *  For committing changes, it is highly recommended to switch to a new branch:
 
@@ -244,20 +244,20 @@ Build Kernel
    .. code-block:: console
       :substitutions:
 
-      host:~$ source /opt/|yocto-distro|/|yocto-manifestname|/environment-setup-cortexa53-crypto-phytec-linux
+      host:~/linux-imx$ source /opt/|yocto-distro|/|yocto-manifestname|/environment-setup-cortexa53-crypto-phytec-linux
 
 *  Build the linux kernel:
 
    .. code-block:: console
 
-      host:~$ make imx_v8_defconfig imx8_phytec_distro.config imx8_phytec_platform.config
-      host:~$ make -j${nproc}
+      host:~/linux-imx$ make imx_v8_defconfig imx8_phytec_distro.config imx8_phytec_platform.config
+      host:~/linux-imx$ make -j${nproc}
 
 *  Install kernel modules to e.g. NFS directory:
 
   .. code-block:: console
 
-      host:~$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
+      host:~/linux-imx$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
 
 *  The Image can be found at ~/linux-imx/arch/arm64/boot/Image
 *  The dtb can be found at
@@ -266,7 +266,7 @@ Build Kernel
 
    .. code-block:: console
 
-      host:~$ make dtbs
+      host:~/linux-imx$ make dtbs
 
 .. note::
 
@@ -292,7 +292,7 @@ mounted SD card.
 .. code-block:: console
    :substitutions:
 
-   host:~$ cp arch/arm64/boot/Image /path/to/sdcard/boot/
-   host:~$ cp arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb /path/to/sdcard/boot/oftree
-   host:~$ make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install
+   host:~/linux-imx$ cp arch/arm64/boot/Image /path/to/sdcard/boot/
+   host:~/linux-imx$ cp arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb /path/to/sdcard/boot/oftree
+   host:~/linux-imx$ make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install
 

--- a/source/bsp/imx8/development/standalone_build.rsti
+++ b/source/bsp/imx8/development/standalone_build.rsti
@@ -144,7 +144,7 @@ Build U-Boot
 
       .. code-block:: console
 
-         host:~$ git checkout -b <new-branch>
+         host:~$ git switch --create <new-branch>
 
       .. note::
 
@@ -237,7 +237,7 @@ Build Kernel
 
    .. code-block:: console
 
-      host:~$ git checkout -b <new-branch>
+      host:~/linux-imx$ git switch --create <new-branch>
 
 *  Set up a build environment:
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -867,7 +867,7 @@ Development
 
       .. code-block:: console
 
-         host:~$ git checkout -b <new-branch>
+         host:~$ git switch --create <new-branch>
 
       .. note::
 

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -862,7 +862,7 @@ Development
 
       .. code-block:: console
 
-         host:~$ git checkout -b <new-branch>
+         host:~$ git switch --create <new-branch>
 
       .. note::
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -876,7 +876,7 @@ Development
 
       .. code-block:: console
 
-         host:~$ git checkout -b <new-branch>
+         host:~$ git switch --create <new-branch>
 
       .. note::
 

--- a/source/yocto/kirkstone.rst
+++ b/source/yocto/kirkstone.rst
@@ -1158,7 +1158,7 @@ in your shell. This will print something like
    $ cd ~/git
    $ git clone git://git.phytec.de/barebox barebox
    $ cd ~/git/barebox
-   $ git checkout -b v2022.02.0-phy1-local-development 7fe12e65d770f7e657e683849681f339a996418b
+   $ git switch --create v2022.02.0-phy1-local-development 7fe12e65d770f7e657e683849681f339a996418b
 
    You now have two possible workflows for your changes:
 
@@ -2021,7 +2021,7 @@ kernel. If you do not have one, use the commands
    host:~$ cd ~/git
    host:~$ git clone git://git.phytec.de/barebox
    host:~$ cd barebox
-   host:~$ git checkout -b v2022.02.0-phy remotes/origin/v2022.02.0-phy
+   host:~$ git switch --create v2022.02.0-phy remotes/origin/v2022.02.0-phy
 
 Add the following snippet to the file build/conf/local.conf
 

--- a/source/yocto/mickledore.rst
+++ b/source/yocto/mickledore.rst
@@ -1086,7 +1086,7 @@ in your shell. This will print something like
    $ cd ~/git
    $ git clone git://git.phytec.de/barebox barebox
    $ cd ~/git/barebox
-   $ git checkout -b v2022.02.0-phy1-local-development 7fe12e65d770f7e657e683849681f339a996418b
+   $ git switch --create v2022.02.0-phy1-local-development 7fe12e65d770f7e657e683849681f339a996418b
 
    You now have two possible workflows for your changes:
 
@@ -1949,7 +1949,7 @@ kernel. If you do not have one, use the commands
    host:~$ cd ~/git
    host:~$ git clone git://git.phytec.de/barebox
    host:~$ cd barebox
-   host:~$ git checkout -b v2022.02.0-phy remotes/origin/v2022.02.0-phy
+   host:~$ git switch --create v2022.02.0-phy remotes/origin/v2022.02.0-phy
 
 Add the following snippet to the file build/conf/local.conf
 


### PR DESCRIPTION
This is a follow-up to #84. It adds the hint for building Devicetrees only which I found quite useful in the past. Additionally, it highlights the optional character of creating a branch (as it was already for uboot standalone) and switches the 'git checkout -b' calls to 'switch --create' as this IMHO better describes what is done there (and is more telly). Finally, I added changed directories to  the prompts for better overview in longer command lists. 