### PR TITLE
imx-common: standalone_build_kernel: Fix make parameter

### DIFF
--- a/source/bsp/imx-common/development/standalone_build_kernel.rsti
+++ b/source/bsp/imx-common/development/standalone_build_kernel.rsti
@@ -34,7 +34,7 @@ Build Kernel
       :substitutions:
 
       host:~/|kernel-repo-name|$ make |kernel-defconfig|
-      host:~/|kernel-repo-name|$ make -j${nproc}
+      host:~/|kernel-repo-name|$ make -j$(nproc)
 
 *  Install kernel modules to e.g. NFS directory:
 


### PR DESCRIPTION
Make sure that the nproc command is actually called and not that a variable is passed. As if ${nproc} is empty it leads to unlimited number of jobs being created and can make the system unresponsive.