### PR TITLE
Add config file for rstcheck

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,15 @@
+[rstcheck]
+ignore_substitutions=
+   yocto-bootenv-link,
+   ref-bootswitch,
+   ref-bsp-images,
+   ref-debugusbconnector,
+   ref-dt,
+   ref-getting-started,
+   ref-network,
+   ref-setup-network-host,
+   ref-usb-otg,
+   ref-disable-emmc-part,
+   ref-serial,
+   ref-jp3,
+   ref-jp4


### PR DESCRIPTION
I am using [rstcheck](https://github.com/rstcheck/rstcheck) as a static analysis tool. Add an initial config file for the analyzer to ignore substitutions it cannot handle. These are enhanced/custom ones introduced by sphinx extensions.