### PR TITLE
GH actions: add status check with documentation preview

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,3 +21,17 @@ jobs:
       run: tox -e py3-html
     - name: Build PDF Documentation
       run: tox -e py3-pdf
+    - name: Deploy Preview
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/html
+        destination_dir: 'previews/${{ github.event.number }}'
+    - name: Create status check with preview link
+      run: |
+        PREVIEW_URL="https://phytec.github.io/doc-bsp-yocto/previews/${{ github.event.number }}"
+        PAYLOAD=$(echo '{}' | jq --arg name 'Click on details for a Doc Preview' --arg url "${PREVIEW_URL}" '{"name": $name, "head_sha": "${{ github.event.pull_request.head.sha }}", "details_url": $url, "status": "completed", "conclusion": "success", "output": {"title": $name, "summary": "Preview available at", "text": $url}}')
+        curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+             -H "Content-Type: application/json" \
+             -X POST -d "${PAYLOAD}" \
+             "https://api.github.com/repos/${{ github.repository }}/check-runs"

--- a/.github/workflows/cleanup_doc_preview.yaml
+++ b/.github/workflows/cleanup_doc_preview.yaml
@@ -1,0 +1,22 @@
+name: Cleanup Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clean up no longer needed preview
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          destination_dir: 'previews/${{ github.event.pull_request.number }}'
+          clean: true  # This will remove the destination directory

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -364,6 +364,14 @@ When committing, make sure to add a sign-off using the option ``-s``::
 
    git commit -s
 
+Documentation Preview
+---------------------
+
+After the Pull Request is opened, make sure to verify that all CI checks pass.
+After the Build action passes, you can review the whole documentation including
+your changes by clicking on the ``Doc Preview`` check that is displayed in the
+checks tab of the pull request.
+
 Frequently asked Questions
 ==========================
 


### PR DESCRIPTION
GitHub pages can host documentation previews for each pull request. This can be helpful for reviewing and getting an overview of changes quickly.

For testing check the passed checks:
`Check External Links / Click on details for a Doc Preview (pull_request)`