### PR TITLE
PDF: add download links to all manuals

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/phytec-qt6demo-image-phyboard-polis-imx8mm-5.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mm-head.pdf
 
 .. IMX8(MM) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mm/phycore-imx8mm.c?h=v2022.04_2.2.2-phy5#n120
@@ -109,6 +110,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mm_phyboard_polis/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |doc-id| |soc| BSP                          |

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/phytec-qt5demo-image-phyboard-polis-imx8mm-5.wic
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mm-pd22.1.1.pdf
 
 .. IMX8(MM) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mm/phycore-imx8mm.c?h=v2021.04_2.2.0-phy13#n188
@@ -99,6 +100,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mm_phyboard_polis/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |soc| BSP Manual                            |

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/phytec-qt6demo-image-phyboard-polis-imx8mm-5.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-polis-imx8mm-5/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mm-pd23.1.0.pdf
 
 .. IMX8(MM) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mm/phycore-imx8mm.c?h=v2022.04_2.2.2-phy5#n120
@@ -108,6 +109,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mm_phyboard_polis/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |soc| BSP Manual                            |

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor/phyboard-polis-imx8mn-2/phytec-headless-image-phyboard-polis-imx8mn-2.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor/phyboard-polis-imx8mn-2/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mn-head.pdf
 
 .. IMX8(MN) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mn/phycore-imx8mn.c?h=v2022.04_2.2.2-phy5#n66
@@ -100,6 +101,9 @@
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mn-head-ubootexternalenv>`
 
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |doc-id| |soc| BSP                          |

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD22.1.1/images/ampliphy-vendor/phyboard-polis-imx8mn-2/phytec-headless-image-phyboard-polis-imx8mn-2.wic
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD22.1.1/images/ampliphy-vendor/phyboard-polis-imx8mn-2/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mn-pd22.1.1.pdf
 
 .. IMX8(MN) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mn/phycore-imx8mn.c?h=v2021.04_2.2.0-phy13
@@ -92,6 +93,9 @@
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mn-pd22.1.1-ubootexternalenv>`
 
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |soc| BSP Manual                            |

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor/phyboard-polis-imx8mn-2/phytec-headless-image-phyboard-polis-imx8mn-2.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MM/BSP-Yocto-NXP-i.MX8MM-PD23.1.0/images/ampliphy-vendor/phyboard-polis-imx8mn-2/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mm
+.. _`static-pdf-dl`: ../../../_static/imx8mn-pd23.1.0.pdf
 
 .. IMX8(MN) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mn/phycore-imx8mn.c?h=v2022.04_2.2.2-phy5#n66
@@ -99,6 +100,9 @@
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mn-pd23.1.0-ubootexternalenv>`
 
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +----------------------+----------------------+
 | |soc| BSP Manual                            |

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -9,6 +9,7 @@
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
 .. |link-bsp-images| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-head.pdf
 
 .. IMX8(MP) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2022.04_2.2.2-phy5#n149
@@ -121,6 +122,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |doc-id| |soc| BSP    |                      |

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-mainline-head.pdf
 
 
 .. General Substitutions
@@ -106,6 +107,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |doc-id| |soc| BSP    |                      |

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt5demo-image-phyboard-pollux-imx8mp-3.wic
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd22.1.1.pdf
 
 .. IMX8(MP) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2021.04_2.2.0-phy13#n239
@@ -109,6 +110,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |soc| BSP Manual                             |

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD23.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd23.1.0.pdf
 
 .. IMX8(MP) specific
 .. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2022.04_2.2.2-phy5#n149
@@ -119,6 +120,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |soc| BSP Manual                             |

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.1/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.1/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.1.pdf
 
 
 .. General Substitutions
@@ -106,6 +107,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |doc-id| |soc| BSP    |                      |

--- a/source/bsp/imx8/imx8mp/pd24.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.2.rst
@@ -8,6 +8,7 @@
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2/images/ampliphy-xwayland/phyboard-pollux-imx8mp-3/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.2.pdf
 
 
 .. General Substitutions
@@ -106,6 +107,10 @@
 .. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
 .. |mcore-jtag-dev| replace:: MIMX8ML8_M7
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |doc-id| |soc| BSP    |                      |

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+.. _`static-pdf-dl`: ../../../_static/imx93-pd24.1.0.pdf
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
 
@@ -101,6 +102,10 @@
 .. |ref-m-core-connections| replace:: :ref:`X16 <imx93-pd24.1.0-components>`
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |soc| BSP Manual                             |

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+.. _`static-pdf-dl`: ../../../_static/imx93-pd24.1.1.pdf
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
 
@@ -102,6 +103,10 @@
 .. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.1.1-components>`
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |soc| BSP Manual                             |

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,10 +20,7 @@ copyright = '2024, PHYTEC Messtechnik GmbH'
 author = 'PHYTEC'
 
 # Use git describe to get the version e.g.: imx8-pd23.1.0-1-gb1830e
-release = re.sub('', '', os.popen('git describe --tags').read().strip())
-
-# Assign to the version variable, to list the version in the html as well.
-version = release
+version = re.sub('', '', os.popen('git describe --tags').read().strip())
 
 # -- General configuration ---------------------------------------------------
 
@@ -111,10 +108,23 @@ latex_engine = 'xelatex'
 latex_elements = {
     'fontpkg':
     '\\usepackage{lmodern}',
-    'preamble':
-    '''
-      \\usepackage{fontspec}
-      \\setmonofont{DejaVu Sans Mono}[Scale=0.8]
+    'preamble': r'''
+      \usepackage{fontspec}
+      \setmonofont{DejaVu Sans Mono}[Scale=0.8]
+      \makeatletter
+      % Redefine Header and Footer style
+      \fancypagestyle{normal}{
+        \fancyhf{}
+        \fancyfoot[R]{{\py@HeaderFamily\thepage}}
+        \fancyfoot[L]{{\py@HeaderFamily\nouppercase{\leftmark}}}
+        \fancyhead[L]{{\py@HeaderFamily \@title}}
+        \fancyhead[R]{{\py@HeaderFamily Documentation Rev.: \textit{''' + version + r'''}}}
+        \renewcommand{\headrulewidth}{0.4pt}
+        \renewcommand{\footrulewidth}{0.4pt}
+      }
+      % Redefine \chaptermark to exclude chapter number
+      \renewcommand{\chaptermark}[1]{\markboth{#1}{}}
+    \makeatother
     ''',
 }
 
@@ -122,7 +132,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/head',
         'imx8mp-head.tex',
-        'L-1017e.Ax i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual DRAFT',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -130,7 +140,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/mainline-head',
         'imx8mp-mainline-head.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual DRAFT',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -138,7 +148,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd24.1.2',
         'imx8mp-pd24.1.2.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual PD24.1.2',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -146,7 +156,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd24.1.1',
         'imx8mp-pd24.1.1.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual PD24.1.1',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -154,7 +164,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd23.1.0',
         'imx8mp-pd23.1.0.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual PD23.1.0',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -162,7 +172,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd22.1.2',
         'imx8mp-pd22.1.2.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual PD22.1.2',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -170,7 +180,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd22.1.1',
         'imx8mp-pd22.1.1.tex',
-        'i.MX 8M Plus BSP Manual',
+        'i.MX 8M Plus BSP Manual PD22.1.1',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -178,7 +188,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mm/head',
         'imx8mm-head.tex',
-        'L-1002e.Ax i.MX 8M Mini BSP Manual',
+        'i.MX 8M Mini BSP Manual DRAFT',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -186,7 +196,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mm/pd23.1.0',
         'imx8mm-pd23.1.0.tex',
-        'i.MX 8M Mini BSP Manual',
+        'i.MX 8M Mini BSP Manual PD23.1.0',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -194,7 +204,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mm/pd22.1.1',
         'imx8mm-pd22.1.1.tex',
-        'i.MX 8M Mini BSP Manual',
+        'i.MX 8M Mini BSP Manual PD22.1.1',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -202,7 +212,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mn/head',
         'imx8mn-head.tex',
-        'L-1002e.Ax i.MX 8M Mini BSP Manual',
+        'i.MX 8M Mini BSP Manual DRAFT',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -210,7 +220,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mn/pd23.1.0',
         'imx8mn-pd23.1.0.tex',
-        'i.MX 8M Nano BSP Manual',
+        'i.MX 8M Nano BSP Manual PD23.1.0',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -218,7 +228,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mn/pd22.1.1',
         'imx8mn-pd22.1.1.tex',
-        'i.MX 8M Nano BSP Manual',
+        'i.MX 8M Nano BSP Manual PD22.1.1',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -226,7 +236,7 @@ latex_documents = [
     (
         'bsp/imx9/imx93/pd24.1.0',
         'imx93-pd24.1.0.tex',
-        'i.MX 93 BSP Manual',
+        'i.MX 93 BSP Manual PD24.1.0',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -234,7 +244,7 @@ latex_documents = [
     (
         'bsp/imx9/imx93/pd24.1.1',
         'imx93-pd24.1.1.tex',
-        'i.MX 93 BSP Manual',
+        'i.MX 93 BSP Manual PD24.1.1',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,

--- a/source/yocto/kirkstone.rst
+++ b/source/yocto/kirkstone.rst
@@ -1,9 +1,14 @@
 .. Download links
+.. _`static-pdf-dl`: ../_static/kirkstone.pdf
 
 .. Yocto
 .. |yocto-codename| replace:: Kirkstone
 .. |yocto-ref-manual| replace:: Yocto Reference Manual
 .. |distro| replace:: ampliphy-vendor-xwayland
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-------------------------------------------------------------+
 | |yocto-ref-manual|                                          |

--- a/source/yocto/mickledore.rst
+++ b/source/yocto/mickledore.rst
@@ -1,9 +1,14 @@
 .. Download links
+.. _`static-pdf-dl`: ../_static/mickledore.pdf
 
 .. Yocto
 .. |yocto-codename| replace:: Mickledore
 .. |yocto-ref-manual| replace:: Yocto Reference Manual
 .. |distro| replace:: ampliphy-vendor-xwayland
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-------------------------------------------------------------+
 | |yocto-ref-manual|                                          |

--- a/source/yocto/scarthgap.rst
+++ b/source/yocto/scarthgap.rst
@@ -1,9 +1,14 @@
 .. Download links
+.. _`static-pdf-dl`: ../_static/scarthgap.pdf
 
 .. Yocto
 .. |yocto-codename| replace:: Scarthgap
 .. |yocto-ref-manual| replace:: Yocto Reference Manual
 .. |distro| replace:: ampliphy-vendor-xwayland
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-------------------------------------------------------------+
 | |yocto-ref-manual|                                          |

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,10 @@ commands =
     sphinx-build -M latex -d build -D language=zh_CN source build/latex/zh_CN -W --keep-going -j auto
     sh -c 'make -C build/latex/en -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
     sh -c 'make -C build/latex/zh_CN -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
+    sh -c 'mkdir -p build/html/_static'
+    sh -c 'cp build/latex/en/*.pdf build/html/_static/'
+    sh -c 'mkdir -p build/html/zh_CN/_static'
+    sh -c 'cp build/latex/zh_CN/*.pdf build/html/zh_CN/_static/'
 
 [testenv:py3-linkcheck]
 commands =


### PR DESCRIPTION
This PR adds the option to download a manual as a pdf file.

Currently there are two issues with the pdf files:

1. The release in the pdf files is the documentation release (e.g. `imx8mp-pd24.1.2-2-gb7c1ba7`). This is confusing for customers that e.g. view an imx93 manual with that release string. Renaming the release string from `Release` to `Documentation Build` may reduce confusions.
2. When providing pdf documents for head versions, we should probably mark them clearly to indicate that those are not final releases.

**Edit:**
To 1.: The release version is no longer shown on the title page, but on the left side of the header as `Documentation rev.`:.
To 2: The right side of the header now shows the release number or `DRAFT` for head manuals.



**Note:** As this PR is based on #203, you can review the pdf download feature with the documentation preview down in the checks.

~**To all Reviewers:** Do you see a benefit to our customers by providing pdf files in this way?~