### PR TITLE
imx9: mcu: Add missing space in firmware load command for remoteproc

### DIFF
--- a/source/bsp/imx9/mcu.rsti
+++ b/source/bsp/imx9/mcu.rsti
@@ -101,7 +101,7 @@ To load the firmware, type:
 
 .. code-block:: console
 
-   target:~$ echo /lib/firmware/<firmware>.elf> /sys/class/remoteproc/remoteproc0/firmware
+   target:~$ echo /lib/firmware/<firmware>.elf > /sys/class/remoteproc/remoteproc0/firmware
    target:~$ echo start > /sys/class/remoteproc/remoteproc0/state
 
 To load a different firmware, the |mcore| needs to be stopped:


### PR DESCRIPTION
The missing space before the '>' is quite confusing, especially as the choosable firmware name is also marked with "<...>".