### PR TITLE
BSPIMX8M-3356 document FIT image standalone build

### DIFF
--- a/source/bsp/imx8/development/kernel-standalone.rsti
+++ b/source/bsp/imx8/development/kernel-standalone.rsti
@@ -1,0 +1,109 @@
+Kernel
+------
+
+The kernel is packaged in a FIT image together with the device tree. U-Boot has
+been adapted to be able to load a FIT image and boot the kernel contained in it.
+As a result, the kernel Image has to packaged in a FIT image.
+
+Setup sources
+.............
+
+*  The used |kernel-repo-name| branch can be found in the `release notes
+   <releasenotes_>`_
+*  The tag needed for this release is called |kernel-tag|
+*  Check out the needed |kernel-repo-name| tag:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ git clone |kernel-repo-url|
+      host:~$ cd ~/|kernel-repo-name|/
+      host:~/|kernel-repo-name|$ git fetch --all --tags
+      host:~/|kernel-repo-name|$ git checkout tags/|kernel-tag|
+
+*  For committing changes, it is highly recommended to switch to a new branch:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|kernel-repo-name|$ git switch --create <new-branch>
+
+*  Set up a build environment:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|kernel-repo-name|$ source /opt/|yocto-distro|/|yocto-sdk-rev|/environment-setup-|yocto-sdk-a-core|-phytec-linux
+
+Build the kernel
+................
+
+*  Build the linux kernel:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|kernel-repo-name|$ make |kernel-defconfig|
+      host:~/|kernel-repo-name|$ make -j$(nproc)
+
+*  Install kernel modules to e.g. NFS directory:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|kernel-repo-name|$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
+
+*  The Image can be found at ~/|kernel-repo-name|/arch/arm64/boot/Image.gz
+*  The dtb can be found at
+   ~/|kernel-repo-name|/arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb
+*  For (re-)building only Devicetrees and -overlays, it is sufficient to run
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|kernel-repo-name|$ make dtbs
+
+.. note::
+
+   If you are facing the following build issue:
+
+   .. code-block::
+
+      scripts/dtc/yamltree.c:9:10: fatal error: yaml.h: No such file or directory
+
+   Make sure you installed the package *"libyaml-dev"* on your host system:
+
+   .. code-block:: console
+
+      host:~$ sudo apt install libyaml-dev
+
+Package the kernel in a FIT image
+.................................
+
+To simply replace the kernel, you will need an ``image tree source`` (.its)
+file. If you already built our BSP with Yocto, you can get the its file from the
+directory mentioned here: |ref-bsp-images| Or you can download the file here:
+|link-bsp-images|
+
+Copy the .its file to the current working directory, create a link to the kernel
+image and create the final fitImage with mkimage.
+
+.. code-block:: console
+   :substitutions:
+
+   host:~/|kernel-repo-name|$ cp /path/to/yocto/deploydir/fitimage-its*.its .
+                     && ln -s arch/arm64/boot/Image.gz linux.bin
+                     && uboot-mkimage -f fitImage-its*.its fitImage
+
+
+Copy FIT image and kernel modules to SD Card
+............................................
+
+When one-time boot via netboot is not sufficient, the FIT image along with the
+kernel modules may be copied directly to a mounted SD card.
+
+.. code-block:: console
+   :substitutions:
+
+   host:~/|kernel-repo-name|$ cp fitImage /path/to/sdcard/boot/
+   host:~/|kernel-repo-name|$ make INSTALL_MOD_PATH=/path/to/sdcard/root/ modules_install

--- a/source/bsp/imx8/development/uboot-standalone.rsti
+++ b/source/bsp/imx8/development/uboot-standalone.rsti
@@ -1,0 +1,149 @@
+U-Boot
+------
+
+Build U-Boot
+............
+
+.. build-uboot-marker
+
+Get the source code
+~~~~~~~~~~~~~~~~~~~
+
+*  Get the U-Boot sources:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ git clone |u-boot-repo-url|
+
+*  To get the correct *U-Boot* **tag** you need to take a look at our release
+   notes, which can be found here: `release notes <releasenotes_>`_
+*  The **tag** used in this release is called |u-boot-tag|
+*  Check out the needed *U-Boot* **tag**:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ cd ~/|u-boot-repo-name|/
+      host:~/|u-boot-repo-name|$ git fetch --all --tags
+      host:~/|u-boot-repo-name|$ git checkout tags/|u-boot-tag|
+
+*  Set up a build environment:
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|u-boot-repo-name|$ source /opt/|yocto-distro|/|yocto-sdk-rev|/environment-setup-|yocto-sdk-a-core|-phytec-linux
+
+Get the needed binaries
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To build the bootloader, you need to copy these files to your |u-boot-repo-name|
+build directory and rename them to fit with *mkimage* script:
+
+*  **ARM Trusted firmware binary** (*mkimage tool* compatible format
+   **bl31.bin**): bl31-|kernel-socname|.bin
+*  **OPTEE image** (optional): tee.bin
+*  **DDR firmware files** (*mkimage tool* compatible format
+   **lpddr4_[i,d]mem_\*d_\*.bin**):
+   lpddr4_dmem_1d_*.bin, lpddr4_dmem_2d_*.bin, lpddr4_imem_1d_*.bin,
+   lpddr4_imem_2d_*.bin
+
+If you already built our BSP with Yocto, you can get the
+bl31-|kernel-socname|.bin, tee.bin and lpddr4_*.bin from the directory mentioned
+here: |ref-bsp-images|
+
+Or you can download the files here: |link-boot-tools|
+
+Build the bootloader
+~~~~~~~~~~~~~~~~~~~~
+
+*  build flash.bin (imx-boot):
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~/|u-boot-repo-name|$ make |u-boot-defconfig|
+      host:~/|u-boot-repo-name|$ make flash.bin
+
+
+Flash the bootloader to a block device
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The flash.bin can be found at |u-boot-repo-name|/ directory and now can be
+flashed. A chip-specific offset is needed:
+
+.. _offset-table:
+
+===== =================== ============================= ============
+SoC   Offset User Area    Offset Boot Partition         eMMC Device
+===== =================== ============================= ============
+|soc| |u-boot-offset| kiB |u-boot-offset-boot-part| kiB /dev/|emmcdev|
+===== =================== ============================= ============
+
+E.g. flash SD card:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~/|u-boot-repo-name|$ sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=|u-boot-offset| conv=sync
+
+.. hint::
+   The specific offset values are also declared in the Yocto variables
+   "BOOTLOADER_SEEK" and "BOOTLOADER_SEEK_EMMC"
+
+.. build-uboot-fixed-ram-size-marker
+
+Build U-Boot With a Fixed RAM Size
+..................................
+
+If you cannot boot your system anymore because the hardware introspection in the
+EEPROM is damaged or deleted, you can create a flash.bin with a fixed ram size.
+You should still contact support and flash the correct EEPROM data, as this
+could lead to unexpected behavior.
+
+Follow the steps to get the U-boot sources and check the correct branch in the
+**Build U-Boot** section.
+
+Edit the file configs/phycore-|kernel-socname|\_defconfig:
+
+.. code-block:: kconfig
+   :substitutions:
+
+   CONFIG_TARGET_PHYCORE_|u-boot-socname-config|=y
+   CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_FIX=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_1GB=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_2GB=y
+   # CONFIG_PHYCORE_|u-boot-socname-config|_RAM_SIZE_4GB=y
+
+Choose the correct RAM size as populated on the board and uncomment the line for
+this ram size.
+After saving the changes, follow the remaining steps from Build U-Boot.
+
+Build U-Boot With a Fixed RAM Frequency
+.......................................
+
+Starting with PD23.1.0 NXP or PD24.1.2 mainline release, the phyCORE-|soc| SoMs
+with revision 1549.3 and newer also support 2GHz RAM timings. These will be
+enabled for supported boards automatically, but they can also be enabled or
+disabled manually.
+
+Edit the file configs/phycore-|kernel-socname|\_defconfig.
+The fixed RAM size with 2GHz timings will be used:
+
+.. code-block:: kconfig
+
+   CONFIG_TARGET_PHYCORE_IMX8MP=y
+   CONFIG_PHYCORE_IMX8MP_RAM_SIZE_FIX=y
+   # CONFIG_PHYCORE_IMX8MP_RAM_SIZE_1GB=y
+   # CONFIG_PHYCORE_IMX8MP_RAM_SIZE_2GB=y
+   # CONFIG_PHYCORE_IMX8MP_RAM_SIZE_4GB=y
+   CONFIG_PHYCORE_IMX8MP_RAM_FREQ_FIX=y
+   CONFIG_PHYCORE_IMX8MP_USE_2GHZ_RAM_TIMINGS=y
+
+
+Choose the correct RAM size as populated on the board and uncomment the line
+for this ram size. When not specifying the
+``CONFIG_PHYCORE_IMX8MP_RAM_FREQ_FIX`` option, the 1.5GHz timings will
+be chosen by default. After saving the changes, follow the remaining steps from
+|ref-build-uboot|.


### PR DESCRIPTION
We switch bootscript to FIT image as well as kernel+dt. Document changes needed when compiling kernel.

---
I rearranged the standalone build section. I often find myself looking for them as reference, but they are not displayed in the toctree.
Further, I think it is more logical to put them first, i.e. before host setup. It is not required and when you want to compile kernel and copy to SD card, there is no need to go through these sections first.