### PR TITLE
doc: use full bsp name for html documents

### DIFF
--- a/source/bsp/imx8/imx8mm/imx8mm.rst
+++ b/source/bsp/imx8/imx8mm/imx8mm.rst
@@ -12,8 +12,8 @@ HEAD
 
    head
 
-PD23.1.0
-========
+BSP-Yocto-NXP-i.MX8MM-PD23.1.0
+==============================
 
 .. toctree::
    :caption: Table of Contents
@@ -22,8 +22,8 @@ PD23.1.0
 
    pd23.1.0
 
-PD22.1.1
-========
+BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+==============================
 
 .. toctree::
    :caption: Table of Contents

--- a/source/bsp/imx8/imx8mn/imx8mn.rst
+++ b/source/bsp/imx8/imx8mn/imx8mn.rst
@@ -12,8 +12,8 @@ HEAD
 
    head
 
-PD23.1.0
-========
+BSP-Yocto-NXP-i.MX8MM-PD23.1.0
+==============================
 
 .. toctree::
    :caption: Table of Contents
@@ -22,8 +22,8 @@ PD23.1.0
 
    pd23.1.0
 
-PD22.1.1
-========
+BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+==============================
 
 .. toctree::
    :caption: Table of Contents

--- a/source/bsp/imx8/imx8mp/imx8mp.rst
+++ b/source/bsp/imx8/imx8mp/imx8mp.rst
@@ -22,8 +22,8 @@ Mainline HEAD
 
    mainline-head
 
-PD24.1.2
-========
+BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2
+===================================
 
 .. toctree::
    :caption: Table of Contents
@@ -32,8 +32,8 @@ PD24.1.2
 
    pd24.1.2
 
-PD24.1.1
-========
+BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.1
+===================================
 
 .. toctree::
    :caption: Table of Contents
@@ -43,8 +43,8 @@ PD24.1.1
    pd24.1.1
 
 
-PD23.1.0
-========
+BSP-Yocto-NXP-i.MX8MP-PD23.1.0
+==============================
 
 .. toctree::
    :caption: Table of Contents
@@ -53,8 +53,8 @@ PD23.1.0
 
    pd23.1.0
 
-PD22.1.1
-========
+BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+==============================
 
 .. toctree::
    :caption: Table of Contents

--- a/source/bsp/imx9/imx93/imx93.rst
+++ b/source/bsp/imx9/imx93/imx93.rst
@@ -2,8 +2,8 @@
 i.MX 93 Manuals
 ====================
 
-PD24.1.1
-========
+BSP-Yocto-NXP-i.MX93-PD24.1.1
+=============================
 
 .. toctree::
    :caption: Table of Contents
@@ -12,8 +12,8 @@ PD24.1.1
 
    pd24.1.1
 
-PD24.1.0
-========
+BSP-Yocto-NXP-i.MX93-PD24.1.0
+=============================
 
 .. toctree::
    :caption: Table of Contents


### PR DESCRIPTION
Mainline BSPs and vendor BSPs can have the same PD name as hinted in https://github.com/phytec/doc-bsp-yocto/pull/201#discussion_r1672213651. It is important to differentiate in the name of the BSP documents.

The Phytec Download section differentiates between Mainline and Vendor BSPs clearly. However, if customers browse the documentation it it not clear from the document overview what kind of BSP is described.

**Do not merge yet:**
- [x] This PR changes the HTML Document name and therefore the links change. Merging this PR has to be coordinated with changing the Website links.