### PR TITLE
BSPIMX8M-3270 bsp: imx8mp: mainline-head: Add back backlight control chapter

### DIFF
--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -1350,6 +1350,12 @@ https://github.com/phytec/linux-phytec/blob/v6.6.21-phy1/arch/arm64/boot/dts/fre
 
 .. include:: /bsp/qt6.rsti
 
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+.. note::
+   We noticed some visible backlight flickering on brightness level 1 (probably
+   due to frequency problems with the hardware).
+
 Power Management
 ----------------
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -1351,6 +1351,12 @@ https://github.com/phytec/linux-phytec/blob/v6.6.21-phy1/arch/arm64/boot/dts/fre
 
 .. include:: /bsp/qt6.rsti
 
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+.. note::
+   We noticed some visible backlight flickering on brightness level 1 (probably
+   due to frequency problems with the hardware).
+
 Power Management
 ----------------
 


### PR DESCRIPTION
Add back backlight control chapter and add a note that on brightness level 1 there is visible backlight flickering probably due to timing problems with the hardware.