### PR TITLE
BSPIMX8M-3281: bsp: imx-common: standalone_build_kernel: Add note to the kernel build

### DIFF
--- a/source/bsp/imx-common/development/standalone_build_preface.rsti
+++ b/source/bsp/imx-common/development/standalone_build_preface.rsti
@@ -93,4 +93,4 @@ dependencies to be installed. For Ubuntu you can install them with:
 
 .. code-block:: console
 
-   host:~$ sudo apt install bison flex
+   host:~$ sudo apt install bison flex libssl-dev


### PR DESCRIPTION
To build the standalone kernel successfully by overcoming the openssl error, need to install the libssl-dev package. update made to the ubuntu dependencies for standalone kernel build in the standalone build
preface.