### PR TITLE
imx8: fix coprocessor target

### DIFF
--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -99,7 +99,7 @@
 .. M-Core specific
 .. |mcore| replace:: M7 Core
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
-.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
 
 +-----------------------+----------------------+

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -93,7 +93,7 @@
 .. M-Core specific
 .. |mcore| replace:: M7 Core
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
-.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
 
 +-----------------------+----------------------+

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -96,7 +96,7 @@
 .. M-Core specific
 .. |mcore| replace:: M7 Core
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
-.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
 
 +-----------------------+----------------------+

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -98,7 +98,7 @@
 .. M-Core specific
 .. |mcore| replace:: M7 Core
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
-.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
 
 +-----------------------+----------------------+

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -92,7 +92,7 @@
 .. M-Core specific
 .. |mcore| replace:: M7 Core
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
-.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
 
 +-----------------------+----------------------+


### PR DESCRIPTION
The imx8mp platform uses the variant MIMX8ML8 that includes a cortex M7 processor. This commit fixes the core that has been identical with the imx8mm (M4) previously.