### PR TITLE
BSPIMX8M-3377 i.MX8MP-PD22.1.2 BSP manual

### DIFF
--- a/source/bsp/imx8/imx8mp/imx8mp.rst
+++ b/source/bsp/imx8/imx8mp/imx8mp.rst
@@ -53,7 +53,17 @@ BSP-Yocto-NXP-i.MX8MP-PD23.1.0
 
    pd23.1.0
 
-BSP-Yocto-NXP-i.MX8MM-PD22.1.1
+BSP-Yocto-NXP-i.MX8MP-PD22.1.2
+==============================
+
+.. toctree::
+   :caption: Table of Contents
+   :numbered:
+   :maxdepth: 2
+
+   pd22.1.2
+
+BSP-Yocto-NXP-i.MX8MP-PD22.1.1
 ==============================
 
 .. toctree::

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -1,11 +1,11 @@
 .. Download links
 .. |dlpage-bsp| replace:: our BSP
-.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD22.1.2
 .. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-8m-plus/#downloads
 .. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/
-.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/sdk/ampliphy-vendor-xwayland/
-.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt5demo-image-phyboard-pollux-imx8mp-3.wic
-.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.2/sdk/ampliphy-vendor-xwayland/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.2/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt5demo-image-phyboard-pollux-imx8mp-3.wic
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.2/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
 
 .. IMX8(MP) specific
@@ -31,7 +31,7 @@
 .. |kernel-repo-name| replace:: linux-imx
 .. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
 .. |kernel-socname| replace:: imx8mp
-.. |kernel-tag| replace:: v5.10.72_2.2.0-phy17
+.. |kernel-tag| replace:: v5.10.72_2.2.0-phy18
 .. |emmcdev| replace:: mmcblk2
 
 .. Bootloader
@@ -45,7 +45,7 @@
 
 .. IMX8(MP) specific
 .. |u-boot-socname-config| replace:: IMX8MP
-.. |u-boot-tag| replace:: v2021.04_2.2.0-phy13
+.. |u-boot-tag| replace:: v2021.04_2.2.0-phy17
 
 
 .. Devicetree
@@ -54,7 +54,7 @@
 .. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
 
 .. IMX8(MP) specific
-.. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n41`
+.. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n41`
 
 .. Yocto
 .. |yocto-bootenv-link| replace:: :yocto-bootenv:`hardknott`
@@ -64,24 +64,24 @@
 .. |yocto-distro| replace:: ampliphy-vendor-xwayland
 .. |yocto-imagename| replace:: phytec-qt5demo-image
 .. |yocto-machinename| replace:: phyboard-pollux-imx8mp-3
-.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.2
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.y
 .. |yocto-ref-manual| replace:: L-813e.A12 Yocto Reference Manual (Hardknott)
 .. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=UIHsG
 .. _yocto-ref-manual-kernel-and-bootloader-config: https://www.phytec.de/cdocuments/?doc=UIHsG#YoctoReferenceManualHardknottL813e-A12-KernelandBootloaderConfiguration
-.. |yocto-sdk-rev| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |yocto-sdk-rev| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.2
 .. |yocto-sdk-a-core| replace:: cortexa53-crypto
 
 
 .. Ref Substitutions
-.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd22.1.1-bootswitch>`
-.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd22.1.1-images>`
-.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd22.1.1-components>`
-.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd22.1.1-device-tree>`
-.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd22.1.1-network>`
-.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd22.1.1-development>`
-.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd22.1.1-components>`
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd22.1.2-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd22.1.2-images>`
+.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd22.1.2-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd22.1.2-device-tree>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd22.1.2-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd22.1.2-development>`
+.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd22.1.2-components>`
 .. |ref-disable-emmc-part| replace:: :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
 
 
@@ -89,17 +89,17 @@
 .. |sbc-network| replace::
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
-   :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n141`.
+   :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n141`.
 .. |pollux-fan-note| replace::
    Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
    to GPIO fan due to availability. The PWM fan will not be supported
    anymore and will not function with the new release.
 
-.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd22.1.1-components>`
-.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd22.1.1-components>`
-.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd22.1.1-components>`
+.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd22.1.2-components>`
+.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd22.1.2-components>`
+.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd22.1.2-components>`
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
-   :ref:`device tree overlay section <imx8mp-pd22.1.1-ubootexternalenv>`
+   :ref:`device tree overlay section <imx8mp-pd22.1.2-ubootexternalenv>`
 
 
 .. M-Core specific
@@ -117,7 +117,7 @@
 +-----------------------+----------------------+
 | Yocto Manual          |                      |
 +-----------------------+----------------------+
-| Release Date          | 2023/05/25           |
+| Release Date          | 2024/08/05           |
 +-----------------------+----------------------+
 | Is Branch of          | |soc| BSP Manual     |
 +-----------------------+----------------------+
@@ -128,7 +128,7 @@ The table below shows the Compatible BSPs for this manual:
 Compatible BSP'S     BSP Release Type BSP Release  Date BSP Status
 
 ==================== ================ ================= ==========
-|yocto-manifestname| Minor            2023/05/23        Released
+|yocto-manifestname| Minor            2024/08/05        Released
 ==================== ================ ================= ==========
 
 .. include:: ../../intro.rsti
@@ -146,7 +146,12 @@ the **Article Number** of your hardware, you can leave the **Machine
 Name** drop-down menu empty and only choose your **Article Number**. Now it
 should show you the necessary **Machine Name** for your specific hardware
 
-.. _imx8mp-pd22.1.1-components:
+.. note::
+   When the PCM-070 does not have the X1 extension connector populated, some
+   Software features described here do not work. These are Wirless LAN, PCIe,
+   CSI (cameras), PEB-AV-12, CAN, USB-OTG.
+
+.. _imx8mp-pd22.1.2-components:
 .. include:: components.rsti
 
 Getting Started
@@ -271,7 +276,7 @@ First Start-up
 
 .. include:: /bsp/building-bsp.rsti
 
-.. _imx8mp-pd22.1.1-images:
+.. _imx8mp-pd22.1.2-images:
 
 * **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
   Bootloader image!
@@ -307,7 +312,7 @@ Bootmode Switch (S3)
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.
 
-.. _imx8mp-pd22.1.1-bootswitch:
+.. _imx8mp-pd22.1.2-bootswitch:
 .. include:: bootmode-switch.rsti
 
 Flash eMMC
@@ -850,7 +855,7 @@ BSPs: `L-1006e.A3 RAUC Update & Device Management Manual
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+
 
-.. _imx8mp-pd22.1.1-development:
+.. _imx8mp-pd22.1.2-development:
 
 Development
 ===========
@@ -1044,8 +1049,33 @@ E.g. flash SD card:
 .. hint::
    The specific offset values are also declared in the Yocto variables "BOOTLOADER_SEEK" and "BOOTLOADER_SEEK_EMMC"
 
-.. include:: /bsp/imx-common/development/standalone_build_u-boot_binman.rsti
-   :start-after: .. build-uboot-fixed-ram-size-marker
+Build U-Boot With a Fixed RAM Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you cannot boot your system anymore because the hardware introspection in the
+EEPROM is damaged or deleted, you can create a flash.bin with a fixed ram size.
+You should still contact support and flash the correct EEPROM data, as this
+could lead to unexpected behavior.
+
+Follow the steps to get the U-boot sources and check the correct branch in the
+**Build U-Boot** section.
+
+Edit the file configs/phycore-|kernel-socname|\_defconfig:
+
+.. code-block:: kconfig
+   :substitutions:
+
+   CONFIG_TARGET_PHYCORE_|u-boot-socname-config|=y
+   CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_FIX=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_1GB=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_2GB=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_4GB=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_4GB_2GHZ=y
+
+Choose the correct RAM size as populated on the board and uncomment the line for
+this ram size. For Article number 0F\ **8**\ 443I, use [...]_4GB_2GHZ, for
+0F\ **5**\ 443I, use [...]_4GB.
+After saving the changes, follow the remaining steps from Build U-Boot.
 
 .. include:: /bsp/imx-common/development/standalone_build_kernel.rsti
 
@@ -1059,7 +1089,7 @@ E.g. flash SD card:
 .. DEVICE TREE
 .. +---------------------------------------------------------------------------+
 
-.. _imx8mp-pd22.1.1-device-tree:
+.. _imx8mp-pd22.1.2-device-tree:
 
 Device Tree (DT)
 ================
@@ -1142,7 +1172,7 @@ Available overlays for |yocto-machinename|.conf are:
    There is one more overlay available for phyboard-pollux-imx8mp-2.conf:
    imx8mp-phyboard-pollux-1552.1.dtbo
 
-.. _imx8mp-pd22.1.1-ubootexternalenv:
+.. _imx8mp-pd22.1.2-ubootexternalenv:
 .. include:: ../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
@@ -1195,9 +1225,9 @@ correctly.
 .. include:: /bsp/peripherals/rs485.rsti
 
 The device tree representation for RS232 and RS485:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n331`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n331`
 
-.. _imx8mp-pd22.1.1-network:
+.. _imx8mp-pd22.1.2-network:
 
 Network
 -------
@@ -1232,10 +1262,10 @@ module and board.
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n367`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n367`
 
 DT configuration for the eMMC interface can be found here:
-:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n220`
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n220`
 
 eMMC Devices
 ------------
@@ -1619,7 +1649,7 @@ be read back as zeros.
 
 The definition of the SPI master node in the device tree can be found here:
 
-:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n72`
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n72`
 
 GPIOs
 -----
@@ -1752,15 +1782,15 @@ Here the LEDs blue-mmc, green-heartbeat, and red-emmc are on the |sbc|.
       target:~$ echo 0 > /sys/class/leds/user-led1/brightness
 
 Device tree configuration for the User I/O configuration can be found here:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n216`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n216`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 
 General I²C1 bus configuration (e.g. |dt-som|.dtsi):
-:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n105`
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n105`
 
 General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n201`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n201`
 
 
 EEPROM
@@ -1791,13 +1821,13 @@ hardware introspection from the ID area to the normal area.
 
 DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
-:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n201`
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n201`
 
 .. include:: ../../peripherals/rtc.rsti
    :end-before: .. rtc_parameter_start_label
 
 DT representation for I²C RTCs:
-:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n207`
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n207`
 
 USB Host Controller
 -------------------
@@ -1812,7 +1842,7 @@ connected to a USB 3.0 PHY.
 .. include:: /bsp/peripherals/usb-host.rsti
 
 DT representation for USB Host:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n341`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n341`
 
 CAN FD
 ------
@@ -1827,12 +1857,12 @@ documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n165`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n165`
 
 .. include:: /bsp/peripherals/pcie.rsti
 
 Device Tree PCIe configuration of imx8mm-phyboard-polis.dtsi:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n277`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n277`
 
 Audio
 -----
@@ -1983,7 +2013,7 @@ TLV320-Codec using the 3.5mm jack.
    capture operations.
 
 Device Tree Audio configuration:
-:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n57`
+:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy18#n57`
 
 Video
 -----
@@ -2110,18 +2140,18 @@ In our BSP, the default Weston output is set to HDMI. ::
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 Device tree description of LVDS-1 and HDMI can be found here:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n255`
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n180`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n255`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n180`
 
 The device tree of LVDS-0 on PEB-AV-10 can be found here:
-:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n132`
+:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy18#n132`
 
 .. include:: ../peripherals/pm.rsti
 
 .. include:: ../peripherals/tm.rsti
 
 The device tree description of GPIO Fan can be found here:
-:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n26`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n26`
 
 .. include:: /bsp/peripherals/watchdog.rsti
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -1,0 +1,2231 @@
+.. Download links
+.. |dlpage-bsp| replace:: our BSP
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-8m-plus/#downloads
+.. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/sdk/ampliphy-vendor-xwayland/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt5demo-image-phyboard-pollux-imx8mp-3.wic
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD22.1.1/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
+.. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+
+.. IMX8(MP) specific
+.. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2021.04_2.2.0-phy13#n239
+
+
+.. General Substitutions
+.. |atfloadaddr| replace:: 0x970000
+.. |kit| replace:: **phyCORE-i.MX8M Plus Kit**
+.. |kit-ram-size| replace:: 2GiB
+.. |sbc| replace:: phyBOARD-Pollux
+.. |soc| replace:: i.MX 8M Plus
+.. |socfamily| replace:: i.MX 8
+.. |som| replace:: phyCORE-i.MX8MP
+.. |debug-uart| replace:: ttymxc0
+.. |serial-uart| replace:: ttymxc1
+.. |expansion-connector| replace:: X6
+
+
+.. Linux Kernel
+.. |kernel-defconfig| replace:: imx_v8_defconfig imx8_phytec_distro.config imx8_phytec_platform.config
+.. |kernel-recipe-path| replace:: meta-phytec/dynamic-layers/freescale-layer/recipes-kernel/linux/linux-imx_*.bb
+.. |kernel-repo-name| replace:: linux-imx
+.. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
+.. |kernel-socname| replace:: imx8mp
+.. |kernel-tag| replace:: v5.10.72_2.2.0-phy17
+.. |emmcdev| replace:: mmcblk2
+
+.. Bootloader
+.. |u-boot-offset| replace:: 32
+.. |u-boot-offset-boot-part| replace:: 0
+.. |u-boot-mmc-flash-offset| replace:: 0x40
+.. |u-boot-emmc-devno| replace:: 2
+.. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
+.. |u-boot-repo-name| replace:: u-boot-imx
+.. |u-boot-repo-url| replace:: git://git.phytec.de/u-boot-imx
+
+.. IMX8(MP) specific
+.. |u-boot-socname-config| replace:: IMX8MP
+.. |u-boot-tag| replace:: v2021.04_2.2.0-phy13
+
+
+.. Devicetree
+.. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
+.. |dt-som| replace:: imx8mp-phycore-som
+.. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+
+.. IMX8(MP) specific
+.. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n41`
+
+.. Yocto
+.. |yocto-bootenv-link| replace:: :yocto-bootenv:`hardknott`
+.. |yocto-bsp-name| replace:: BSP-Yocto-IMX8MP
+.. _yocto-bsp-name: `dl-server`_
+.. |yocto-codename| replace:: hardknott
+.. |yocto-distro| replace:: ampliphy-vendor-xwayland
+.. |yocto-imagename| replace:: phytec-qt5demo-image
+.. |yocto-machinename| replace:: phyboard-pollux-imx8mp-3
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
+.. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.y
+.. |yocto-ref-manual| replace:: L-813e.A12 Yocto Reference Manual (Hardknott)
+.. _yocto-ref-manual: https://www.phytec.de/cdocuments/?doc=UIHsG
+.. _yocto-ref-manual-kernel-and-bootloader-config: https://www.phytec.de/cdocuments/?doc=UIHsG#YoctoReferenceManualHardknottL813e-A12-KernelandBootloaderConfiguration
+.. |yocto-sdk-rev| replace:: BSP-Yocto-NXP-i.MX8MP-PD22.1.1
+.. |yocto-sdk-a-core| replace:: cortexa53-crypto
+
+
+.. Ref Substitutions
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd22.1.1-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd22.1.1-images>`
+.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd22.1.1-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd22.1.1-device-tree>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd22.1.1-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd22.1.1-development>`
+.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd22.1.1-components>`
+.. |ref-disable-emmc-part| replace:: :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
+
+
+.. IMX8(MP) specific
+.. |sbc-network| replace::
+   The device tree set up for EQOS Ethernet IP core where the PHY is populated
+   on the |sbc| can be found here:
+   :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n141`.
+.. |pollux-fan-note| replace::
+   Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
+   to GPIO fan due to availability. The PWM fan will not be supported
+   anymore and will not function with the new release.
+
+.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd22.1.1-components>`
+.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd22.1.1-components>`
+.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd22.1.1-components>`
+.. |ubootexternalenv| replace:: U-boot External Environment subsection of the
+   :ref:`device tree overlay section <imx8mp-pd22.1.1-ubootexternalenv>`
+
+
+.. M-Core specific
+.. |mcore| replace:: M7 Core
+.. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
+.. |mcore-sdk-version| replace:: 2.13.0
+
++-----------------------+----------------------+
+| |soc| BSP Manual                             |
++-----------------------+----------------------+
+| Document Title        | |soc| BSP Manual     |
++-----------------------+----------------------+
+| Document Type         | BSP Manual           |
++-----------------------+----------------------+
+| Yocto Manual          |                      |
++-----------------------+----------------------+
+| Release Date          | 2023/05/25           |
++-----------------------+----------------------+
+| Is Branch of          | |soc| BSP Manual     |
++-----------------------+----------------------+
+
+The table below shows the Compatible BSPs for this manual:
+
+==================== ================ ================= ==========
+Compatible BSP'S     BSP Release Type BSP Release  Date BSP Status
+
+==================== ================ ================= ==========
+|yocto-manifestname| Minor            2023/05/23        Released
+==================== ================ ================= ==========
+
+.. include:: ../../intro.rsti
+
+Supported Hardware
+------------------
+
+On our web page, you can see all supported Machines with the available Article
+Numbers for this release: |yocto-manifestname| `download <dlpage-bsp_>`_.
+
+If you choose a specific **Machine Name** in the section **Supported Machines**,
+you can see which **Article Numbers** are available under this machine and also
+a short description of the hardware information. In case you only have
+the **Article Number** of your hardware, you can leave the **Machine
+Name** drop-down menu empty and only choose your **Article Number**. Now it
+should show you the necessary **Machine Name** for your specific hardware
+
+.. _imx8mp-pd22.1.1-components:
+.. include:: components.rsti
+
+Getting Started
+===============
+
+The |kit| is shipped with a pre-flashed SD card. It contains the
+|yocto-imagename| and can be used directly as a boot source. The eMMC is
+programmed with only a U-boot by default. You can get all sources from the
+`PHYTEC download server <dl-server_>`_. This chapter explains how to flash a BSP
+image to SD card and how to start the board.
+
+Get the Image
+-------------
+
+The WIC image contains all BSP files in several, correctly pre-formatted
+partitions and can be copied to an SD card easily using the single Linux
+command ``dd``. It can be built by Yocto or downloaded from the PHYTEC download
+server.
+
+Get the WIC file from the download server:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ wget |link-image|
+
+Write the Image to SD Card
+--------------------------
+
+.. warning::
+   To create your bootable SD card with the ``dd`` command, you must have root
+   privileges. Be very careful when specifying the destination device with
+   ``dd``! All files on the selected destination device will be erased
+   immediately without any further query!
+
+   Selecting the wrong device may result in **data loss** and e.g. could erase
+   your currently running system!
+
+To create your bootable SD card, you must first find the correct device name
+of your SD card and possible partitions. Unmount any mounted partitions before
+you start copying the image to the SD card.
+
+#. In order to get the correct device name, remove your SD card and
+   execute::
+
+      host$ lsblk
+
+#. Now insert your SD card and execute the command again::
+
+      host$ lsblk
+
+#. Compare the two outputs to find the new device names listed in the second
+   output. These are the device names of the SD card (device and partitions if
+   the SD card was formatted).
+#. In order to verify the device names being found, execute the command
+   ``sudo dmesg``. Within the last lines of its output, you should also find the
+   device names, e.g. ``/dev/sde`` or ``/dev/mmcblk0`` (depending on your
+   system).
+
+Alternatively, you may use a graphical program of your choice, like `GNOME Disks
+<https://apps.gnome.org/en/DiskUtility/>`_ or `KDE Partition Manager
+<https://apps.kde.org/partitionmanager/>`_, to find the correct device.
+
+Now that you have the correct device name, e.g. ``/dev/sde``,
+you can see the partitions which must be unmounted if the SD card is formatted.
+In this case, you will also find the device name with an appended number
+(e.g. ``/dev/sde1``) in the output. These represent the partitions. Some Linux
+distributions automatically mount partitions when the device gets plugged in.
+Before writing, however, these need to be unmounted to avoid data corruption.
+
+*  Unmount all partitions, e.g.::
+
+      host$ sudo umount /dev/sde1
+
+*  After having unmounted all partitions, you can create your bootable SD card::
+
+      host$ sudo dd if=<IMAGENAME>-<MACHINE>.wic of=/dev/sdX bs=1M conv=fsync status=progress
+
+   Again, make sure to replace ``/dev/sdX`` with your actual device name found
+   previously.
+
+   The parameter ``conv=fsync`` forces a sync operation on the device before
+   ``dd`` returns. This ensures that all blocks are written to the SD card and
+   none are left in memory. The parameter ``status=progress`` will print out
+   information on how much data is and still has to be copied until it is
+   finished.
+
+An alternative and much faster way to prepare an SD card can be done by using
+`bmap-tools <https://github.com/intel/bmap-tools>`_ from Intel. Yocto
+automatically creates a block map file (``<IMAGENAME>-<MACHINE>.wic.bmap``) for
+the WIC image that describes the image content and includes checksums for data
+integrity. *bmaptool* is packaged by various Linux distributions. For
+Debian-based systems install it by issuing::
+
+   host$ sudo apt install bmap-tools
+
+Flash a WIC image to SD card by calling::
+
+   host$ bmaptool copy <IMAGENAME>-<MACHINE>.wic /dev/<your_device>
+
+.. warning::
+   *bmaptool* only overwrites the areas of an SD card where image data is
+   located. This means that a previously written U-Boot environment may still be
+   available after writing the image.
+
+First Start-up
+--------------
+
+* To boot from an SD card, |ref-bootswitch| needs to be set to the following
+  position:
+
+.. image:: images/SD_Card_Boot.png
+
+* Insert the SD card
+* Connect the target and the host with **mirco USB** on |ref-debugusbconnector|
+  debug USB
+* Power up the board
+
+.. +---------------------------------------------------------------------------+
+.. Building the BSP
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/building-bsp.rsti
+
+.. _imx8mp-pd22.1.1-images:
+
+* **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
+  Bootloader image!
+* **oftree**: Default kernel device tree
+* **u-boot-spl.bin**: Secondary program loader (SPL)
+* **bl31-imx8mp.bin**: ARM Trusted Firmware binary
+* **lpddr4_pmu_train_2d_dmem_202006.bin,
+  lpddr4_pmu_train_2d_imem_202006.bin**: DDR PHY firmware images
+* **imx-boot**: Bootloader build by imx-mkimage which includes SPL, U-Boot, ARM
+  Trusted Firmware and DDR firmware. This is the final bootloader image which is
+  bootable.
+* **Image**: Linux kernel image
+* **Image.config**: Kernel configuration
+* **imx8mp-phyboard-pollux-rdk*.dtb**: Kernel device tree file
+* **imx8mp-phy*.dtbo**: Kernel device tree overlay files
+* **phytec-qt5demo-image\*.tar.gz**: Root file system
+* **phytec-qt5demo-image\*.wic**: SD card image
+
+.. +---------------------------------------------------------------------------+
+.. INSTALLING THE OS
+.. +---------------------------------------------------------------------------+
+
+Installing the OS
+=================
+
+Bootmode Switch (S3)
+--------------------
+
+.. tip::
+
+   Hardware revision baseboard: 1552.2
+
+The |sbc| features a boot switch with four individually switchable ports to
+select the phyCORE-|soc| default bootsource.
+
+.. _imx8mp-pd22.1.1-bootswitch:
+.. include:: bootmode-switch.rsti
+
+Flash eMMC
+----------
+
+To boot from eMMC, make sure that the BSP image is flashed correctly to the eMMC
+and the |ref-bootswitch| is set to **Default SOM boot**.
+
+.. warning::
+   When eMMC and SD card are flashed with the same (identical) image, the UUIDs
+   of the boot partitions are also identical. If the SD card is connected when
+   booting, this leads to non-deterministic behavior as Linux mounts the boot
+   partition based on UUID.
+
+   .. code-block:: console
+
+      target:~$ blkid
+
+   can be run to inspect whether the current setup is affected. If ``mmcblk2p1``
+   and ``mmcblk1p1`` have an identical UUID, the setup is affected.
+
+Flash eMMC from Network
+.......................
+
+|soc| boards have an Ethernet connector and can be updated over a network. Be
+sure to set up the development host correctly. The IP needs to be set to
+192.168.3.10, the netmask to 255.255.255.0, and a TFTP server needs to be
+available. From a high-level point of view, an eMMC device is like an SD card.
+Therefore, it is possible to flash the **WIC image** (``<name>.wic``) from
+the Yocto build system directly to the eMMC. The image contains the
+bootloader, kernel, device tree, device tree overlays, and root file system.
+
+Flash eMMC from Network in u-boot on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These steps will show how to update the eMMC via a network. However, they only
+work if the size of the image file is less than 1GB. If the image file is
+larger, go to the section Format SD Card. Configure the |ref-bootswitch| to boot
+from SD Card and put in an SD card. Power on the board and stop in U-Boot
+prompt.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+*  Load your image via network to RAM:
+
+   .. code-block::
+      :substitutions:
+
+      u-boot=> tftp ${loadaddr} |yocto-imagename|-|yocto-machinename|.wic
+      Using ethernet@30be0000 device
+      TFTP from server 192.168.3.10; our IP address is 192.168.3.11
+      Filename '|yocto-imagename|-|yocto-machinename|.wic'.
+      Load address: 0x40480000
+      Loading: ######################################
+               ######################################
+               ######################################
+               ...
+               ...
+               ...
+               ######################################
+               #############
+               11.2 MiB/s
+      done
+      Bytes transferred = 911842304 (36599c00 hex)
+
+*  Write the image to the eMMC:
+
+   .. code-block::
+
+      u-boot=> mmc dev 2
+      switch to partitions #0, OK
+      mmc2(part 0) is current device
+      u-boot=> setexpr nblk ${filesize} / 0x200
+      u-boot=> mmc write ${loadaddr} 0x0 ${nblk}
+
+      MMC write: dev # 2, block # 0, count 1780942 ... 1780942 blocks written: OK
+
+Flash eMMC via Network in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update the eMMC from your target.
+
+.. tip::
+   A working network is necessary! Setup Network Host.
+
+Take a compressed or uncompressed image on the host and send it with ssh through
+the network (then uncompress it, if necessary) to the eMMC of the target with a
+one-line command:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ ssh <USER>@192.168.3.10 "dd if=<path_to_file>/|yocto-imagename|-|yocto-machinename|.wic" | dd of=/dev/mmcblk2
+
+Flash eMMC via Network in Linux on Host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is also possible to install the OS at eMMC from your Linux host. As before,
+you need a complete image on your host.
+
+.. tip::
+
+   A working network is necessary! Setup Network Host.
+
+Show your available image files on the host:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ ls
+   |yocto-imagename|-|yocto-machinename|.wic
+
+Send the image with the command dd command combined with ssh through the network
+to the eMMC of your device:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic status=progress | ssh root@192.168.3.11 "dd of=/dev/mmcblk2"
+
+Flash eMMC u-boot image via Network from running u-boot
+.......................................................
+
+Update the standalone u-boot image imx-boot is also possible from u-boot. This
+can be used if the bootloader on eMMC is located in the eMMC user area.
+
+.. tip::
+
+   A working network is necessary! Setup Network Host.
+
+Load image over tftp into RAM and then write it to eMMC:
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> tftp ${loadaddr} imx-boot
+   u-boot=> setexpr nblk ${filesize} / 0x200
+   u-boot=> mmc dev 2
+   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${nblk}
+
+.. hint::
+   The hexadecimal value represents the offset as a multiple of 512 byte
+   blocks. See the `offset table <#offset-table>`__ for the correct value
+   of the corresponding SoC.
+
+Flash eMMC from USB
+...................
+
+Flash eMMC from USB in u-boot on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tip::
+
+   This step only works if the size of the image file is less than 1GB due to
+   limited usage of RAM size in Bootloader after enabling the OPTEE.
+
+These steps will show how to update the eMMC via a USB device. Configure the
+bootmode switch to |ref-bootswitch| and put in an SD card. Power on the board
+and stop in u-boot prompt. Insert a USB device with the copied WIC image
+to the USB slot.
+
+Load your image from the USB device to RAM:
+
+.. code-block::
+
+   u-boot=> usb start
+   starting USB...
+   USB0:   USB EHCI 1.00
+   scanning bus 0 for devices... 2 USB Device(s) found
+          scanning usb for storage devices... 1 Storage Device(s) found
+   u-boot=> fatload usb 0:1 ${loadaddr} *.wic
+   497444864 bytes read in 31577 ms (15 MiB/s)
+
+Write the image to the eMMC:
+
+.. code-block::
+
+   u-boot=> mmc dev 2
+   switch to partitions #0, OK
+   mmc2(part 0) is current device
+   u-boot=> setexpr nblk ${filesize} / 0x200
+   u-boot=> mmc write ${loadaddr} 0x0 ${nblk}
+
+   MMC write: dev # 2, block # 0, count 1024000 ... 1024000 blocks written: OK
+   u-boot=> boot
+
+Flash eMMC from USB in Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These steps will show how to flash the eMMC on Linux with a USB stick. You only
+need a complete image saved on the USB stick and a bootable WIC image. (e.g.
+|yocto-imagename|-|yocto-machinename|.wic). Set the bootmode switch to
+|ref-bootswitch|.
+
+*  Insert and mount the USB stick:
+
+   .. code-block:: console
+
+      [   60.458908] usb-storage 1-1.1:1.0: USB Mass Storage device detected
+      [   60.467286] scsi host0: usb-storage 1-1.1:1.0
+      [   61.504607] scsi 0:0:0:0: Direct-Access                               8.07 PQ: 0 ANSI: 2
+      [   61.515283] sd 0:0:0:0: [sda] 3782656 512-byte logical blocks: (1.94 GB/1.80 GiB)
+      [   61.523285] sd 0:0:0:0: [sda] Write Protect is off
+      [   61.528509] sd 0:0:0:0: [sda] No Caching mode page found
+      [   61.533889] sd 0:0:0:0: [sda] Assuming drive cache: write through
+      [   61.665969]  sda: sda1
+      [   61.672284] sd 0:0:0:0: [sda] Attached SCSI removable disk
+      target:~$ mount /dev/sda1 /mnt
+
+*  Now show your saved image files on the USB Stick:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ cd /mnt
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.wic
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      mmcblk2
+      mmcblk2boot0
+      mmcblk2boot1
+      mmcblk2p1
+      mmcblk2p2
+      mmcblk2rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (mmcblk2boot0; mmcblk2boot1)
+*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/mmcblk2
+
+*  After a complete write, your board can boot from eMMC.
+
+.. warning::
+
+   Before this will work, you need to configure the multi-port switch
+   to **Default SOM Boot** to |ref-bootswitch|.
+
+Flash eMMC from SD Card
+.......................
+
+Even if there is no network available, you can update the eMMC. For that, you
+only need a ready-to-use image file (``*.wic``) located on the SD card.
+Because the image file is quite large, you have to enlarge your SD card to use
+its full space (if it was not enlarged before). To enlarge your SD card, see
+Resizing ext4 Root Filesystem.
+
+Flash eMMC from SD card in u-boot on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tip::
+
+   This step only works if the size of the image file is less than 1GB due to
+   limited usage of RAM size in Bootloader after enabling the OPTEE. If the
+   image file is too large use the `Updating eMMC from SD card in
+   Linux on Target` subsection.
+
+*  Flash an SD card with a working image and create a third FAT partition. Copy
+   the WIC image (for example |yocto-imagename|.wic) to this
+   partition.
+*  Configure the bootmode switch to boot from the SD Card and insert the SD
+   card.
+*  Power on the board and stop in u-boot.
+*  Flash your WIC image (for example |yocto-imagename|.wic)
+   from the SD card to eMMC. This will partition the card and copy imx-boot,
+   Image, dtb, dtbo, and root file system to eMMC.
+*  Load the image:
+
+   .. code-block::
+      :substitutions:
+
+      u-boot=> fatload mmc 1:3 ${loadaddr} |yocto-imagename|-|yocto-machinename|.wic
+      reading
+      911842304 bytes read in 39253 ms (22.2 MiB/s)
+
+*  Switch the mmc dev:
+
+   .. code-block::
+
+      u-boot=> mmc list
+      FSL_SDHC: 1 (SD)
+      FSL_SDHC: 2 (eMMC)
+      u-boot=> mmc dev 2
+      switch to partitions #0, OK
+      mmc0(part 0) is current device
+      u-boot=> setexpr nblk ${filesize} / 0x200
+      u-boot=> mmc write ${loadaddr} 0x0 ${nblk}
+
+      MMC write: dev # 2, block # 0, count 1780942 ... 1780942 blocks written: OK
+
+*  Power off the board and change the multi-port switch to Default SOM Boot to
+   boot from eMMC.
+
+Flash eMMC from SD card in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also flash the eMMC on Linux. You only need a complete image saved on
+the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic).
+
+*  Show your saved image files on the SD card:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.wic
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      mmcblk2
+      mmcblk2boot0
+      mmcblk2boot1
+      mmcblk2p1
+      mmcblk2p2
+      mmcblk2rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
+*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+   partition):
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/mmcblk2
+
+*  After a complete write, your board can boot from eMMC.
+
+.. warning::
+
+   Before this will work, you need to configure the |ref-bootswitch| to Default
+   SOM Boot to boot from eMMC.
+
+Flash SPI NOR Flash
+-------------------
+
+The |som| modules are optionally equipped with SPI NOR Flash. To boot from SPI
+Flash, set |ref-bootswitch| to **QSPI boot** to boot from QSPI. The SPI Flash is
+usually quite small. The phyBOARD-Pollux-i.MX8MP kit only has 32MB SPI NOR flash
+populated. Only the bootloader and the environment can be stored. The kernel,
+device tree, and file system are taken from eMMC by default.
+
+The SPI NOR flash partition table is defined in the U-Boot environment. It can
+be printed with:
+
+.. code-block::
+
+   u-boot=> printenv mtdparts
+   mtdparts=30bb0000.spi:3840k(u-boot),128k(env),128k(env:redund),-(none)
+
+Flash SPI NOR Flash from Network
+................................
+
+The SPI NOR can contain the bootloader and environment to boot from. The arm64
+kernel can not decompress itself, the image size extends the SPI NOR flash
+populated on the phyCORE-|soc|.
+
+.. tip::
+
+   A working network is necessary! Setup Network Host.
+
+Flash SPI NOR from Network in u-boot on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to updating the eMMC over a network, be sure to set up the development
+host correctly. The IP needs to be set to 192.168.3.10, the netmask to
+255.255.255.0, and a TFTP server needs to be available. Before reading and
+writing is possible, the SPI-NOR flash needs to be probed:
+
+.. code-block::
+
+   u-boot=> sf probe
+   SF: Detected mt25qu512a with page size 256 Bytes, erase size 64 KiB, total 64 MiB
+
+*  A specially formatted u-boot image for the SPI NOR flash is used. Ensure you
+   use the correct image file. Load the image over tftp, erase and write the
+   bootloader to the flash:
+
+   .. code-block::
+      :substitutions:
+
+      u-boot=> tftp ${loadaddr} imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi
+      u-boot=> sf update ${loadaddr} 0 ${filesize}
+      device 0 offset 0x0, size 0x1c0b20
+      1641248 bytes written, 196608 bytes skipped in 4.768s, speed 394459 B/s
+
+*  Erase the environment partition as well. This way, the environment can be
+   written after booting from SPI NOR flash:
+
+   .. code-block::
+
+      u-boot=> sf erase 0x400000 0x100000
+
+.. warning::
+
+   Erasing the complete SPI NOR flash when it is fully written will take quite
+   some time. This can trigger the watchdog to reset. Due to this, erase the
+   full flash in Linux.
+
+Flash SPI NOR from Network in kernel on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*  Copy the image from the host to the target:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ scp imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi root@192.168.3.11:/root
+
+*  Find the number of erase blocks of the U-boot partition:
+
+   .. code-block:: console
+
+      target:~$ mtdinfo /dev/mtd0
+      mtd0
+      Name:                           u-boot
+      Type:                           nor
+      Eraseblock size:                65536 bytes, 64.0 KiB
+      Amount of eraseblocks:          60 (3932160 bytes, 3.7 MiB)
+      Minimum input/output unit size: 1 byte
+      Sub-page size:                  1 byte
+      Character device major/minor:   90:0
+      Bad blocks are allowed:         false
+      Device is writable:             true
+
+*  Erase the u-boot partition and flash it:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ flash_erase /dev/mtd0 0x0 60
+      target:~$ flashcp imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi /dev/mtd0
+
+Flash SPI NOR Flash from SD Card
+................................
+
+The bootloader on SPI NOR flash can be also flashed with SD Card.
+
+Flash SPI NOR from SD Card in u-boot on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*  Copy the SPI NOR flash U-boot image
+   imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi to the FAT partition
+   on the SD Card. Before reading and writing are possible, the SPI-NOR flash
+   needs to be probed:
+
+   .. code-block::
+
+      u-boot=> sf probe
+      SF: Detected n25q256ax1 with page size 256 Bytes, erase size 64 KiB, total 32 MiB
+
+*  A specially formatted U-boot image for the SPI NOR flash is used. Ensure you
+   use the correct image file. Load the image from the SD Card, erase and write
+   the bootloader to the flash:
+
+   .. code-block::
+      :substitutions:
+
+      u-boot=> mmc dev 1
+      u-boot=> fatload mmc 1:1 ${loadaddr} imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi
+      u-boot=> sf update ${loadaddr} 0 ${filesize}
+
+*  Erase the environment partition as well. This way, the environment can be
+   written after booting from SPI NOR flash:
+
+   .. code-block::
+
+      u-boot=> sf erase 0x400000 0x100000
+
+.. warning::
+
+   Erasing the complete SPI NOR flash when it is fully written will take quite
+   some time. This can trigger the watchdog to reset. Due to this, erase the
+   full flash in Linux.
+
+Flash SPI NOR from SD Card in kernel on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*  Mount the SD Card:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ mount /dev/mmcblkp1 /mnt
+
+*  Find the number of erase blocks of the u-boot partition:
+
+   .. code-block:: console
+
+      target:~$  mtdinfo /dev/mtd0
+      mtd0
+      Name:                           u-boot
+      Type:                           nor
+      Eraseblock size:                65536 bytes, 64.0 KiB
+      Amount of eraseblocks:          60 (3932160 bytes, 3.7 MiB)
+      Minimum input/output unit size: 1 byte
+      Sub-page size:                  1 byte
+      Character device major/minor:   90:0
+      Bad blocks are allowed:         false
+      Device is writable:             true
+
+*  Erase the u-boot partition and flash it:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ flash_erase /dev/mtd0 0x0 60
+      target:~$ flashcp /mnt/imx-boot-|yocto-machinename|-fspi.bin-flash_evk_flexspi /dev/mtd0
+
+RAUC
+----
+
+The RAUC (Robust Auto-Update Controller) mechanism support has been added to
+meta-ampliphy. It controls the procedure of updating a device with new firmware.
+This includes updating the Linux kernel, Device Tree, and root filesystem.
+PHYTEC has written an online manual on how we have intergraded RAUC into our
+BSPs: `L-1006e.A3 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=BKXvGQ>`__.
+
+.. +---------------------------------------------------------------------------+
+.. DEVELOPMENT
+.. +---------------------------------------------------------------------------+
+
+.. _imx8mp-pd22.1.1-development:
+
+Development
+===========
+
+.. include:: /bsp/imx-common/development/host_network_setup.rsti
+.. include:: /bsp/imx-common/development/netboot.rsti
+
+Working with UUU-Tool
+---------------------
+
+The Universal Update Utility Tool (UUU-Tool) from NXP is a software to execute
+on the host to load and run the bootloader on the board through SDP (Serial
+Download Protocol). For detailed information visit
+https://github.com/nxp-imx/mfgtools or download the `Official UUU-tool
+documentation <https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-processors/140261/1/UUU.pdf>`_.
+
+Host preparations for UUU-Tool Usage
+....................................
+
+*  Follow the instructions from https://github.com/nxp-imx/mfgtools#linux.
+
+*  If you built UUU from source, add it to ``PATH``:
+
+   This BASH command adds UUU only temporarily to ``PATH``. To add it permanently, add this line to
+   ``~/.bashrc``.
+
+   .. code-block:: console
+
+      export PATH=~/mfgtools/uuu/:"$PATH"
+
+*  Set udev rules (documented in ``uuu -udev``):
+
+   .. code-block:: console
+
+      host:~$ sudo sh -c "uuu -udev >> /etc/udev/rules.d/70-uuu.rules"
+      host:~$ sudo udevadm control --reload
+
+Get Images
+..........
+
+Download imx-boot from our server or get it from your Yocto build directory at
+build/deploy/images/|yocto-machinename|/. For flashing a wic image to eMMC,
+you will also need |yocto-imagename|-|yocto-machinename|.wic.
+
+Prepare Target
+..............
+
+Set the |ref-bootswitch| to **USB Serial Download**. Also, connect USB port
+|ref-usb-otg| to your host.
+
+Starting bootloader via UUU-Tool
+................................
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b spl imx-boot
+
+You can see the bootlog on the console via |ref-debugusbconnector|, as usual.
+
+.. note::
+   The default boot command when booting with UUU-Tool is set to fastboot. If
+   you want to change this, please adjust the environment variable bootcmd_mfg
+   in U-boot prompt with setenv bootcmd_mfg. Please note, when booting with
+   UUU-tool the default environment is loaded. Saveenv has no effect. If you
+   want to change the boot command permanently for UUU-boot, you need to change
+   this in U-Boot code.
+
+Flashing U-boot Image to eMMC via UUU-Tool
+...........................................
+
+.. warning::
+
+   UUU flashes U-boot into eMMC BOOT (hardware) boot partitions, and it sets
+   the BOOT_PARTITION_ENABLE in the eMMC! This is a problem since we want the
+   bootloader to reside in the eMMC USER partition. Flashing next U-Boot version
+   .wic image and not disabling BOOT_PARTITION_ENABLE bit will result in device
+   always using U-boot saved in BOOT partitions. To fix this in U-Boot:
+
+   .. code-block:: console
+      :substitutions:
+
+      u-boot=> mmc partconf |u-boot-emmc-devno| 0 0 0
+      u-boot=> mmc partconf |u-boot-emmc-devno|
+      EXT_CSD[179], PARTITION_CONFIG:
+      BOOT_ACK: 0x0
+      BOOT_PARTITION_ENABLE: 0x0
+      PARTITION_ACCESS: 0x0
+
+   or check |ref-disable-emmc-part| from Linux.
+
+   This way the bootloader is still flashed to eMMC BOOT partitions but it is
+   not used!
+
+   When using **partup** tool and ``.partup`` package for eMMC flashing this is
+   done by default, which makes partup again superior flash option.
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b emmc imx-boot
+
+Flashing wic Image to eMMC via UUU-Tool
+...........................................
+
+Execute and power up the board:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ sudo uuu -b emmc_all imx-boot |yocto-imagename|-|yocto-machinename|.wic
+
+.. include:: /bsp/imx-common/development/standalone_build_preface.rsti
+.. include:: /bsp/imx-common/development/standalone_build_u-boot_binman.rsti
+   :end-before: .. build-uboot-marker
+
+*  Get the U-Boot sources:
+
+   .. code-block:: console
+
+      host:~$ git clone git://git.phytec.de/u-boot-imx
+
+*  To get the correct *U-Boot* **tag** you need to take a look at our release
+   notes, which can be found here: `release notes <releasenotes_>`_
+*  The **tag** needed at this release is called |u-boot-tag|
+*  Check out the needed *U-Boot* **tag**:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ cd ~/u-boot-imx/
+   host:~$ git fetch --all --tags
+   host:~$ git checkout tags/|u-boot-tag|
+
+*  Technically, you can now build the U-Boot, but practically there are some
+   further steps necessary:
+
+   *  Create your own development branch:
+
+      .. code-block:: console
+
+         host:~$ git switch --create <new-branch>
+
+      .. note::
+
+         You can name your development branch as you like, this is just an example.
+
+*  Copy all binaries into the U-Boot build directory
+*  Set up a build environment:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ source /opt/|yocto-distro|/|yocto-manifestname|/environment-setup-cortexa53-crypto-phytec-linux
+
+*  Set this environment variable before building the Image:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ export ATF_LOAD_ADDR=|atfloadaddr|
+
+*  build flash.bin (imx-boot):
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ make phycore-|kernel-socname|_defconfig
+      host:~$ make flash.bin
+
+The flash.bin can be found at u-boot-imx/ directory and now can be flashed. A
+chip-specific offset is needed:
+
+.. _offset-table:
+
+===== =================== ============================= ============
+SoC   Offset User Area    Offset Boot Partition         eMMC Device
+===== =================== ============================= ============
+|soc| |u-boot-offset| kiB |u-boot-offset-boot-part| kiB /dev/mmcblk2
+===== =================== ============================= ============
+
+E.g. flash SD card:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
+
+.. hint::
+   The specific offset values are also declared in the Yocto variables "BOOTLOADER_SEEK" and "BOOTLOADER_SEEK_EMMC"
+
+.. include:: /bsp/imx-common/development/standalone_build_u-boot_binman.rsti
+   :start-after: .. build-uboot-fixed-ram-size-marker
+
+.. include:: /bsp/imx-common/development/standalone_build_kernel.rsti
+
+.. include:: /bsp/imx8/development/development_manifests.rsti
+
+.. include:: /bsp/imx8/development/upstream_manifest.rsti
+
+.. include:: /bsp/imx-common/development/format_sd-card.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVICE TREE
+.. +---------------------------------------------------------------------------+
+
+.. _imx8mp-pd22.1.1-device-tree:
+
+Device Tree (DT)
+================
+
+Introduction
+------------
+
+The following text briefly describes the Device Tree and can be found in
+the Linux kernel Documentation
+(https://docs.kernel.org/devicetree/usage-model.html)
+
+*"The “Open Firmware Device Tree”, or simply Devicetree (DT), is a data
+structure and language for describing hardware. More specifically, it is a
+description of hardware that is readable by an operating system so that the
+operating system doesn't need to hard code details of the machine."*
+
+The kernel documentation is a really good source for a DT introduction. An
+overview of the device tree data format can be found on the device tree usage
+page at `devicetree.org <https://www.devicetree.org/>`_.
+
+PHYTEC |soc| BSP Device Tree Concept
+------------------------------------
+
+The following sections explain some rules PHYTEC has defined on how to set up
+device trees for our |soc| SoC-based boards.
+
+Device Tree Structure
+.....................
+
+*  *Module.dtsi* - Module includes all devices mounted on the SoM, such as PMIC
+   and RAM.
+*  *Carrierboard.dtsi* - Devices that come from the |soc| SoC but are just routed
+   down to the carrier board and used there are included in this dtsi.
+*  *Board.dts* - include the carrier board and module dtsi files. There may also
+   be some hardware configuration nodes enabled on the carrier board or the
+   module (i.e. the Board .dts shows the special characteristics of the board
+   configuration). For example, there are phyCORE-|soc| SOMs which may or may not
+   have a MIPI DSI to LVDS converter mounted. The converter is enabled (if
+   available) in the Board .dts and not in the Module .dtsi
+
+From the root directory of the Linux Kernel our devicetree files for |socfamily|
+platforms can be found in ``arch/arm64/boot/dts/freescale/``.
+
+Device Tree Overlay
+...................
+
+Device Tree overlays are device tree fragments that can be merged into a device
+tree during boot time. These are for example hardware descriptions of an
+expansion board. They are instead of being added to the device tree as an extra
+include, now applied as an overlay. They also may only contain setting the
+status of a node depending on if it is mounted or not. The device tree overlays
+are placed next to the other device tree files in our Linux kernel repository in
+the subfolder ``arch/arm64/boot/dts/freescale/overlays``.
+
+Available overlays for |yocto-machinename|.conf are:
+
+.. code-block::
+
+   imx8mp-isi-csi1.dtbo
+   imx8mp-isi-csi2.dtbo
+   imx8mp-isp-csi1.dtbo
+   imx8mp-isp-csi2.dtbo
+   imx8mp-phyboard-pollux-peb-av-010.dtbo
+   imx8mp-phyboard-pollux-peb-av-012.dtbo
+   imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+   imx8mp-phycore-no-eth.dtbo
+   imx8mp-phycore-no-rtc.dtbo
+   imx8mp-phycore-no-spiflash.dtbo
+   imx8mp-phycore-rpmsg.dtbo
+   imx8mp-vm016-csi1.dtbo
+   imx8mp-vm016-csi1-fpdlink.dtbo
+   imx8mp-vm016-csi2.dtbo
+   imx8mp-vm016-csi2-fpdlink.dtbo
+   imx8mp-vm017-csi1.dtbo
+   imx8mp-vm017-csi1-fpdlink.dtbo
+   imx8mp-vm017-csi2.dtbo
+   imx8mp-vm017-csi2-fpdlink.dtbo
+
+.. hint::
+   There is one more overlay available for phyboard-pollux-imx8mp-2.conf:
+   imx8mp-phyboard-pollux-1552.1.dtbo
+
+.. _imx8mp-pd22.1.1-ubootexternalenv:
+.. include:: ../dt-overlays.rsti
+
+.. +---------------------------------------------------------------------------+
+.. ACCESSING PERIPHERALS
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/peripherals/introduction.rsti
+
+.. include:: /bsp/imx-common/peripherals/pin-muxing.rsti
+
+The following is an example of the pin muxing of the UART1 device in
+imx8mp-phyboard-pollux.dtsi:
+
+.. code-block::
+
+   pinctrl_uart1: uart1grp {
+           fsl,pins = <
+                   MX8MP_IOMUXC_UART1_RXD_UART1_DCE_RX     0x49
+                   MX8MP_IOMUXC_UART1_TXD_UART1_DCE_TX     0x49
+           >;
+   };
+
+The first part of the string MX8MP_IOMUXC_UART1_RXD_UART1_DCE_RX names the pad
+(in this example UART1_RXD). The second part of the string (UART1_DCE_RX) is the
+desired muxing option for this pad. The pad setting value (hex value on the
+right) defines different modes of the pad, for example, if internal pull
+resistors are activated or not. In this case, the internal resistors are
+disabled.
+
+RS232/RS485
+-----------
+
+The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
+to USB converter expansion. This USB is brought out at Micro-USB connector X1.
+UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
+multi-protocol transceiver for RS-232 and RS-485, available at pin header
+connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
+configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
+|ref-jp4| on the baseboard. For more information about the correct setup please
+refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+
+We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
+enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
+using ioctls. Have a look at our small example application rs485test, which is
+also included in the BSP. The jumpers |ref-jp3| and |ref-jp4| need to be set
+correctly.
+
+.. include:: /bsp/peripherals/rs232.rsti
+.. include:: /bsp/peripherals/rs485.rsti
+
+The device tree representation for RS232 and RS485:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n331`
+
+.. _imx8mp-pd22.1.1-network:
+
+Network
+-------
+
+|sbc|-|soc| provides two ethernet interfaces. A gigabit Ethernet is provided by our
+module and board.
+
+.. warning::
+
+   The naming convention of the Ethernet interfaces in the hardware (ethernet0
+   and ethernet1) do not align with the network interfaces (eth0 and eth1) in
+   Linux. So, be aware of these differences:
+
+   | ethernet1 = eth0
+   | ethernet0 = eth1
+
+.. include:: /bsp/imx-common/peripherals/network.rsti
+
+.. include:: wireless-network.rsti
+
+.. include:: ../../peripherals/wireless-network.rsti
+
+.. note::
+
+   If the connection fails with the error message: "Failed to connect:
+   org.bluez.Error.Failed" try restarting PulseAudio with:
+
+   .. code-block:: console
+
+      target:~$ pulseaudio --start
+
+.. include:: /bsp/imx-common/peripherals/sd-card.rsti
+
+DT configuration for the MMC (SD card slot) interface can be found here:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n367`
+
+DT configuration for the eMMC interface can be found here:
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n220`
+
+eMMC Devices
+------------
+
+PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+main storage. eMMC devices contain raw MLC memory cells combined with a memory
+controller that handles ECC and wear leveling. They are connected via an SD/MMC
+interface to the |soc| and are represented as block devices in the Linux kernel
+like SD cards, flash drives, or hard disks.
+
+The electric and protocol specifications are provided by JEDEC
+(https://www.jedec.org/standards-documents/technology-focus-areas/flash-memory-ssds-ufs-emmc/e-mmc).
+The eMMC manufacturer's datasheet is relatively short and meant to be read
+together with the supported version of the JEDEC eMMC standard.
+
+PHYTEC currently utilizes the eMMC chips with JEDEC Version 5.0 and 5.1
+
+Extended CSD Register
+.....................
+
+eMMC devices have an extensive amount of extra information and settings that are
+available via the Extended CSD registers. For a detailed list of the registers,
+see manufacturer datasheets and the JEDEC standard.
+
+In the Linux user space, you can query the registers:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ mmc extcsd read /dev/|emmcdev|
+
+You will see:
+
+.. code-block::
+
+   =============================================
+      Extended CSD rev 1.7 (MMC 5.0)
+   =============================================
+
+    Card Supported Command sets [S_CMD_SET: 0x01]
+    [...]
+
+Enabling Background Operations (BKOPS)
+......................................
+
+In contrast to raw NAND Flash, an eMMC device contains a Flash Transfer Layer
+(FTL) that handles the wear leveling, block management, and ECC of the raw MLC
+cells. This requires some maintenance tasks (for example erasing unused blocks)
+that are performed regularly. These tasks are called **Background
+Operations (BKOPS)**.
+
+By default (depending on the chip), the background operations may or may not be
+executed periodically, impacting the worst-case read and write latency.
+
+The JEDEC Standard has specified a method since version v4.41 that the host can
+issue BKOPS manually. See the JEDEC Standard chapter Background Operations and
+the description of registers BKOPS_EN (Reg: 163) and BKOPS_START (Reg: 164) in
+the eMMC datasheet for more details.
+
+Meaning of Register BKOPS_EN (Reg: 163) Bit MANUAL_EN (Bit 0):
+
+*  Value 0: The host does not support the manual trigger of BKOPS. Device write
+   performance suffers.
+*  Value 1: The host does support the manual trigger of BKOPS. It will issue
+   BKOPS from time to time when it does not need the device.
+
+The mechanism to issue background operations has been implemented in
+the Linux kernel since v3.7. You only have to enable BKOPS_EN on the eMMC device
+(see below for details).
+
+The JEDEC standard v5.1 introduces a new automatic BKOPS feature. It frees the
+host to trigger the background operations regularly because the device starts
+BKOPS itself when it is idle (see the description of bit AUTO_EN in
+register BKOPS_EN (Reg: 163)).
+
+The userspace tool mmc does not currently support enabling automatic BKOPS
+features.
+
+*  To check whether *BKOPS_EN* is set, execute:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ mmc extcsd read /dev/|emmcdev| | grep BKOPS_EN
+
+   The output will be, for example:
+
+   .. code-block::
+
+      Enable background operations handshake [BKOPS_EN]: 0x01
+      #OR
+      Enable background operations handshake [BKOPS_EN]: 0x00
+
+   Where value 0x00 means BKOPS_EN is disabled and device write performance
+   suffers. Where value 0x01 means BKOPS_EN is enabled and the host will issue
+   background operations from time to time.
+
+*  To set the BKOPS_EN bit, execute:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ mmc bkops enable /dev/|emmcdev|
+
+*  To ensure that the new setting is taken over and the kernel triggers BKOPS by
+   itself, shut down the system:
+
+   .. code-block:: console
+
+      target:~$ poweroff
+
+.. tip::
+
+   The BKOPS_EN bit is one-time programmable only. It cannot be reversed.
+
+Reliable Write
+..............
+
+There are two different Reliable Write options:
+
+1. Reliable Write option for a whole eMMC device/partition.
+2. Reliable Write for single write transactions.
+
+.. tip::
+
+   Do not confuse eMMC partitions with partitions of a DOS, MBR, or GPT
+   partition table (see the previous section).
+
+The first Reliable Write option is mostly already enabled on the eMMCs mounted
+on the phyCORE-|soc| SoMs. To check this on the running target:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ mmc extcsd read /dev/|emmcdev| | grep -A 5 WR_REL_SET
+   Write reliability setting register [WR_REL_SET]: 0x1f
+    user area: the device protects existing data if a power failure occurs during a write o
+   peration
+    partition 1: the device protects existing data if a power failure occurs during a write
+    operation
+    partition 2: the device protects existing data if a power failure occurs during a write
+    operation
+    partition 3: the device protects existing data if a power failure occurs during a write
+    operation
+    partition 4: the device protects existing data if a power failure occurs during a write
+    operation
+   --
+    Device supports writing EXT_CSD_WR_REL_SET
+    Device supports the enhanced def. of reliable write
+
+Otherwise, it can be enabled with the mmc tool:
+
+.. code-block:: console
+
+   target:~$ mmc --help
+
+   [...]
+   mmc write_reliability set <-y|-n> <partition> <device>
+
+The second Reliable Write option is the configuration bit Reliable Write Request
+parameter (bit 31) in command CMD23. It has been used in the kernel
+since v3.0 by file systems, e.g. ext4 for the journal and user space
+applications such as fdisk for the partition table. In the Linux kernel source
+code, it is handled via the flag REQ_META.
+
+**Conclusion**: ext4 file system with mount option data=journal should be safe
+against power cuts. The file system check can recover the file system after a
+power failure, but data that was written just before the power cut may be lost.
+In any case, a consistent state of the file system can be recovered. To ensure
+data consistency for the files of an application, the system functions fdatasync
+or fsync should be used in the application.
+
+Resizing ext4 Root Filesystem
+.............................
+
+When flashing the sdcard image to eMMC the ext4 root partition is not extended
+to the end of the eMMC. parted can be used to expand the root partition. The
+example works for any block device such as eMMC, SD card, or hard disk.
+
+*  Get the current device size:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ parted /dev/|emmcdev| print
+
+*  The output looks like this:
+
+   .. code-block::
+      :substitutions:
+
+      Model: MMC Q2J55L (sd/mmc)
+      Disk /dev/|emmcdev|: 7617MB
+      Sect[ 1799.850385]  |emmcdev|: p1 p2
+      or size (logical/physical): 512B/512B
+      Partition Table: msdos
+      Disk Flags:
+
+      Number  Start   End     Size    Type     File system  Flags
+       1      4194kB  72.4MB  68.2MB  primary  fat16        boot, lba
+       2      72.4MB  537MB   465MB   primary  ext4
+
+*  Use parted to resize the root partition to the max size of the device:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ parted /dev/|emmcdev| resizepart 2 100%
+      Information: You may need to update /etc/fstab.
+
+      target:~$ parted /dev/|emmcdev| print
+      Model: MMC Q2J55L (sd/mmc)
+      Disk /dev/|emmcdev|: 7617MB
+      Sector size (logical/physical): 512[ 1974.191657]  |emmcdev|: p1 p2
+      B/512B
+      Partition Table: msdos
+      Disk Flags:
+
+      Number  Start   End     Size    Type     File system  Flags
+       1      4194kB  72.4MB  68.2MB  primary  fat16        boot, lba
+       2      72.4MB  7617MB  7545MB  primary  ext4
+
+Increasing the filesystem size can be done while it is mounted.  But you can
+also boot the board from an SD card and then resize the file system on the eMMC
+partition while it is not mounted.
+
+*  Resize the filesystem to a new partition size:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ resize2fs /dev/|emmcdev|p2
+      resize2fs 1.46.1 (9-Feb-2021)
+      Filesystem at /dev/|emmcdev|p2 is mounted on /; on-line resizing required
+      [ 131.609512] EXT4-fs (|emmcdev|p2): resizing filesystem
+      from 454136 to 7367680 blocks
+      old_desc_blocks = 4, new_desc_blocks = 57
+      [ 131.970278] EXT4-fs (|emmcdev|p2): resized filesystem to 7367680
+      The filesystem on /dev/|emmcdev|p2 is now 7367680 (1k) blocks long
+
+Enable pseudo-SLC Mode
+......................
+
+eMMC devices use MLC memory cells
+(https://en.wikipedia.org/wiki/Multi-level_cell) to store the data. Compared
+with SLC memory cells used in NAND Flash, MLC memory cells have lower
+reliability and a higher error rate at lower costs.
+
+If you prefer reliability over storage capacity, you can enable
+the pseudo-SLC mode or SLC mode. The method used here employs the enhanced
+attribute, described in the JEDEC standard, which can be set for continuous
+regions of the device. The JEDEC standard does not specify the implementation
+details and the guarantees of the enhanced attribute. This is left to the
+chipmaker. For the Micron chips, the enhanced attribute increases the
+reliability but also halves the capacity.
+
+.. warning::
+
+   When enabling the enhanced attribute on the device, all data will be lost.
+
+The following sequence shows how to enable the enhanced attribute.
+
+*  First obtain the current size of the eMMC device with:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ parted -m /dev/|emmcdev| unit B print
+
+   You will receive:
+
+   .. code-block::
+      :substitutions:
+
+      BYT;
+      /dev/|emmcdev|:63652757504B:sd/mmc:512:512:unknown:MMC S0J58X:;
+
+   As you can see this device has 63652757504 Byte = 60704 MiB.
+
+*  To get the maximum size of the device after pseudo-SLC is enabled use:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ mmc extcsd read /dev/|emmcdev| | grep ENH_SIZE_MULT -A 1
+
+   which shows, for example:
+
+   .. code-block::
+
+      Max Enhanced Area Size [MAX_ENH_SIZE_MULT]: 0x000764
+      i.e. 3719168 KiB
+      --
+      Enhanced User Data Area Size [ENH_SIZE_MULT]: 0x000000
+      i.e. 0 KiB
+
+   Here the maximum size is 3719168 KiB = 3632 MiB.
+
+*  Now, you can set enhanced attribute for the whole device, e.g. 3719168 KiB, by
+   typing:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ mmc enh_area set -y 0 3719168 /dev/|emmcdev|
+
+   You will get:
+
+   .. code-block::
+      :substitutions:
+
+      Done setting ENH_USR area on /dev/|emmcdev|
+      setting OTP PARTITION_SETTING_COMPLETED!
+      Setting OTP PARTITION_SETTING_COMPLETED on /dev/|emmcdev| SUCCESS
+      Device power cycle needed for settings to take effect.
+      Confirm that PARTITION_SETTING_COMPLETED bit is set using 'extcsd read' after power cycle
+
+*  To ensure that the new setting has taken over, shut down the system:
+
+   .. code-block:: console
+
+      target:~$ poweroff
+
+   and perform a power cycle. It is recommended that you verify the settings now.
+
+*  First, check the value of ENH_SIZE_MULT which must be 3719168 KiB:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ mmc extcsd read /dev/|emmcdev| | grep ENH_SIZE_MULT  -A 1
+
+   You should receive::
+
+      Max Enhanced Area Size [MAX_ENH_SIZE_MULT]: 0x000764
+      i.e. 3719168 KiB
+      --
+      Enhanced User Data Area Size [ENH_SIZE_MULT]: 0x000764
+      i.e. 3719168 KiB
+
+*  Finally, check the size of the device:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ parted -m /dev/|emmcdev| unit B print
+      BYT;
+      /dev/|emmcdev|:31742492672B:sd/mmc:512:512:unknown:MMC S0J58X:;
+
+Erasing the Device
+..................
+
+It is possible to erase the eMMC device directly rather than overwriting it with
+zeros. The eMMC block management algorithm will erase the underlying MLC memory
+cells or mark these blocks as discard. The data on the device is lost and will
+be read back as zeros.
+
+*  After booting from SD Card execute:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ blkdiscard -f --secure /dev/|emmcdev|
+
+   The option --secure ensures that the command waits until the eMMC device has
+   erased all blocks. The -f (force) option disables all checking before erasing
+   and it is needed when the eMMC device contains existing partitions with data.
+
+.. tip::
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ dd if=/dev/zero of=/dev/|emmcdev| conv=fsync
+
+   also destroys all information on the device, but this command is bad for wear
+   leveling and takes much longer!
+
+.. include:: /bsp/imx-common/emmc.rsti
+
+.. include:: ../peripherals/spi-master.rsti
+
+The definition of the SPI master node in the device tree can be found here:
+
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n72`
+
+GPIOs
+-----
+
+The |sbc| has a set of pins especially dedicated to user I/Os. Those pins are
+connected directly to |soc| pins and are muxed as GPIOs. They are directly
+usable in Linux userspace. The processor has organized its GPIOs into five banks
+of 32 GPIOs each (GPIO1 – GPIO5)
+GPIOs. gpiochip0, gpiochip32, gpiochip64, gpiochip96, and gpiochip128 are
+the sysfs representation of these internal |soc| GPIO banks GPIO1 – GPIO5.
+
+The GPIOs are identified as GPIO<X>_<Y> (e.g. GPIO5_07). <X> identifies the GPIO
+bank and counts from 1 to 5, while <Y> stands for the GPIO within the bank. <Y>
+is being counted from 0 to 31 (32 GPIOs on each bank).
+
+By contrast, the Linux kernel uses a single integer to enumerate all available
+GPIOs in the system. The formula to calculate the right number is:
+
+.. code-block::
+
+   Linux GPIO number: <N> = (<X> - 1) * 32 + <Y>
+
+Accessing GPIOs from userspace will be done using the libgpiod. It provides a
+library and tools for interacting with the Linux GPIO character device. Examples
+of some usages of various tools:
+
+*  Detecting the gpiochips on the chip:
+
+   .. code-block:: console
+
+      target:~$ gpiodetect
+      gpiochip0 [30200000.gpio] (32 lines)
+      gpiochip1 [30210000.gpio] (32 lines)
+      gpiochip2 [30220000.gpio] (32 lines)
+      gpiochip3 [30230000.gpio] (32 lines)
+      gpiochip4 [30240000.gpio] (32 lines)
+
+*  Show detailed information about the gpiochips. Like their names, consumers,
+   direction, active state, and additional flags:
+
+   .. code-block:: console
+
+      target:~$ gpioinfo gpiochip0
+
+*  Read the value of a GPIO (e.g GPIO 20 from chip0):
+
+   .. code-block:: console
+
+      target:~$ gpioget gpiochip0 20
+
+*  Set the value of GPIO 20 on chip0 to 0 and exit tool:
+
+   .. code-block:: console
+
+      target:~$ gpioset --mode=exit gpiochip0 20=0
+
+*  Help text of gpioset shows possible options:
+
+   .. code-block:: console
+
+      target:~$ gpioset --help
+      Usage: gpioset [OPTIONS] <chip name/number> <offset1>=<value1> <offset2>=<value2> ...
+      Set GPIO line values of a GPIO chip
+
+      Options:
+        -h, --help:           display this message and exit
+        -v, --version:        display the version and exit
+        -l, --active-low:     set the line active state to low
+        -m, --mode=[exit|wait|time|signal] (defaults to 'exit'):
+                      tell the program what to do after setting values
+        -s, --sec=SEC:        specify the number of seconds to wait (only valid for --mode=time)
+        -u, --usec=USEC:      specify the number of microseconds to wait (only valid for --mode=time)
+        -b, --background:     after setting values: detach from the controlling terminal
+
+      Modes:
+        exit:         set values and exit immediately
+        wait:         set values and wait for user to press ENTER
+        time:         set values and sleep for a specified amount of time
+        signal:       set values and wait for SIGINT or SIGTERM
+
+      Note: the state of a GPIO line controlled over the character device reverts to default
+      when the last process referencing the file descriptor representing the device file exits.
+      This means that it's wrong to run gpioset, have it exit and expect the line to continue
+      being driven high or low. It may happen if given pin is floating but it must be interpreted
+      as undefined behavior.
+
+
+.. warning::
+
+   Some of the user IOs are used for special functions. Before using a user IO,
+   refer to the schematic or the hardware manual of your board to ensure that it
+   is not already in use.
+
+.. include:: ../peripherals/gpios.rsti
+   :start-after: .. gpios-via-sysfs-marker
+
+LEDs
+----
+
+If any LEDs are connected to GPIOs, you have the possibility to access them by a
+special LED driver interface instead of the general GPIO interface (section
+GPIOs). You will then access them using ``/sys/class/leds/`` instead
+of ``/sys/class/gpio/``. The maximum brightness of the LEDs can be read from
+the ``max_brightness`` file. The brightness file will set the brightness of the LED
+(taking a value from 0 up to max_brightness). Most LEDs do not have hardware
+brightness support and will just be turned on by all non-zero brightness
+settings.
+
+Below is a simple example.
+
+To get all available LEDs, type:
+
+.. code-block:: console
+
+   target:~$ ls /sys/class/leds
+   mmc1::@    mmc2::@    user-led1@ user-led2@ user-led3@
+
+Here the LEDs blue-mmc, green-heartbeat, and red-emmc are on the |sbc|.
+
+*  To toggle the LEDs ON:
+
+   .. code-block:: console
+
+      target:~$ echo 255 > /sys/class/leds/user-led1/brightness
+
+*  To toggle OFF:
+
+   .. code-block:: console
+
+      target:~$ echo 0 > /sys/class/leds/user-led1/brightness
+
+Device tree configuration for the User I/O configuration can be found here:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n216`
+
+.. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
+
+General I²C1 bus configuration (e.g. |dt-som|.dtsi):
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n105`
+
+General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n201`
+
+
+EEPROM
+------
+
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) and the ID-page (bus: I2C-0
+address: 0x59) can be accessed via the sysfs interface in Linux. The first
+256 bytes of the main EEPROM and the ID-page are used for board detection and
+must not be overwritten. Overwriting reserved spaces will result in boot issues.
+
+.. include:: ../peripherals/eeprom.rsti
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on both EEPROM data spaces. If
+you have accidentally deleted or overwritten the normal area, you can copy the
+hardware introspection from the ID area to the normal area.
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-0/device/0-0059/eeprom of=/sys/class/i2c-dev/i2c-0/device/0-0051/eeprom bs=1
+
+.. note::
+
+   If you deleted both EEPROM spaces, please contact our support!
+
+DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+found in our PHYTEC git:
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n201`
+
+.. include:: ../../peripherals/rtc.rsti
+   :end-before: .. rtc_parameter_start_label
+
+DT representation for I²C RTCs:
+:imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n207`
+
+USB Host Controller
+-------------------
+
+The USB controller of the |soc| SoC provides a low-cost connectivity solution
+for numerous consumer portable devices by providing a mechanism for data
+transfer between USB devices with a line/bus speed of up to 4 Gbit/s (SuperSpeed
+'SS'). The USB subsystem has two independent USB controller cores. Both cores
+are capable of acting as a USB peripheral device or a USB host. Each is
+connected to a USB 3.0 PHY.
+
+.. include:: /bsp/peripherals/usb-host.rsti
+
+DT representation for USB Host:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n341`
+
+CAN FD
+------
+
+The |sbc| two flexCAN interfaces supporting CAN FD. They are supported by the
+Linux standard CAN framework which builds upon then the Linux network layer.
+Using this framework, the CAN interfaces behave like an ordinary Linux network
+device, with some additional features special to CAN. More information can be
+found in the Linux Kernel
+documentation: https://www.kernel.org/doc/html/latest/networking/can.html
+
+.. include:: ../peripherals/canfd.rsti
+
+Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n165`
+
+.. include:: /bsp/peripherals/pcie.rsti
+
+Device Tree PCIe configuration of imx8mm-phyboard-polis.dtsi:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n277`
+
+Audio
+-----
+
+Playback devices supported for |sbc| are HDMI and the TI TLV320AIC3007 audio
+codec on the PEB-AV-10 connector. On the AV-Connector there is a 3.5mm headset
+jack with OMTP-standard and an 8-pin header. The 8-pin header contains a mono
+speaker, headphones, and line in signals.
+
+.. note::
+
+   Using the PEB-AV-10 connector for display output along HDMI as audio output
+   is not supported. The audio output device must match the video output device.
+
+To check if your soundcard driver is loaded correctly and what the device is
+called, type for playback devices:
+
+.. code-block:: console
+
+   target:~$ aplay -L
+
+Or type for recording devices:
+
+.. code-block:: console
+
+   target:~$ arecord -L
+
+Alsamixer
+.........
+
+To inspect the capabilities of your soundcard, call:
+
+.. code-block:: console
+
+   target:~$ alsamixer
+
+You should see a lot of options as the audio-IC has many features you can
+experiment with. It might be better to open alsamixer via ssh instead of the
+serial console, as the console graphical effects are better. You have either
+mono or stereo gain controls for all mix points. "MM" means the feature is muted
+(both output, left & right), which can be toggled by hitting **m**. You can also
+toggle by hitting '**<**' for left and '**>**' for right output. With the **tab**
+key, you can switch between controls for playback and recording.
+
+ALSA configuration
+..................
+
+Our BSP comes with a ALSA configuration file ``/etc/asound.conf``.
+
+The ALSA configuration file can be edited as desired or deleted since it is not
+required for ALSA to work properly.
+
+.. code-block:: console
+
+   target:~$ vi /etc/asound.conf
+
+To set PEB-AV-10 as output, set *playback.pcm* from "dummy" to "pebav10":
+
+.. code-block::
+
+   [...]
+
+   pcm.asymed {
+           type asym
+           playback.pcm "pebav10"
+           capture.pcm "dsnoop"
+   }
+
+   [...]
+
+If the sound is not audible change playback devices to the software volume control
+playback devices, set *playback.pcm* to the respective softvol playback device either
+"softvol_hdmi" or "softvol_pebav10". Use alsamixer controls to vary the volume levels.
+
+.. code-block::
+
+   [...]
+
+   pcm.asymed {
+           type asym
+           playback.pcm "softvol_hdmi"
+           capture.pcm "dsnoop"
+   }
+
+   [...]
+
+Pulseaudio Configuration
+........................
+
+For applications using Pulseaudio, check for available sinks:
+
+.. code-block:: console
+
+   target:~$ pactl list short sinks
+   0   alsa_output.platform-snd_dummy.0.stereo-fallback    module-alsa-card.c  s16le 2ch 44100Hz   SUSPENDED
+   1   alsa_output.platform-sound-peb-av-10.stereo-fallback    module-alsa-card.c  s16le 2ch 44100Hz   SUSPENDED
+
+To select PEB-AV-10, type:
+
+.. code-block:: console
+
+   target:~$ pactl set-default-sink 1
+
+Playback
+........
+
+Run speaker-test to check playback availability:
+
+.. code-block:: console
+
+   target:~$ speaker-test -c 2 -t wav
+
+To playback simple audio streams, you can use aplay. For example to play the
+ALSA test sounds:
+
+.. code-block:: console
+
+   target:~$ aplay /usr/share/sounds/alsa/*
+
+To playback other formats like mp3 for example, you can use Gstreamer:
+
+.. code-block:: console
+
+   target:~$ gst-launch-1.0 playbin uri=file:/path/to/file.mp3
+
+Capture
+.......
+
+``arecord`` is a command-line tool for capturing audio streams which use Line In as
+the default input source. To select a different audio source you can
+use ``alsamixer``. For example, switch on *Right PGA Mixer Mic3R* and *Left PGA Mixer
+Mic3R* in order to capture the audio from the microphone input of the
+TLV320-Codec using the 3.5mm jack.
+
+.. code-block:: console
+
+   target:~$ amixer -c "sndpebav10" sset 'Left PGA Mixer Mic3R' on
+   target:~$ amixer -c "sndpebav10" sset 'Right PGA Mixer Mic3R' on
+
+.. code-block:: console
+
+   target:~$ arecord -t wav -c 2 -r 44100 -f S16_LE test.wav
+
+.. hint::
+
+   Since playback and capture share hardware interfaces, it is not possible to
+   use different sampling rates and formats for simultaneous playback and
+   capture operations.
+
+Device Tree Audio configuration:
+:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n57`
+
+Video
+-----
+
+Videos with Gstreamer
+.....................
+
+The video is installed by default in the BSP:
+
+.. code-block:: console
+
+   target:~$ gst-launch-1.0 playbin uri=file:///usr/share/phytec-qtdemo/videos/caminandes.webm
+
+*  Or:
+
+.. code-block:: console
+
+   target:~$ gst-launch-1.0 -v filesrc location=<video.mp4> \
+   \! qtdemux  \! h264parse \! queue \! vpudec \! waylandsink async=false enable-last-sample=false \
+   qos=false sync=false
+
+*  Or:
+
+.. code-block:: console
+
+   target:~$ gplay-1.0 /usr/share/phytec-qtdemo/videos/caminandes.webm
+
+kmssink Plugin ID Evaluation
+............................
+
+The kmssink plugin needs a connector ID. To get the connector ID, you can use
+the tool modetest.
+
+.. code-block:: console
+
+   target:~$ modetest -c imx-drm
+
+The output will show something like:
+
+.. code-block::
+
+   Connectors:
+   id  encoder status      name        size (mm)   modes   encoders
+   35  34  connected   LVDS-1          216x135     1   34
+     modes:
+       index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot
+     #0 1280x800 59.07 1280 1380 1399 1440 800 804 808 823 70000 flags: phsync, pvsync; type: preferred, driver
+     props:
+       1 EDID:
+           flags: immutable blob
+           blobs:
+
+           value:
+       2 DPMS:
+           flags: enum
+           enums: On=0 Standby=1 Suspend=2 Off=3
+           value: 0
+       5 link-status:
+           flags: enum
+           enums: Good=0 Bad=1
+           value: 0
+       6 non-desktop:
+           flags: immutable range
+           values: 0 1
+           value: 0
+       4 TILE:
+           flags: immutable blob
+           blobs:
+
+           value:
+
+Display
+-------
+
+The |sbc| supports up to 4 different display outputs. Three can be used
+simultaneously. The following table shows the required extensions and devicetree
+overlays for the different interfaces.
+
+========= ======================== ======================================
+Interface Expansion                devicetree overlay
+========= ======================== ======================================
+HDMI      |sbc|                    no overlay needed (enabled by default)
+LVDS0     PEB-AV-10                imx8mp-phyboard-pollux-peb-av-010.dtbo
+                                   (loaded by default)
+LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
+MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo
+========= ======================== ======================================
+
+.. note::
+
+   *  HDMI will not work if LVDS1 (onboard) is enabled.
+   *  When changing Weston output, make sure to match the audio output as well.
+   *  LVDS0 (PEB-AV-10) and LVDS1 (onboard)can not be used at the same time.
+
+HDMI is always enabled in the devicetree. The other interfaces can be enabled
+with Device Tree Overlay.
+
+The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-010). We support a
+10'' edt,etml1010g0dka display for the PEB-AV-10 and PEB-AV-12.
+
+.. note::
+
+   The current display driver limits the pixel clock for a display connected to
+   LVDS to 74.25Mhz (or a divider of it).  If this does not fit your display
+   requirements, please contact Support for further help.
+
+Weston Configuration
+....................
+
+In order to get an output from Weston on the correct display, it still needs to
+be configured correctly. This will be done at /etc/xdg/weston/weston.ini.
+
+Single Display
+~~~~~~~~~~~~~~
+
+In our BSP, the default Weston output is set to HDMI. ::
+
+   [output]
+   name=HDMI-A-1
+   mode=current
+
+.. include:: /bsp/qt5.rsti
+
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+Device tree description of LVDS-1 and HDMI can be found here:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n255`
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n180`
+
+The device tree of LVDS-0 on PEB-AV-10 can be found here:
+:imx-dt:`overlays/imx8mp-phyboard-pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n132`
+
+.. include:: ../peripherals/pm.rsti
+
+.. include:: ../peripherals/tm.rsti
+
+The device tree description of GPIO Fan can be found here:
+:imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n26`
+
+.. include:: /bsp/peripherals/watchdog.rsti
+
+.. include:: ../peripherals/snvs-power-key.rsti
+
+NPU
+---
+
+The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an accelerator
+for artificial intelligence operations. Refer to our latest phyCORE-|soc| AI Kit
+Guide on the phyCORE-|soc| download section to get information about the
+NPU: `L-1015e.A0 phyCORE-i.MX 8M Plus AI Kit Guide
+<https://www.phytec.de/cdocuments/?doc=ZQBhDw>`_
+
+NXP Examples for eIQ
+....................
+
+NXP provides a set of machine learning examples for eIQ using Python3. To add a
+pre-configured machine learning package group, add to your local.conf and build
+your BSP::
+
+   IMAGE_INSTALL_append = " packagegroup-imx-ml python3-pip python3-requests opencv"
+
+This will require about 1GB of additional space on the SD Card. Instructions
+on how to install and use the NXP examples can be found at
+https://community.nxp.com/t5/Blogs/PyeIQ-3-x-Release-User-Guide/ba-p/1305998.
+
+.. hint::
+
+   The installation of the eiq examples with pip3 requires an internet
+   connection.
+
+.. note::
+
+   On some Ubuntu 20.04 hosts, cmake uses the host's Python 3 instead of Python
+   3.7 from Yocto when building python3-pybind11. (see
+   https://community.nxp.com/t5/i-MX-Processors/Yocto-L5-4-70-2-3-0-build-image-failed/m-p/1219619)
+
+   As a workaround edit, the python3-pybind11 recipe by::
+
+      $ devtool edit-recipe python3-pybind11
+
+   and add to the file::
+
+      EXTRA_OECMAKE += "-DPYTHON_EXECUTABLE=${RECIPE_SYSROOT_NATIVE}/usr/bin/python3-native/python3.7"
+
+.. include:: ../peripherals/isp.rsti
+
+.. include:: ../peripherals/ocotp-ctrl.rsti
+
+Reading the registers using ``/dev/mem`` will cause the system to hang unless the
+*ocotp_root_clk* is enabled. To enable this clock permanent, add to the device
+tree:
+
+.. code-block::
+
+   &clk {
+           init-on-array = <IMX8MP_CLK_OCOTP_ROOT>;
+   };
+
+.. +---------------------------------------------------------------------------+
+.. i.MX 8M Plus M7 Core
+.. +---------------------------------------------------------------------------+
+
+.. include:: ../mcu.rsti
+
+.. +---------------------------------------------------------------------------+
+.. BSP EXTENSIONS
+.. +---------------------------------------------------------------------------+
+
+BSP Extensions
+==============
+
+Chromium
+--------
+
+Our BSP for the |sbc|-|soc| supports Chromium. You can include it in the
+|yocto-imagename| with only a few steps.
+
+Adding Chromium to Your local.conf
+..................................
+
+To include Chromium you have to add the following line into your local.conf. You
+can find it in <yocto_dir>/build/conf/local.conf. This adds Chromium to your
+next image build. ::
+
+   IMAGE_INSTALL_append = " chromium-ozone-wayland"
+
+.. note::
+
+   Compiling Chromium takes a long time.
+
+Get Chromium Running on the Target
+..................................
+
+To run Chromium, it needs a few arguments to use the hardware graphics
+acceleration::
+
+   target$ chromium --use-gl=desktop --enable-features=VaapiVideoDecoder --no-sandbox
+
+If you want to start Chromium via SSH, you must first define the display on
+which Chromium will run. For example::
+
+   target$ DISPLAY=:0
+
+After you have defined this, you can start it via virtual terminal on Weston as
+shown above.

--- a/source/conf.py
+++ b/source/conf.py
@@ -143,6 +143,14 @@ latex_documents = [
         False,
     ),
     (
+        'bsp/imx8/imx8mp/pd22.1.2',
+        'imx8mp-pd22.1.2.tex',
+        'i.MX 8M Plus BSP Manual',
+        'PHYTEC Messtechnik GmbH',
+        'manual',
+        False,
+    ),
+    (
         'bsp/imx8/imx8mp/pd22.1.1',
         'imx8mp-pd22.1.1.tex',
         'i.MX 8M Plus BSP Manual',


### PR DESCRIPTION
Create PD22.1.2 BSP manual based on the PD22.1.1 BSP manual. 

- Adjust all the external links.
- Adjust Kernel and U-Boot tag
- Adjust internal references
- Adjust BSP version and release date

Wait for merge until PD22.1.2 is released for all the external links to work.