### PR TITLE
Wip/tremmet/imx8mp pd24.1.0 RAUC doc version 

### DIFF
--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -825,7 +825,8 @@ The RAUC (Robust Auto-Update Controller) mechanism support has been added to
 meta-ampliphy. It controls the procedure of updating a device with new firmware.
 This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
-BSPs: L-1006e.A3 RAUC Update & Device Management Manual.
+BSPs: `L-1006e.A3 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=BKXvGQ>`__.
 
 .. +---------------------------------------------------------------------------+
 ..                                DEVELOPMENT

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -820,7 +820,8 @@ The RAUC (Robust Auto-Update Controller) mechanism support has been added to
 meta-ampliphy. It controls the procedure of updating a device with new firmware.
 This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
-BSPs: L-1006e.A3 RAUC Update & Device Management Manual.
+BSPs: `L-1006e.A3 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=BKXvGQ>`__.
 
 .. +---------------------------------------------------------------------------+
 ..                                DEVELOPMENT

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -775,9 +775,8 @@ The RAUC (Robust Auto-Update Controller) mechanism support has been added to
 meta-ampliphy. It controls the procedure of updating a device with new firmware.
 This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
-BSPs: `L-1006e.A5 RAUC Update & Device Management Manual
-<https://www.phytec.de/cdocuments/?doc=fgByJg>`__.
-
+BSPs: `L-1006e.A6 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=F4DiM>`__.
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -834,7 +834,8 @@ The RAUC (Robust Auto-Update Controller) mechanism support has been added to
 meta-ampliphy. It controls the procedure of updating a device with new firmware.
 This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
-BSPs: L-1006e.A3 RAUC Update & Device Management Manual.
+BSPs: `L-1006e.A3 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=BKXvGQ>`__.
 
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -775,8 +775,8 @@ The RAUC (Robust Auto-Update Controller) mechanism support has been added to
 meta-ampliphy. It controls the procedure of updating a device with new firmware.
 This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
-BSPs: `L-1006e.A5 RAUC Update & Device Management Manual
-<https://www.phytec.de/cdocuments/?doc=fgByJg>`__.
+BSPs: `L-1006e.A6 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=F4DiM>`__.
 
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT


### PR DESCRIPTION
We got a customer request that the RAUC docu link needs to be updated to the latest version for the i.MX8MP Mainline Release.

Also add a link to the RAUC documentation for the PD22.1.1 release.