### PR TITLE
Wip/tremmet/pollux mainline flash from sd

### DIFF
--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -72,6 +72,7 @@
 .. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-mainline-head-development>`
 .. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-mainline-head-components>`
 .. |ref-disable-emmc-part| replace:: :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
+.. |ref-format-sd| replace:: :ref:`Resizing ext4 Root Filesystem  <imx8mp-mainline-head-format-sd>`
 
 
 .. IMX8(MP) specific
@@ -652,9 +653,8 @@ Flash eMMC from SD Card
 
 Even if there is no network available, you can update the eMMC. For that, you
 only need a ready-to-use image file (``*.wic``) located on the SD card.
-Because the image file is quite large, you have to enlarge your SD card to use
-its full space (if it was not enlarged before). To enlarge your SD card, see
-Resizing ext4 Root Filesystem.
+Because the image file is quite large, you have to create a third partition.
+To create a new partition or enlarge your SD card, see |ref-format-sd|.
 
 Alternatively, flash a partup package to the SD card, as described in
 |ref-getting-started|. This will ensure the full space of the SD card is used.
@@ -949,6 +949,9 @@ Execute and power up the board:
 .. standalone build needs to be reworked (maybe more generic to make this file
    reuse it)
 .. include:: /bsp/imx8/development/upstream_manifest.rsti
+
+.. _imx8mp-mainline-head-format-sd:
+
 Format SD-Card
 --------------
 

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -777,6 +777,7 @@ This includes updating the Linux kernel, Device Tree, and root filesystem.
 PHYTEC has written an online manual on how we have intergraded RAUC into our
 BSPs: `L-1006e.A6 RAUC Update & Device Management Manual
 <https://www.phytec.de/cdocuments/?doc=F4DiM>`__.
+
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -669,7 +669,7 @@ Flash eMMC from SD card in U-Boot on Target
    image file is too large use the `Updating eMMC from SD card in
    Linux on Target` subsection.
 
-*  Flash an SD card with a working image and create a third FAT partition. Copy
+*  Flash an SD card with a working image and create a third ext4 partition. Copy
    the WIC image (for example |yocto-imagename|.\ |yocto-imageext|) to this
    partition.
 *  Configure the |ref-bootswitch| to SD Card and insert the SD Card.
@@ -679,7 +679,7 @@ Flash eMMC from SD card in U-Boot on Target
    .. code-block::
       :substitutions:
 
-      u-boot=> fatload mmc 1:3 ${loadaddr} |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
+      u-boot=> ext4load mmc 1:3 ${loadaddr} |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       reading
       911842304 bytes read in 39253 ms (22.2 MiB/s)
 


### PR DESCRIPTION
The chapter flashing the eMMC from SD-Card has some inconsistency that are fixed with this pull request. 

Also added a small fix which I introduced in a previous pull request.