### PR TITLE
ci workflow: increase timeout for linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -237,6 +237,6 @@ linkcheck_ignore = [
     "https://github.com/phytec/doc-bsp-yocto"
 ]
 
-linkcheck_timeout = 30
+linkcheck_timeout = 60
 linkcheck_workers = 10
 linkcheck_anchors = False


### PR DESCRIPTION
Phytec hw manuals are converted on request and can be larger in size. Depending on the utilization of the Phytec documentation server, a timeout of 30 s may not be sufficient and the github action is failing.