### PR TITLE
readme: remove documentation badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://github.com/phytec/doc-bsp-yocto/workflows/Documentation/badge.svg
-   :target: https://github.com/phytec/doc-bsp-yocto/actions/workflows/documentation.yaml
-
 PHYTEC Yocto BSP Documentation
 ==============================
 


### PR DESCRIPTION
The documentation badge was broken and is not really needed as the status of the latest deploy build is always shown in the top row that also shows the latest commit.