### PR TITLE
gh actions: Deploy on release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
     branches: [ main ]
+    tags: ['*']
 
 jobs:
   deploy:


### PR DESCRIPTION
As of now only the release action has been build, but the site did not got deployed to github pages. This change makes the deploy action run after the release has been created.