### PR TITLE
Wip/bhahn/BSPIMX8M-3208: bsp: imx8: rework EEPROM chapter

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -392,9 +392,16 @@ General I²C4 bus configuration (e.g. |dt-carrierboard|.dts):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) can be accessed via the sysfs
+interface in Linux. The first 256 bytes of the main EEPROM and the ID-page
+(bus: I2C-0 address: 0x59) are used for board detection and must not be
+overwritten. Therefore the ID-page can not be accessed via the sysfs interface.
+Overwriting reserved spaces will result in boot issues.
+
+.. note::
+
+   If you deleted reserved EEPROM spaces, please contact our support!
 
 .. include:: ../peripherals/eeprom.rsti
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -1630,11 +1630,28 @@ General I²C4 bus configuration (e.g. |dt-carrierboard|.dtsi):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -664,11 +664,28 @@ General I²C4 bus configuration (e.g. |dt-carrierboard|.dts):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -377,9 +377,16 @@ General I²C3 bus configuration (e.g. |dt-carrierboard|.dts):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) can be accessed via the sysfs
+interface in Linux. The first 256 bytes of the main EEPROM and the ID-page
+(bus: I2C-0 address: 0x59) are used for board detection and must not be
+overwritten. Therefore the ID-page can not be accessed via the sysfs interface.
+Overwriting reserved spaces will result in boot issues.
+
+.. note::
+
+   If you deleted reserved EEPROM spaces, please contact our support!
 
 .. include:: ../peripherals/eeprom.rsti
 

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -1626,11 +1626,28 @@ General I²C3 bus configuration (e.g. |dt-carrierboard|.dtsi):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -649,11 +649,28 @@ General I²C3 bus configuration (e.g. |dt-carrierboard|.dts):
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som|. Both can be used
-with the sysfs interface in Linux. The ID page of the I2C EEPROM populated on
-the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -425,9 +425,16 @@ General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som| SoM and on the
-|sbc|. Both can be used with the sysfs interface in Linux. The ID page of the
-I2C EEPROM populated on the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) can be accessed via the sysfs
+interface in Linux. The first 256 bytes of the main EEPROM and the ID-page
+(bus: I2C-0 address: 0x59) are used for board detection and must not be
+overwritten. Therefore the ID-page can not be accessed via the sysfs interface.
+Overwriting reserved spaces will result in boot issues.
+
+.. note::
+
+   If you deleted reserved EEPROM spaces, please contact our support!
 
 .. include:: ../peripherals/eeprom.rsti
 

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -796,9 +796,16 @@ https://github.com/phytec/linux-phytec/blob/v6.6.21-phy1/arch/arm64/boot/dts/fre
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som| SoM and on the
-|sbc|. Both can be used with the sysfs interface in Linux. The ID page of the
-I2C EEPROM populated on the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) can be accessed via the sysfs
+interface in Linux. The first 256 bytes of the main EEPROM and the ID-page
+(bus: I2C-0 address: 0x59) are used for board detection and must not be
+overwritten. Therefore the ID-page can not be accessed via the sysfs interface.
+Overwriting reserved spaces will result in boot issues.
+
+.. note::
+
+   If you deleted reserved EEPROM spaces, please contact our support!
 
 .. include:: ../peripherals/eeprom.rsti
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -1647,11 +1647,28 @@ General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som| SoM and on the
-|sbc|. Both can be used with the sysfs interface in Linux. The ID page of the
-I2C EEPROM populated on the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -697,11 +697,28 @@ General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
 EEPROM
 ------
 
-There are two different i2c EEPROM flashes populated on |som| SoM and on the
-|sbc|. Both can be used with the sysfs interface in Linux. The ID page of the
-I2C EEPROM populated on the SoM is also used for board detection.
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issue.
 
 .. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
 
 DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:

--- a/source/bsp/imx8/peripherals/eeprom.rsti
+++ b/source/bsp/imx8/peripherals/eeprom.rsti
@@ -56,18 +56,3 @@ is |kit-ram-size| RAM.
 
 SoMs that are flashed with data format API revision 2 will print out information
 about the module in the early stage.
-
-Rescue EEPROM Data
-..................
-
-The hardware introspection data is pre-written on both EEPROM data spaces. If
-you have accidentally deleted or overwritten the normal area, you can copy the
-hardware introspection from the ID area to the normal area.
-
-.. code-block:: console
-
-   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
-
-.. note::
-
-   If you deleted both EEPROM spaces, please contact our support!


### PR DESCRIPTION
Based on BSPIMX8M-3205 =>probably needs rebase when that is merged. => only the last commit is new

Update description at the beginning. There are not two EEPROMs it is one
with two different addresses.
    
Starting with PD24.1.0 the EEPROM ID-page will not be accessible via the
sysfs anymore. Change that in the description. Update command for
restoring 0x51 EEPROM to U-Boot.
    
Remove the "Rescue EEPROM Data" chapter for new manuals and dissolve it
for PD22.1.1 and PD23.1.0. The command does not work for newer versions.
For newer versions move the note to contact our support to the top.