### PR TITLE
Sphinx: add internationalization

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,12 @@ jobs:
     - name: Install dependencies
       run: |
           sudo apt update
-          sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
+          sudo apt install tox texlive-latex-extra texlive-xetex texlive-lang-chinese latexmk python3-pip -y
           pip3 install -r requirements/setup.txt
     - name: Render HTML Documentation
-      run: tox -e py3-html
+      run: |
+        tox -e py3-intl
+        tox -e py3-html
     - name: Build PDF Documentation
       run: tox -e py3-pdf
     - name: Deploy Preview

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,9 @@ jobs:
           sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
           pip3 install -r requirements/setup.txt
     - name: Render Documentation
-      run: tox -e py3-html
+      run: |
+        tox -e py3-intl
+        tox -e py3-html
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
           pip3 install -r requirements/setup.txt
 
     - name: Build PDF Documentation
-      run: tox -e py3-pdf
+      run: |
+        tox -e py3-intl
+        tox -e py3-pdf
 
       ######## CREATE RELEASE and UPLOAD BUILD ARTIFACTS ########
     - name: Extract tag name
@@ -44,4 +46,4 @@ jobs:
         draft: true
         prerelease: false
         name: ${{ env.TAG_NAME }}
-        files: build/latex/*.pdf
+        files: build/latex/en/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ storage/
 *.swp
 build/
 .vscode/
+*.mo

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -321,6 +321,46 @@ Organization:
    content on GitHub, at least 1 other person need to approve a pull request
    and thus approve the content being added to a manual.
 
+Internationalization
+====================
+
+The documentation supports internationalization via the Sphinx extension
+``sphinx-intl``. The extension is used to extract translatable messages from
+the documentation and store them in *.po files. These files are then used to
+generate translated html and pdf versions of the documentation.
+
+All translation strings from a certain language are compated into a few files
+for the whole documentation. This allows to share translation messages for
+identical strings in multiple manuals.::
+
+   ./locale/zh_CN/LC_MESSAGES/sphinx.po
+   ./locale/zh_CN/LC_MESSAGES/index.po
+   ./locale/zh_CN/LC_MESSAGES/yocto.po
+   ./locale/zh_CN/LC_MESSAGES/contributing_links.po
+   ./locale/zh_CN/LC_MESSAGES/bsp.po
+
+To add support for new languages, extend the build commands in tox.ini and
+re-build the documentation to generate relevant po files.::
+
+   tox -e py3-intl
+
+After the po files are generated, translators can start translating the
+documentation. The translated po files are then used to generate translated
+html and pdf versions of the documentation.::
+
+   tox -e py3-html
+   tox -e py3-pdf
+
+To add new language links to the sidebar menu for the html documentation, add
+the language path to the ``languages`` list in the ``conf.py`` file.::
+
+   html_context = {
+       # Language selector, works together with versions.html in templates
+       'languages': [
+           ['en', pages_root],
+           ['zh_CN', pages_root + '/zh_CN']
+       ]
+   }
 
 Unresolved Issues
 =================

--- a/README.rst
+++ b/README.rst
@@ -32,14 +32,27 @@ Make also sure that your system has following tools installed
 Building the Documentation
 --------------------------
 
-Build the documentation as HTML, which is the default build target::
+There are 3 build targets available:
 
-   tox
+- ``tox -e py3-html``: Build the documentation as HTML for the default
+  language (en). This build command builds the documentation in multi-core mode
+  and is the fastest. Building the documentation in other languages does not
+  support parallel processing and is significantly slower.
 
-To produce a LaTeX generated PDF documentation, specify the target explicitly::
+- ``tox -e py3-intl``: Update the internationalization index files and
+  build the documentation as HTML for all languages, but English.
 
-   tox -e py3-pdf
+- ``tox -e py3-pdf``: Build the documentation as a PDF file for all
+  languages.
 
-Open the locally built HTML pages in your webbrowser::
+Open the locally built HTML pages in your webbrowser in the default language::
 
    xdg-open build/html/index.html
+
+Or for a translated language::
+
+   xdg-open build/html/zh_CN/index.html
+
+PDF files are available at::
+
+   build/latex/<lang>/doc-bsp-yocto.pdf

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
 Sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
 Sphinx-Substitution-Extensions==2022.2.16.0
+sphinx-intl==2.2.0

--- a/scripts/check_filesize.sh
+++ b/scripts/check_filesize.sh
@@ -4,7 +4,8 @@
 MAX_SIZE=300k
 DIR=source
 
-large_files=$(find $DIR -type f -size +"$MAX_SIZE" -exec du -h {} \;)
+# Allow *.po files to be larger than the maximum size.
+large_files=$(find $DIR -type f ! -name "*.po" -size +"$MAX_SIZE" -exec du -h {} \;)
 
 if [ -n "$large_files" ]; then
   echo -e "Error: Large files were found: \n$large_files"

--- a/source/conf.py
+++ b/source/conf.py
@@ -54,6 +54,7 @@ extlinks_detect_hardcoded_links = True
 
 highlight_language = 'none'
 
+# -- Internationalization ----------------------------------------------------
 
 # Set the default language
 locale_dirs = ['locale/']
@@ -77,18 +78,27 @@ html_theme_options = {
     'navigation_depth': 5,
 }
 
+pages_root = "https://phytec.github.io/doc-bsp-yocto"
 html_context = {
     "display_github": True,
     "github_user": "phytec",
     "github_repo": "doc-bsp-yocto",
     "github_version": "main",
     "conf_py_path": "/source/",
+    # Language selector, works together with versions.html in templates
+    'languages': [
+        ['en', pages_root],
+        ['zh_CN', pages_root + '/zh_CN']
+    ]
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['sphinx/static']
+
+# The templates directory is used to display a language selector in the sidebar.
+templates_path = ['sphinx/templates']
 
 html_css_files = [
     'css/code-block.css',

--- a/source/conf.py
+++ b/source/conf.py
@@ -54,6 +54,13 @@ extlinks_detect_hardcoded_links = True
 
 highlight_language = 'none'
 
+
+# Set the default language
+locale_dirs = ['locale/']
+# Compact all strings into a single file, this avoids editing identical strings
+# in multiple .po files.
+gettext_compact = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/source/locale/zh_CN/LC_MESSAGES/bsp.po
+++ b/source/locale/zh_CN/LC_MESSAGES/bsp.po
@@ -22,19 +22,19 @@ msgstr ""
 
 #: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mp/imx8mp.rst:3
 msgid "i.MX 8M Plus Manuals"
-msgstr ""
+msgstr "i.MX 8M Plus 手册"
 
 #: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mm/imx8mm.rst:3
 msgid "i.MX 8M Mini Manuals"
-msgstr ""
+msgstr "i.MX 8M Mini 手册"
 
 #: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mn/imx8mn.rst:3
 msgid "i.MX 8M Nano Manuals"
-msgstr ""
+msgstr "i.MX 8M Nano 手册"
 
 #: ../../source/bsp/imx8/imx8.rst:3 ../../source/bsp/imx8/imx8.rst:5
 msgid "i.MX 8 Manuals"
-msgstr ""
+msgstr "i.MX 8 手册"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:113
 #: ../../source/bsp/imx8/imx8mm/head.rst:116
@@ -45,7 +45,7 @@ msgstr ""
 #: ../../source/bsp/imx8/imx8mp/head.rst:128
 #: ../../source/bsp/imx8/imx8mp/head.rst:139
 msgid "|doc-id| |soc| BSP Manual Head"
-msgstr ""
+msgstr "|doc-id| |soc| BSP 手册标题"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:116
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:105
@@ -63,7 +63,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:108
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:109
 msgid "Document Title"
-msgstr ""
+msgstr "文档标题"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:119
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:107
@@ -81,7 +81,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:110
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:111
 msgid "Document Type"
-msgstr ""
+msgstr "文档类型"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:119
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:107
@@ -99,7 +99,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:110
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:111
 msgid "BSP Manual"
-msgstr ""
+msgstr "BSP 手册"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:121
 #: ../../source/bsp/imx8/imx8mn/head.rst:113
@@ -108,7 +108,7 @@ msgstr ""
 #: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:119
 #: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:119
 msgid "Article Number"
-msgstr ""
+msgstr "文章编号"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:121
 #: ../../source/bsp/imx8/imx8mn/head.rst:113
@@ -117,7 +117,7 @@ msgstr ""
 #: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:119
 #: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:119
 msgid "|doc-id|"
-msgstr ""
+msgstr "|doc-id|"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:123
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:109
@@ -135,7 +135,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:112
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:113
 msgid "Yocto Manual"
-msgstr ""
+msgstr "Yocto 手册"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:125
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:111
@@ -153,14 +153,14 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:114
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:115
 msgid "Release Date"
-msgstr ""
+msgstr "发布日期"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:125
 #: ../../source/bsp/imx8/imx8mn/head.rst:117
 #: ../../source/bsp/imx8/imx8mp/head.rst:137
 #: ../../source/bsp/imx8/imx8mp/mainline-head.rst:123
 msgid "XXXX/XX/XX"
-msgstr ""
+msgstr "XXXX/XX/XX"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:127
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:113
@@ -178,7 +178,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:116
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:117
 msgid "Is Branch of"
-msgstr ""
+msgstr "是 ... 的分支"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:131
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:116
@@ -196,7 +196,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:119
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:120
 msgid "The table below shows the Compatible BSPs for this manual:"
-msgstr ""
+msgstr "下表显示了与本手册兼容的 BSP。"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:134
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
@@ -214,7 +214,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
 msgid "Compatible BSP'S"
-msgstr ""
+msgstr "兼容的 BSPs"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:134
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
@@ -232,7 +232,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
 msgid "BSP Release Type"
-msgstr ""
+msgstr "BSP 发布类型"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:134
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
@@ -244,7 +244,7 @@ msgstr ""
 #: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:129
 #: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:132
 msgid "BSP Release  Date"
-msgstr ""
+msgstr "BSP 发布日期"
 
 #: ../../source/bsp/imx8/imx8mm/head.rst:134
 #: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
@@ -262,7 +262,7 @@ msgstr ""
 #: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
 #: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
 msgid "BSP Status"
-msgstr ""
+msgstr "BSP 状态"
 
 #: ../../source/bsp/intro.rsti:1
 msgid ""

--- a/source/locale/zh_CN/LC_MESSAGES/bsp.po
+++ b/source/locale/zh_CN/LC_MESSAGES/bsp.po
@@ -1,0 +1,12297 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, PHYTEC Messtechnik GmbH
+# This file is distributed under the same license as the PHYTEC BSP
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PHYTEC BSP Documentation imx8mp-pd22.1.2-5-ge2f699d\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-23 11:20+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mp/imx8mp.rst:3
+msgid "i.MX 8M Plus Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mm/imx8mm.rst:3
+msgid "i.MX 8M Mini Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8.rst:5 ../../source/bsp/imx8/imx8mn/imx8mn.rst:3
+msgid "i.MX 8M Nano Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8.rst:3 ../../source/bsp/imx8/imx8.rst:5
+msgid "i.MX 8 Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:113
+#: ../../source/bsp/imx8/imx8mm/head.rst:116
+#: ../../source/bsp/imx8/imx8mm/head.rst:127
+#: ../../source/bsp/imx8/imx8mn/head.rst:105
+#: ../../source/bsp/imx8/imx8mn/head.rst:108
+#: ../../source/bsp/imx8/imx8mn/head.rst:119
+#: ../../source/bsp/imx8/imx8mp/head.rst:128
+#: ../../source/bsp/imx8/imx8mp/head.rst:139
+msgid "|doc-id| |soc| BSP Manual Head"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:116
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:105
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:114
+#: ../../source/bsp/imx8/imx8mn/head.rst:108
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:99
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:106
+#: ../../source/bsp/imx8/imx8mp/head.rst:128
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:114
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:115
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:115
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:125
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:114
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:114
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:108
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:109
+msgid "Document Title"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:119
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:107
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:116
+#: ../../source/bsp/imx8/imx8mn/head.rst:111
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:101
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:108
+#: ../../source/bsp/imx8/imx8mp/head.rst:131
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:127
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:117
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:110
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:111
+msgid "Document Type"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:119
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:107
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:116
+#: ../../source/bsp/imx8/imx8mn/head.rst:111
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:101
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:108
+#: ../../source/bsp/imx8/imx8mp/head.rst:131
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:127
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:117
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:117
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:110
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:111
+msgid "BSP Manual"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:121
+#: ../../source/bsp/imx8/imx8mn/head.rst:113
+#: ../../source/bsp/imx8/imx8mp/head.rst:133
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:119
+msgid "Article Number"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:121
+#: ../../source/bsp/imx8/imx8mn/head.rst:113
+#: ../../source/bsp/imx8/imx8mp/head.rst:133
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:119
+msgid "|doc-id|"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:123
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:109
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:118
+#: ../../source/bsp/imx8/imx8mn/head.rst:115
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:103
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:110
+#: ../../source/bsp/imx8/imx8mp/head.rst:135
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:119
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:121
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:112
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:113
+msgid "Yocto Manual"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:125
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:111
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mn/head.rst:117
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:105
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:112
+#: ../../source/bsp/imx8/imx8mp/head.rst:137
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:131
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:123
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:114
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:115
+msgid "Release Date"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:125
+#: ../../source/bsp/imx8/imx8mn/head.rst:117
+#: ../../source/bsp/imx8/imx8mp/head.rst:137
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:123
+msgid "XXXX/XX/XX"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:127
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:122
+#: ../../source/bsp/imx8/imx8mn/head.rst:119
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:107
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:114
+#: ../../source/bsp/imx8/imx8mp/head.rst:139
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:125
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:133
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:125
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:125
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:116
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:117
+msgid "Is Branch of"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:131
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:116
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:125
+#: ../../source/bsp/imx8/imx8mn/head.rst:123
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:110
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:117
+#: ../../source/bsp/imx8/imx8mp/head.rst:143
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:126
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:126
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:136
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:129
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:119
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:120
+msgid "The table below shows the Compatible BSPs for this manual:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:134
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:128
+#: ../../source/bsp/imx8/imx8mn/head.rst:126
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mp/head.rst:146
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:139
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:132
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
+msgid "Compatible BSP'S"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:134
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:128
+#: ../../source/bsp/imx8/imx8mn/head.rst:126
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mp/head.rst:146
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:139
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:132
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
+msgid "BSP Release Type"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:134
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mn/head.rst:126
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mp/head.rst:146
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:132
+msgid "BSP Release  Date"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:134
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:119
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:128
+#: ../../source/bsp/imx8/imx8mn/head.rst:126
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mp/head.rst:146
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:129
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:139
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:132
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
+msgid "BSP Status"
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:1
+msgid ""
+"This BSP manual guides you through the installation and creation steps "
+"for the Board Support Package (BSP) and describes how to handle the "
+"interfaces for the |kit|. Furthermore, this document describes how to "
+"create BSP images from the source code. This is useful for those who need"
+" to change the default image and need a way to implement these changes in"
+" a simple and reproducible way. Further, some sections of this manual "
+"require executing commands on a personal computer (host). Any and all of "
+"these commands are assumed to be executed on a Linux Operating System."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:12
+msgid ""
+"This document contains code examples that describe the communication with"
+" the board over the serial shell. The code examples lines begin with "
+"\"host:~$\", \"target:~$\" or \"u-boot=>\". This describes where the "
+"commands are to be executed. Only after these keywords must the actual "
+"command be copied."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:18
+msgid "PHYTEC Documentation"
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:20
+msgid ""
+"PHYTEC provides a variety of hardware and software documentation for all "
+"of our products. This includes any or all of the following:"
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:23
+msgid ""
+"**QS Guide**: A short guide on how to set up and boot a phyCORE board "
+"along with brief informationon building a BSP, the device tree, and "
+"accessing peripherals."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:26
+msgid ""
+"**Hardware Manual**: A detailed description of the System on Module and "
+"accompanying carrierboard."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:28
+msgid ""
+"**Yocto Guide**: A comprehensive guide for the Yocto version the phyCORE "
+"uses. This guide contains an overview of Yocto; introducing, installing, "
+"and customizing the PHYTEC BSP; how to work with programs like Poky and "
+"Bitbake; and much more."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:32
+msgid ""
+"**BSP Manual**: A manual specific to the BSP version of the phyCORE. "
+"Information such as how to build the BSP, booting, updating software, "
+"device tree, and accessing peripherals can be found here."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:36
+msgid ""
+"**Development Environment Guide**: This guide shows how to work with the "
+"Virtual Machine (VM) Host PHYTEC has developed and prepared to run "
+"various Development Environments. There are detailed step-by-step "
+"instructions for Eclipse and Qt Creator, which are included in the VM. "
+"There are instructions for running demo projects for these programs on a "
+"phyCORE product as well. Information on how to build a Linux host PC "
+"yourself is also a part of this guide."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:44
+msgid ""
+"**Pin Muxing Table**: phyCORE SOMs have an accompanying pin table (in "
+"Excel format). This table will show the complete default signal path, "
+"from the processor to the carrier board. The default device tree muxing "
+"option will also be included. This gives a developer all the information "
+"needed in one location to make muxing changes and design options when "
+"developing a specialized carrier board or adapting a PHYTEC phyCORE SOM "
+"to an application."
+msgstr ""
+
+#: ../../source/bsp/intro.rsti:53
+msgid ""
+"On top of these standard manuals and guides, PHYTEC will also provide "
+"Product Change Notifications, Application Notes, and Technical Notes. "
+"These will be done on a case-by-case basis. Most of the documentation can"
+" be found on the |dlpage-product| of our product."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:143
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:128
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:137
+#: ../../source/bsp/imx8/imx8mn/head.rst:135
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:122
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:129
+#: ../../source/bsp/imx8/imx8mp/head.rst:156
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:142
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:138
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:138
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:149
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:142
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:142
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:132
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:133
+msgid "Supported Hardware"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:145
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:130
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:139
+msgid ""
+"The |sbc| populated with either the i.MX 8M Mini SoC or i.MX 8M Nano SoC,"
+" is supported."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:148
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:133
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:142
+#: ../../source/bsp/imx8/imx8mn/head.rst:139
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:126
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:133
+msgid ""
+"On our web page, you can see all supported Machines with the available "
+"Article Numbers for this release: |yocto-manifestname| `download <dlpage-"
+"bsp_>`_. If you choose a specific **Machine Name** in the section "
+"**Supported Machines**, you can see which **Article Numbers** are "
+"available under this machine and also a short description of the hardware"
+" information. In case you only have the **Article Number** of your "
+"hardware, you can leave the **Machine Name** drop-down menu empty and "
+"only choose your **Article Number**. Now it should show you the necessary"
+" **Machine Name** for your specific hardware"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/components.rsti:2
+#: ../../source/bsp/imx8/imx8mp/components.rsti:2
+msgid "|sbc| Components"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/components.rsti:10
+msgid "|sbc| Components (top)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/components.rsti:17
+msgid "|sbc| Components (bottom)"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:2
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:146
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:161
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:139
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:152
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:154
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:159
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:171
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:164
+msgid "Getting Started"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:4
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:163
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:154
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:173
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:166
+msgid ""
+"The |kit| is shipped with a pre-flashed SD card. It contains the |yocto-"
+"imagename| and can be used directly as a boot source. The eMMC is "
+"programmed with only a U-Boot by default. You can get all sources from "
+"the `PHYTEC download server <dl-server_>`_. This chapter explains how to "
+"flash a BSP image to SD card and how to start the board."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:10
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:169
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:160
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:179
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:172
+msgid ""
+"There are several ways to flash an image to SD card or even eMMC. Most "
+"notably using simple, sequential writing with the Linux command line tool"
+" ``dd``. An alternative way is to use PHYTEC's system initialization "
+"program called `partup <https://github.com/phytec/partup>`_, which makes "
+"it especially easy to format more complex systems. You can get `prebuilt "
+"Linux binaries of partup <https://github.com/phytec/partup/releases>`__ "
+"from its release page. Also read `partup's README "
+"<https://github.com/phytec/partup#readme>`__ for installation "
+"instructions."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:20
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:155
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:179
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:148
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:170
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:163
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:168
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:189
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:182
+msgid "Get the Image"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:22
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:181
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:172
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:191
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:184
+msgid ""
+"The image contains all necessary files and makes sure partitions and any "
+"raw data are correctly written. Both the partup package and the WIC "
+"image, which can be flashed using ``dd``, can be downloaded from the "
+"`PHYTEC download server <dl-server_>`_."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:27
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:186
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:177
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:196
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:189
+msgid "Get either the partup package or the WIC image from the download server:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:36
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:195
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:186
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:205
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:198
+msgid ""
+"For eMMC, more complex partitioning schemes or even just large images, we"
+" recommend using the partup package, as it is faster in writing than "
+"``dd`` and allows for a more flexible configuration of the target flash "
+"device."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:41
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:170
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:200
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:163
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:191
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:178
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:183
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:210
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:203
+msgid "Write the Image to SD Card"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:44
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:203
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:194
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:213
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:206
+msgid ""
+"To create your bootable SD card, you must have root privileges on your "
+"Linux host PC. Be very careful when specifying the destination device! "
+"All files on the selected device will be erased immediately without any "
+"further query!"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:48
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:207
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:198
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:217
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:210
+msgid ""
+"Selecting the wrong device may result in **data loss** and e.g. could "
+"erase your currently running system on your host PC!"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:52
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:211
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:202
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:221
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:214
+msgid "Finding the Correct Device"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:56
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:213
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:204
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:223
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:216
+msgid ""
+"To create your bootable SD card, you must first find the correct device "
+"name of your SD card and possible partitions. If any partitions of the SD"
+" cards are mounted, unmount those before you start copying the image to "
+"the SD card."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:60
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:217
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:208
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:227
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:220
+msgid "In order to get the correct device name, remove your SD card and execute:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:67
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:224
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:215
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:234
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:227
+msgid "Now insert your SD card and execute the command again:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:73
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:194
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:230
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:187
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:221
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:202
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:207
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:240
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:233
+msgid ""
+"Compare the two outputs to find the new device names listed in the second"
+" output. These are the device names of the SD card (device and partitions"
+" if the SD card was formatted)."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:76
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:197
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:233
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:190
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:224
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:205
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:210
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:243
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:236
+msgid ""
+"In order to verify the device names being found, execute the command "
+"``sudo dmesg``. Within the last lines of its output, you should also find"
+" the device names, e.g. ``/dev/sde`` or ``/dev/mmcblk0`` (depending on "
+"your system)."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:81
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:202
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:238
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:195
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:229
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:210
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:215
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:248
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:241
+msgid ""
+"Alternatively, you may use a graphical program of your choice, like "
+"`GNOME Disks <https://apps.gnome.org/en/DiskUtility/>`_ or `KDE Partition"
+" Manager <https://apps.kde.org/partitionmanager/>`_, to find the correct "
+"device."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:85
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:206
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:242
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:199
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:233
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:214
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:219
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:252
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:245
+msgid ""
+"Now that you have the correct device name, e.g. ``/dev/sde``, you can see"
+" the partitions which must be unmounted if the SD card is formatted. In "
+"this case, you will also find the device name with an appended number "
+"(e.g. ``/dev/sde1``) in the output. These represent the partitions. Some "
+"Linux distributions automatically mount partitions when the device gets "
+"plugged in. Before writing, however, these need to be unmounted to avoid "
+"data corruption."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:92
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:249
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:240
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:259
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:252
+msgid "Unmount all those partitions, e.g.:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:99
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:256
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:247
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:266
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:259
+msgid ""
+"Now, the SD card is ready to be flashed with an image, using either "
+"``partup``, ``dd`` or ``bmap-tools``."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:103
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:285
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:276
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:295
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:263
+msgid "Using bmap-tools"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:105
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:265
+msgid ""
+"One way to prepare an SD card is using `bmap-tools "
+"<https://github.com/yoctoproject/bmaptool>`_. Yocto automatically creates"
+" a block map file (``<IMAGENAME>-<MACHINE>.wic.bmap``) for the WIC image "
+"that describes the image content and includes checksums for data "
+"integrity. *bmaptool* is packaged by various Linux distributions. For "
+"Debian-based systems install it by issuing:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:116
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:298
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:289
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:308
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:276
+msgid "Flash a WIC image to SD card by calling:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:123
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:305
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:296
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:315
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:283
+msgid ""
+"Replace <your_device> with your actual SD card's device name found "
+"previously, and make sure to place the file "
+"``<IMAGENAME>-<MACHINE>.wic.bmap`` alongside the regular WIC image file, "
+"so bmaptool knows which blocks to write and which to skip."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:129
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:244
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:311
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:237
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:302
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:252
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:257
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:321
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:289
+msgid ""
+"*bmaptool* only overwrites the areas of an SD card where image data is "
+"located. This means that a previously written U-Boot environment may "
+"still be available after writing the image."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:134
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:260
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:251
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:270
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:294
+msgid "Using partup"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:136
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:262
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:253
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:272
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:296
+msgid "Writing to an SD card with partup is done in a single command:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:143
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:269
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:260
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:279
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:303
+msgid ""
+"Make sure to replace <your_device> with your actual device name found "
+"previously."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:145
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:271
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:262
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:281
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:305
+msgid ""
+"Further usage of partup is explained at its `official documentation "
+"website <https://partup.readthedocs.io/en/latest/>`__."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:149
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:309
+msgid ""
+"Host systems which are using resize2fs version 1.46.6 and older (e.g. "
+"Ubuntu 22.04) are not able to write partup packages created with Yocto "
+"Mickledore or newer to SD-Card. This is due to a new default option in "
+"resize2fs which causes an incompatibility. See `release notes "
+"<https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.47.0>`_."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:155
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:315
+msgid ""
+"*partup* has the advantage of allowing to clear specific raw areas in the"
+" MMC user area, which is used in our provided partup packages to erase "
+"any existing U-Boot environments. This is a known issue *bmaptool* does "
+"not solve, as mentioned in the previous chapter."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:160
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:280
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:271
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:290
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:320
+msgid ""
+"Another key advantage of partup over other flashing tools is that it "
+"allows configuring MMC specific parts, like writing to eMMC boot "
+"partitions, without the need to call multiple other commands when "
+"writing."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:165
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:316
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:307
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:326
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:325
+msgid "Using ``dd``"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:167
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:318
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:309
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:328
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:327
+msgid ""
+"After having unmounted all SD card's partitions, you can create your "
+"bootable SD card."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:169
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:320
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:311
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:330
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:329
+msgid ""
+"Some PHYTEC BSPs produce uncompressed images (with filename-extension "
+"\\*.wic), and some others produce compressed images (with filename-"
+"extension \\*.wic.xz)."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:172
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:323
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:314
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:333
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:332
+msgid "To flash an uncompressed images (\\*.wic) use command below:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:179
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:330
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:321
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:340
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:339
+msgid "Or to flash a compressed images (\\*.wic.xz) use that command:"
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:186
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:337
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:328
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:347
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:346
+msgid ""
+"Again, make sure to replace <your_device> with your actual device name "
+"found previously."
+msgstr ""
+
+#: ../../source/bsp/getting-started.rsti:189
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:224
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:340
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:217
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:331
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:232
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:237
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:350
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:349
+msgid ""
+"The parameter ``conv=fsync`` forces a sync operation on the device before"
+" ``dd`` returns. This ensures that all blocks are written to the SD card "
+"and none are left in memory. The parameter ``status=progress`` will print"
+" out information on how much data is and still has to be copied until it "
+"is finished."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:168
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:249
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:347
+#: ../../source/bsp/imx8/imx8mn/head.rst:159
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:242
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:338
+#: ../../source/bsp/imx8/imx8mp/head.rst:179
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:166
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:257
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:262
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:357
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:356
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:166
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:155
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:161
+msgid "First Start-up"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:170
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:251
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:349
+#: ../../source/bsp/imx8/imx8mn/head.rst:161
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:244
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:340
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:259
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:264
+msgid ""
+"To boot from an SD card, |ref-bootswitch| needs to be set to the "
+"following position:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:4
+#: ../../source/bsp/imx8/imx8mm/head.rst:173
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:254
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:352
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:3
+#: ../../source/bsp/imx8/imx8mn/head.rst:164
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:247
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:343
+msgid "Bootmode Selection"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:2
+#: ../../source/bsp/imx8/imx8mm/head.rst:177
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:258
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:356
+msgid "Mini"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:179
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:260
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:358
+#: ../../source/bsp/imx8/imx8mn/head.rst:172
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:255
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:351
+#: ../../source/bsp/imx8/imx8mp/head.rst:186
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:173
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:264
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:269
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:364
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:363
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:173
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:162
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:168
+msgid "Insert the SD card"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:180
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:261
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:359
+#: ../../source/bsp/imx8/imx8mn/head.rst:173
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:256
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:352
+#: ../../source/bsp/imx8/imx8mp/head.rst:187
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:174
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:265
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:270
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:365
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:364
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:174
+msgid ""
+"Connect the target and the host with **mirco USB** on |ref-"
+"debugusbconnector| debug USB"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:182
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:263
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:361
+#: ../../source/bsp/imx8/imx8mn/head.rst:175
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:258
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:354
+#: ../../source/bsp/imx8/imx8mp/head.rst:189
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:176
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:267
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:272
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:367
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:366
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:176
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:165
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:170
+msgid "Power up the board"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:2
+msgid "Building the BSP"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:4
+msgid ""
+"This section will guide you through the general build process of the "
+"|soc| BSP using Yocto and the phyLinux script. For more information about"
+" our meta-layer or Yocto in general visit: |yocto-ref-manual|_."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:9
+msgid "Basic Set-Up"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:11
+msgid ""
+"If you have never created a Phytec BSP with Yocto on your computer, you "
+"should take a closer look at the chapter BSP Workspace Installation in "
+"the |yocto-ref-manual|_."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:16
+msgid "Get the BSP"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:18
+msgid ""
+"There are two ways to get the BSP sources. You can download the complete "
+"BSP sources from our download page: |yocto-bsp-name|_; or you can fetch "
+"and build it yourself with Yocto. This is particularly useful if you want"
+" to make customizations."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:23
+msgid ""
+"The phyLinux script is a basic management tool for PHYTEC Yocto BSP "
+"releases written in Python. It is mainly a helper to get started with the"
+" BSP structure."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:26
+msgid ""
+"Create a fresh project folder, get phyLinux, and make the script "
+"executable:"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:37
+msgid ""
+"A clean folder is important because phyLinux will clean its working "
+"directory. Calling phyLinux from a directory that isn't empty will result"
+" in a warning."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:41
+msgid "Run phyLinux:"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:49
+msgid ""
+"On the first initialization, the phyLinux script will ask you to install "
+"the Repo tool in your ``/usr/local/bin`` directory."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:52
+msgid ""
+"During the execution of the init command, you need to choose your "
+"processor platform (SoC), PHYTEC's BSP release number, and the hardware "
+"you are working on."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:58
+msgid ""
+"If you cannot identify your board with the information given in the "
+"selector, have a look at the invoice for the product. And have a look at "
+"|dlpage-bsp|_."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:62
+msgid ""
+"It is also possible to pass this information directly using command line "
+"parameters:"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:70
+msgid ""
+"After the execution of the init command, phyLinux will print a few "
+"important notes. For example, it will print your git identify, SOC and "
+"BSP release which was selected as well as information for the next steps "
+"in the build process."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:75
+msgid "Starting the Build Process"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:77
+msgid "Set up the shell environment variables:"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:85
+msgid "This needs to be done every time you open a new shell for starting builds."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:87
+msgid "The current working directory of the shell should change to build/."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:88
+msgid ""
+"Open the main configuration file and accept the GPU and VPU binary "
+"license agreements. Do this by uncommenting the corresponding line, as "
+"below."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:98
+msgid "Build your image:"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:106
+msgid ""
+"For the first build we suggest starting with our smaller non-graphical "
+"image phytec-headless-image to see if everything is working correctly."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:114
+msgid ""
+"The first compile process takes about 40 minutes on a modern Intel Core "
+"i7. All subsequent builds will use the filled caches and should take "
+"about 3 minutes."
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:119
+msgid "BSP Images"
+msgstr ""
+
+#: ../../source/bsp/building-bsp.rsti:121
+msgid ""
+"All images generated by Bitbake are deployed to "
+"``~/yocto/build/deploy/images/<machine>``. The following list shows for "
+"example all files generated for the |yocto-machinename| machine:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:192
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:273
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:371
+#: ../../source/bsp/imx8/imx8mn/head.rst:185
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:268
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:364
+#: ../../source/bsp/imx8/imx8mp/head.rst:199
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:186
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:277
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:282
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:377
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:376
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:186
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:176
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:182
+msgid ""
+"**u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final"
+" Bootloader image!"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:194
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:275
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:373
+#: ../../source/bsp/imx8/imx8mn/head.rst:187
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:270
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:366
+#: ../../source/bsp/imx8/imx8mp/head.rst:201
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:188
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:279
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:284
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:379
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:378
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:188
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:178
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:184
+msgid "**oftree**: Default kernel device tree"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:195
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:276
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:374
+#: ../../source/bsp/imx8/imx8mn/head.rst:188
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:271
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:367
+#: ../../source/bsp/imx8/imx8mp/head.rst:202
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:189
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:280
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:285
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:380
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:379
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:189
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:179
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:185
+msgid "**u-boot-spl.bin**: Secondary program loader (SPL)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:196
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:277
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:375
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:272
+msgid "**bl31-imx8mm.bin**: ARM Trusted Firmware binary"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:197
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:278
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:376
+#: ../../source/bsp/imx8/imx8mn/head.rst:190
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:273
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:369
+#: ../../source/bsp/imx8/imx8mp/head.rst:204
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:282
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:287
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:382
+msgid ""
+"**lpddr4_pmu_train_2d_dmem_202006.bin, "
+"lpddr4_pmu_train_2d_imem_202006.bin**: DDR PHY firmware images"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:199
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:280
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:378
+#: ../../source/bsp/imx8/imx8mn/head.rst:192
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:275
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:371
+#: ../../source/bsp/imx8/imx8mp/head.rst:206
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:284
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:289
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:384
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:184
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:190
+msgid ""
+"**imx-boot**: Bootloader build by imx-mkimage which includes SPL, U-Boot,"
+" ARM Trusted Firmware and DDR firmware. This is the final bootloader "
+"image which is bootable."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:202
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:283
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:381
+#: ../../source/bsp/imx8/imx8mn/head.rst:195
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:278
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:374
+#: ../../source/bsp/imx8/imx8mp/head.rst:211
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:195
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:287
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:292
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:387
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:385
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:195
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:187
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:193
+msgid "**Image**: Linux kernel image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:203
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:284
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:382
+#: ../../source/bsp/imx8/imx8mn/head.rst:196
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:279
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:375
+#: ../../source/bsp/imx8/imx8mp/head.rst:212
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:196
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:288
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:293
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:388
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:386
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:196
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:188
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:194
+msgid "**Image.config**: Kernel configuration"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:204
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:285
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:383
+msgid "**imx8mm-phyboard-polis-rdk*.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:205
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:286
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:384
+msgid "**imx8mm-phy*.dtbo**: Kernel device tree overlay files"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:206
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:385
+#: ../../source/bsp/imx8/imx8mp/head.rst:215
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:198
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:391
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:388
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:198
+msgid "**phytec-qt6demo-image\\*.tar.gz**: Root file system"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:207
+msgid "**phytec-qt6demo-image\\*.rootfs.wic.xz**: SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:214
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:295
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:393
+#: ../../source/bsp/imx8/imx8mn/head.rst:207
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:290
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:386
+#: ../../source/bsp/imx8/imx8mp/head.rst:223
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:206
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:299
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:304
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:399
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:396
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:206
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:214
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:220
+msgid "Installing the OS"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:217
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:298
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:396
+#: ../../source/bsp/imx8/imx8mn/head.rst:210
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:293
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:389
+msgid "Bootmode Switch (S1)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:219
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:300
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:398
+#: ../../source/bsp/imx8/imx8mn/head.rst:212
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:295
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:391
+msgid ""
+"The |sbc| features a boot switch with six individually switchable ports "
+"to select the phyCORE-|soc| default bootsource."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:8
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:10
+msgid "eMMC (Default SoM boot)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:12
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:30
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:13
+msgid "SPI NOR"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:16
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:17
+#: ../../source/bsp/imx9/imx93/bootmode-switch.rsti:13
+msgid "USB Serial Download"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:20
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:20
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:21
+#: ../../source/bsp/imx9/imx93/bootmode-switch.rsti:17
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:89
+msgid "SD Card"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:23
+#: ../../source/bsp/imx8/imx8mm/head.rst:311
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1159
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1156
+#: ../../source/bsp/imx8/imx8mn/head.rst:306
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1155
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1137
+msgid "Switch between UART1 RS485/RS232"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:27
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:54
+msgid "UART1 RS485"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/bootmode-switch.rsti:31
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:59
+msgid "UART1 RS232"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:307
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:405
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:302
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:398
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:228
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:315
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:320
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:415
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:412
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:228
+#: ../../source/bsp/imx8/installing-os.rsti:2
+#: ../../source/bsp/imx9/installing-os.rsti:2
+msgid "Flash eMMC"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:407
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:400
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:208
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:417
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:208
+#: ../../source/bsp/imx8/installing-os.rsti:4
+msgid ""
+"For consistency, it is assumed that a TFTP server is configured; More "
+"importantly, all generated images, as listed above, are copied to the "
+"default /srv/tftp directory. If you do not have this set up, you need to "
+"adjust the paths that point to the images being used in the instructions."
+" For instructions on how to set up the TFTP server and directory, see "
+"|ref-setup-network-host|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:413
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:406
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:230
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:423
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:414
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:230
+#: ../../source/bsp/imx8/installing-os.rsti:10
+#: ../../source/bsp/imx9/installing-os.rsti:4
+msgid ""
+"To boot from eMMC, make sure that the BSP image is flashed correctly to "
+"the eMMC and the |ref-bootswitch| is set to **eMMC**."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:313
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:417
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:308
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:410
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:234
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:321
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:326
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:427
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:418
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:234
+#: ../../source/bsp/imx8/installing-os.rsti:14
+#: ../../source/bsp/imx9/installing-os.rsti:8
+msgid ""
+"When eMMC and SD card are flashed with the same (identical) image, the "
+"UUIDs of the boot partitions are also identical. If the SD card is "
+"connected when booting, this leads to non-deterministic behavior as Linux"
+" mounts the boot partition based on UUID."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:322
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:426
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:317
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:419
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:243
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:330
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:335
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:436
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:427
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:243
+#: ../../source/bsp/imx8/installing-os.rsti:23
+msgid ""
+"can be run to inspect whether the current setup is affected. If "
+"``mmcblk2p1`` and ``mmcblk1p1`` have an identical UUID, the setup is "
+"affected."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:326
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:430
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:321
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:423
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:247
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:334
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:339
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:440
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:431
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:247
+#: ../../source/bsp/imx8/installing-os.rsti:27
+#: ../../source/bsp/imx9/installing-os.rsti:107
+msgid "Flash eMMC from Network"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:328
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:432
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:323
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:425
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:249
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:336
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:341
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:442
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:433
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:249
+#: ../../source/bsp/imx8/installing-os.rsti:29
+#: ../../source/bsp/imx9/installing-os.rsti:109
+msgid ""
+"|soc| boards have an Ethernet connector and can be updated over a "
+"network. Be sure to set up the development host correctly. The IP needs "
+"to be set to 192.168.3.10, the netmask to 255.255.255.0, and a TFTP "
+"server needs to be available. From a high-level point of view, an eMMC "
+"device is like an SD card. Therefore, it is possible to flash the **WIC "
+"image** (``<name>.wic``) from the Yocto build system directly to the "
+"eMMC. The image contains the bootloader, kernel, device tree, device tree"
+" overlays, and root file system."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:441
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:434
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:258
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:451
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:442
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:258
+#: ../../source/bsp/imx8/installing-os.rsti:38
+msgid "Flash eMMC from Network in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:443
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:436
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:260
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:453
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:444
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:260
+#: ../../source/bsp/imx8/installing-os.rsti:40
+msgid "These steps will show how to update the eMMC via a network."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:447
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:593
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:440
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:586
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:457
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:603
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:568
+#: ../../source/bsp/imx8/installing-os.rsti:44
+#: ../../source/bsp/imx8/installing-os.rsti:197
+msgid ""
+"This step only works if the size of the image file is less than 1GB due "
+"to limited usage of RAM size in the Bootloader after enabling OPTEE."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:347
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:452
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:522
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:541
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:568
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:800
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:342
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:445
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:515
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:534
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:561
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:793
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:264
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:321
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:340
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:367
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:355
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:360
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:462
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:532
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:551
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:578
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:810
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:448
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:493
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:512
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:538
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:264
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:321
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:340
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:367
+#: ../../source/bsp/imx8/installing-os.rsti:49
+#: ../../source/bsp/imx8/installing-os.rsti:126
+#: ../../source/bsp/imx8/installing-os.rsti:145
+#: ../../source/bsp/imx8/installing-os.rsti:172
+#: ../../source/bsp/imx8/installing-os.rsti:405
+#: ../../source/bsp/imx9/installing-os.rsti:134
+#: ../../source/bsp/imx9/installing-os.rsti:152
+#: ../../source/bsp/imx9/installing-os.rsti:178
+msgid "A working network is necessary! |ref-setup-network-host|"
+msgstr ""
+
+#: ../../source/bsp/imx8/installing-os.rsti:51
+msgid "Uncompress your image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:349
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:454
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:344
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:447
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:278
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:357
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:362
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:464
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:450
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:278
+#: ../../source/bsp/imx8/installing-os.rsti:58
+msgid "Load your image via network to RAM:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:456
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:449
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:466
+#: ../../source/bsp/imx8/installing-os.rsti:60
+msgid "when using dhcp"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:480
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:473
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:490
+#: ../../source/bsp/imx8/installing-os.rsti:84
+msgid ""
+"when using a static ip address (serverip and ipaddr must be set "
+"additionally)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:371
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:479
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:503
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:612
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:366
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:474
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:496
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:605
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:302
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:418
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:379
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:487
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:384
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:492
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:513
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:622
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:474
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:587
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:302
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:418
+#: ../../source/bsp/imx8/installing-os.rsti:107
+#: ../../source/bsp/imx8/installing-os.rsti:217
+msgid "Write the image to the eMMC:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:384
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:516
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:379
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:509
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:315
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:392
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:397
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:526
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:487
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:315
+#: ../../source/bsp/imx8/installing-os.rsti:120
+#: ../../source/bsp/imx9/installing-os.rsti:128
+msgid "Flash eMMC via Network in Linux on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:386
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:518
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:381
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:511
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:317
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:394
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:399
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:528
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:489
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:317
+#: ../../source/bsp/imx8/installing-os.rsti:122
+#: ../../source/bsp/imx9/installing-os.rsti:130
+msgid "You can update the eMMC from your target."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:323
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:323
+#: ../../source/bsp/imx8/installing-os.rsti:128
+msgid ""
+"Take a compressed or decompressed image with the accompanying block map "
+"file `*.bmap` on the host and send it with `ssh` through the network to "
+"the eMMC of the target with a one-line command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:401
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:534
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:396
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:527
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:333
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:409
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:414
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:544
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:505
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:333
+#: ../../source/bsp/imx8/installing-os.rsti:138
+#: ../../source/bsp/imx9/installing-os.rsti:145
+msgid "Flash eMMC via Network in Linux on Host"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:403
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:536
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:398
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:529
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:335
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:411
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:416
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:546
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:507
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:335
+#: ../../source/bsp/imx8/installing-os.rsti:140
+#: ../../source/bsp/imx9/installing-os.rsti:147
+msgid ""
+"It is also possible to install the OS at eMMC from your Linux host. As "
+"before, you need a complete image on your host."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:410
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:543
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:405
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:536
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:342
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:418
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:423
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:553
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:514
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:342
+#: ../../source/bsp/imx8/installing-os.rsti:147
+#: ../../source/bsp/imx9/installing-os.rsti:154
+msgid "Show your available image files on the host:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:552
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:545
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:351
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:562
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:351
+#: ../../source/bsp/imx8/installing-os.rsti:156
+msgid ""
+"Send the image with the ``bmaptool`` command combined with ssh through "
+"the network to the eMMC of your device:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:561
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:554
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:360
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:571
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:531
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:360
+#: ../../source/bsp/imx8/installing-os.rsti:165
+#: ../../source/bsp/imx9/installing-os.rsti:171
+msgid "Flash eMMC U-Boot image via Network from running U-Boot"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:563
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:556
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:362
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:573
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:533
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:362
+#: ../../source/bsp/imx8/installing-os.rsti:167
+#: ../../source/bsp/imx9/installing-os.rsti:173
+msgid ""
+"Update the standalone U-Boot image imx-boot is also possible from U-Boot."
+" This can be used if the bootloader on eMMC is located in the eMMC user "
+"area."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:436
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:570
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:431
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:563
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:369
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:444
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:449
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:580
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:540
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:369
+#: ../../source/bsp/imx8/installing-os.rsti:174
+#: ../../source/bsp/imx9/installing-os.rsti:180
+msgid "Load image over tftp into RAM and then write it to eMMC:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:447
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:581
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:442
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:574
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:380
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:455
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:460
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:591
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:551
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:380
+#: ../../source/bsp/imx8/installing-os.rsti:185
+#: ../../source/bsp/imx9/installing-os.rsti:191
+msgid ""
+"The hexadecimal value represents the offset as a multiple of 512 byte "
+"blocks. See the `offset table <#offset-table>`__ for the correct value of"
+" the corresponding SoC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:586
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:579
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:385
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:596
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:385
+#: ../../source/bsp/imx8/installing-os.rsti:190
+msgid "Flash eMMC from USB stick"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:589
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:582
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:388
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:599
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:388
+#: ../../source/bsp/imx8/installing-os.rsti:193
+msgid "Flash eMMC from USB stick in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:400
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:400
+#: ../../source/bsp/imx8/installing-os.rsti:200
+msgid ""
+"These steps will show how to update the eMMC via a USB device. Configure "
+"the |ref-bootswitch| to SD Card and insert an SD card. Power on the board"
+" and stop in U-Boot prompt. Insert a USB device with the copied "
+"uncompressed WIC image to the USB slot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:467
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:600
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:462
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:593
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:405
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:475
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:480
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:610
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:575
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:405
+#: ../../source/bsp/imx8/installing-os.rsti:205
+msgid "Load your image from the USB device to RAM:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:493
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:626
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:488
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:619
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:432
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:501
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:506
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:636
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:601
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:432
+#: ../../source/bsp/imx8/installing-os.rsti:231
+#: ../../source/bsp/imx9/installing-os.rsti:199
+msgid "Flash eMMC from USB in Linux"
+msgstr ""
+
+#: ../../source/bsp/imx8/installing-os.rsti:233
+msgid ""
+"These steps will show how to flash the eMMC on Linux with a USB stick. "
+"You only need a complete image saved on the USB stick and a bootable WIC "
+"image. (e.g. |yocto-imagename|-|yocto-machinename|.|yocto-imageext|). Set"
+" the |ref-bootswitch| to SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:500
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:632
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:495
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:625
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:438
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:508
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:513
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:642
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:607
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:438
+#: ../../source/bsp/imx8/installing-os.rsti:237
+#: ../../source/bsp/imx9/installing-os.rsti:205
+msgid "Insert and mount the USB stick:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:515
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:647
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:510
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:640
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:453
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:523
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:528
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:657
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:622
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:453
+#: ../../source/bsp/imx8/installing-os.rsti:252
+#: ../../source/bsp/imx9/installing-os.rsti:220
+msgid "Now show your saved image files on the USB Stick:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:541
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:656
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:536
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:649
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:462
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:549
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:554
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:666
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:648
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:462
+#: ../../source/bsp/imx8/installing-os.rsti:261
+msgid ""
+"Write the image to the phyCORE-|soc| eMMC (MMC device 2 without "
+"partition):"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:548
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:649
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:663
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:768
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:543
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:644
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:656
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:761
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:469
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:573
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:556
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:657
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:561
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:662
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:673
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:778
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:655
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:777
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:469
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:573
+#: ../../source/bsp/imx8/installing-os.rsti:268
+#: ../../source/bsp/imx8/installing-os.rsti:373
+#: ../../source/bsp/imx9/installing-os.rsti:100
+#: ../../source/bsp/imx9/installing-os.rsti:254
+msgid "After a complete write, your board can boot from eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:667
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:660
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:473
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:677
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:659
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:473
+#: ../../source/bsp/imx8/installing-os.rsti:272
+#: ../../source/bsp/imx9/installing-os.rsti:258
+msgid ""
+"Before this will work, you need to configure the |ref-bootswitch| to "
+"**eMMC**."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:556
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:671
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:551
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:664
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:477
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:564
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:569
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:681
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:663
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:477
+#: ../../source/bsp/imx8/installing-os.rsti:276
+#: ../../source/bsp/imx9/installing-os.rsti:21
+msgid "Flash eMMC from SD Card"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:673
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:666
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:479
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:683
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:479
+#: ../../source/bsp/imx8/installing-os.rsti:278
+msgid ""
+"Even if there is no network available, you can update the eMMC. For that,"
+" you only need a ready-to-use image file (``*.wic``) located on the SD "
+"card. Because the image file is quite large, you have to create a third "
+"partition. To create a new partition or enlarge your SD card, see |ref-"
+"format-sd|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:678
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:671
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:484
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:688
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:671
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:484
+#: ../../source/bsp/imx8/installing-os.rsti:283
+#: ../../source/bsp/imx9/installing-os.rsti:29
+msgid ""
+"Alternatively, flash a partup package to the SD card, as described in "
+"|ref-getting-started|. This will ensure the full space of the SD card is "
+"used."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:682
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:675
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:488
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:692
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:675
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:488
+#: ../../source/bsp/imx8/installing-os.rsti:287
+msgid "Flash eMMC from SD card in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:686
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:679
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:696
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:679
+#: ../../source/bsp/imx8/installing-os.rsti:291
+msgid ""
+"This step only works if the size of the image file is less than 1GB due "
+"to limited usage of RAM size in the Bootloader after enabling OPTEE. If "
+"the image file is too large use the `Updating eMMC from SD card in Linux "
+"on Target` subsection."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:496
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:496
+#: ../../source/bsp/imx8/installing-os.rsti:296
+msgid ""
+"Flash an SD card with a working image and create a third ext4 partition. "
+"Copy the WIC image (for example |yocto-imagename|.rootfs.wic) to this "
+"partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:694
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:687
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:498
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:704
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:687
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:498
+#: ../../source/bsp/imx8/installing-os.rsti:299
+msgid "Configure the |ref-bootswitch| to SD Card and insert the SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:695
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:688
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:499
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:705
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:688
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:499
+#: ../../source/bsp/imx8/installing-os.rsti:300
+msgid "Power on the board and stop in U-Boot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:583
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:696
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:578
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:689
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:500
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:591
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:596
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:706
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:689
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:500
+#: ../../source/bsp/imx8/installing-os.rsti:301
+msgid "Load the image:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:705
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:698
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:510
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:715
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:698
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:510
+#: ../../source/bsp/imx8/installing-os.rsti:310
+msgid "Switch the mmc dev to eMMC:"
+msgstr ""
+
+#: ../../source/bsp/imx8/installing-os.rsti:321
+msgid ""
+"Flash your WIC image (for example |yocto-imagename|.rootfs.wic) from the "
+"SD card to eMMC. This will partition the card and copy imx-boot, Image, "
+"dtb, dtbo, and root file system to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:727
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:720
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:532
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:737
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:720
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:532
+#: ../../source/bsp/imx8/installing-os.rsti:332
+msgid "Power off the board and change the |ref-bootswitch| to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:611
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:730
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:606
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:723
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:535
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:619
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:624
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:740
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:723
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:535
+#: ../../source/bsp/imx8/installing-os.rsti:335
+#: ../../source/bsp/imx9/installing-os.rsti:33
+msgid "Flash eMMC from SD card in Linux on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:732
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:725
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:537
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:742
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:725
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:537
+#: ../../source/bsp/imx8/installing-os.rsti:337
+msgid ""
+"You can also flash the eMMC on Linux. You only need a partup package or "
+"WIC image saved on the SD card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:735
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:728
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:540
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:745
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:728
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:540
+#: ../../source/bsp/imx8/installing-os.rsti:340
+msgid "Show your saved partup package or WIC image files on the SD card:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:745
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:738
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:550
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:755
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:754
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:550
+#: ../../source/bsp/imx8/installing-os.rsti:350
+msgid ""
+"Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without** "
+"partition) using `partup`_:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:753
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:746
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:558
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:763
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:762
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:558
+#: ../../source/bsp/imx8/installing-os.rsti:358
+msgid ""
+"Flashing the partup package has the advantage of using the full capacity "
+"of the eMMC device, adjusting partitions accordingly."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:758
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:751
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:563
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:768
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:563
+#: ../../source/bsp/imx8/installing-os.rsti:363
+msgid "Alternatively, ``bmaptool`` may be used instead:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:765
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:758
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:570
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:775
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:570
+#: ../../source/bsp/imx8/installing-os.rsti:370
+msgid ""
+"Keep in mind that the root partition does not make use of the full space "
+"when flashing with ``bmaptool``."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:772
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:765
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:577
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:782
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:781
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:577
+#: ../../source/bsp/imx8/installing-os.rsti:377
+#: ../../source/bsp/imx9/installing-os.rsti:104
+msgid "Before this will work, you need to configure the |ref-bootswitch| to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:657
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:775
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:652
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:768
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:665
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:670
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:785
+#: ../../source/bsp/imx8/installing-os.rsti:380
+msgid "Flash SPI NOR Flash"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:777
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:770
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:787
+#: ../../source/bsp/imx8/installing-os.rsti:382
+msgid ""
+"The |som| modules are optionally equipped with SPI NOR Flash. To boot "
+"from SPI Flash, set |ref-bootswitch| to **SPI NOR**. The SPI Flash is "
+"usually quite small. The phyBOARD-Pollux-i.MX8MP kit only has 32MB SPI "
+"NOR flash populated. Only the bootloader and the environment can be "
+"stored. The kernel, device tree, and file system are taken from eMMC by "
+"default."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:665
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:783
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:660
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:776
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:673
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:678
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:793
+#: ../../source/bsp/imx8/installing-os.rsti:388
+msgid ""
+"The SPI NOR flash partition table is defined in the U-Boot environment. "
+"It can be printed with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:674
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:792
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:669
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:785
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:682
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:687
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:802
+#: ../../source/bsp/imx8/installing-os.rsti:397
+msgid "Flash SPI NOR Flash from Network"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:676
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:794
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:671
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:787
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:684
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:689
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:804
+#: ../../source/bsp/imx8/installing-os.rsti:399
+msgid ""
+"The SPI NOR can contain the bootloader and environment to boot from. The "
+"arm64 kernel can not decompress itself, the image size extends the SPI "
+"NOR flash populated on the phyCORE-|soc|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:803
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:796
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:813
+#: ../../source/bsp/imx8/installing-os.rsti:408
+msgid "Flash SPI NOR from Network in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:805
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:798
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:815
+#: ../../source/bsp/imx8/installing-os.rsti:410
+msgid ""
+"Similar to updating the eMMC over a network, be sure to set up the "
+"development host correctly. The IP needs to be set to 192.168.3.10, the "
+"netmask to 255.255.255.0, and a TFTP server needs to be available. Before"
+" reading and writing is possible, the SPI NOR flash needs to be probed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:815
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:808
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:825
+#: ../../source/bsp/imx8/installing-os.rsti:420
+msgid ""
+"A specially formatted U-Boot image for the SPI NOR flash is used. Ensure "
+"you use the correct image file. Load the image over tftp, erase and write"
+" the bootloader to the flash:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:709
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:785
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:827
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:899
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:704
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:780
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:820
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:892
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:717
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:793
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:722
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:798
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:837
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:909
+#: ../../source/bsp/imx8/installing-os.rsti:432
+#: ../../source/bsp/imx8/installing-os.rsti:504
+msgid ""
+"Erase the environment partition as well. This way, the environment can be"
+" written after booting from SPI NOR flash:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:723
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:835
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:718
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:828
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:731
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:736
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:845
+#: ../../source/bsp/imx8/installing-os.rsti:440
+msgid "Flash SPI NOR from Network in kernel on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:725
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:837
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:720
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:830
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:733
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:738
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:847
+#: ../../source/bsp/imx8/installing-os.rsti:442
+msgid "Copy the image from the host to the target:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:844
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:837
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:854
+#: ../../source/bsp/imx8/installing-os.rsti:449
+msgid "Find the number of blocks to erase of the U-boot partition:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:860
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:853
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:870
+#: ../../source/bsp/imx8/installing-os.rsti:465
+msgid "Erase the U-Boot partition and flash it:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:757
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:869
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:752
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:862
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:765
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:770
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:879
+#: ../../source/bsp/imx8/installing-os.rsti:474
+msgid "Flash SPI NOR Flash from SD Card"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:759
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:871
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:754
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:864
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:767
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:772
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:881
+#: ../../source/bsp/imx8/installing-os.rsti:476
+msgid "The bootloader on SPI NOR flash can be also flashed with SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:874
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:867
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:884
+#: ../../source/bsp/imx8/installing-os.rsti:479
+msgid "Flash SPI NOR from SD Card in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:876
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:909
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:869
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:902
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:886
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:919
+#: ../../source/bsp/imx8/installing-os.rsti:481
+#: ../../source/bsp/imx8/installing-os.rsti:514
+msgid ""
+"Copy the SPI NOR flash U-boot image imx-boot-|yocto-machinename|-fspi"
+".bin-flash_evk_flexspi to the first partition on the SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:880
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:873
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:890
+#: ../../source/bsp/imx8/installing-os.rsti:485
+msgid ""
+"Before reading and writing are possible, the SPI-NOR flash needs to be "
+"probed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:774
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:888
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:769
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:881
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:782
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:787
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:898
+#: ../../source/bsp/imx8/installing-os.rsti:493
+msgid ""
+"A specially formatted U-boot image for the SPI NOR flash is used. Ensure "
+"you use the correct image file. Load the image from the SD Card, erase "
+"and write the bootloader to the flash:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:799
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:907
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:794
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:900
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:807
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:812
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:917
+#: ../../source/bsp/imx8/installing-os.rsti:512
+msgid "Flash SPI NOR from SD Card in kernel on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:801
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:913
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:796
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:906
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:809
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:814
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:923
+#: ../../source/bsp/imx8/installing-os.rsti:518
+msgid "Mount the SD Card:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:920
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:913
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:930
+#: ../../source/bsp/imx8/installing-os.rsti:525
+msgid "Find the number of blocks to erase of the U-Boot partition:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:748
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:824
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:936
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:743
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:819
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:929
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:756
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:832
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:761
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:837
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:946
+#: ../../source/bsp/imx8/installing-os.rsti:541
+msgid "Erase the u-boot partition and flash it:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:833
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:945
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:828
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:938
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:580
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:841
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:846
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:955
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:784
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:580
+#: ../../source/bsp/imx8/installing-os.rsti:550
+#: ../../source/bsp/imx9/installing-os.rsti:262
+msgid "RAUC"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:947
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:940
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:957
+#: ../../source/bsp/imx8/installing-os.rsti:552
+msgid ""
+"The RAUC (Robust Auto-Update Controller) mechanism support has been added"
+" to meta-ampliphy. It controls the procedure of updating a device with "
+"new firmware. This includes updating the Linux kernel, Device Tree, and "
+"root filesystem. PHYTEC has written an online manual on how we have "
+"intergraded RAUC into our BSPs: |rauc-manual|_."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:234
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:849
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:960
+#: ../../source/bsp/imx8/imx8mn/head.rst:227
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:844
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:953
+#: ../../source/bsp/imx8/imx8mp/head.rst:247
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:596
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:857
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:862
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:970
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:800
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:596
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:238
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:247
+msgid "Development"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:2
+msgid "Host Network Preparation"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:4
+msgid ""
+"For various tasks involving a network in the Bootloader, some host "
+"services are required to be set up. On the development host, a TFTP, NFS "
+"and DHCP server must be installed and configured. The following tools "
+"will be needed to boot via Ethernet:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:14
+msgid "TFTP Server Setup"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:16
+msgid "First, create a directory to store the TFTP files:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:22
+msgid ""
+"Then copy your BSP image files to this directory and make sure other "
+"users have read access to all the files in the tftp directory, otherwise "
+"they are not accessible from the target."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:30
+msgid ""
+"You also need to configure a static IP address for the appropriate "
+"interface. The default IP address of the PHYTEC evaluation boards is "
+"192.168.3.11. Setting a host address 192.168.3.10 with netmask "
+"255.255.255.0 is a good choice."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:38
+msgid ""
+"Replace <network-interface> with the network interface you configured and"
+" want to connect the board to. You can show all network interfaces by not"
+" specifying a network interface."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:42
+msgid "The message you receive should contain this:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:48
+msgid "Create or edit the ``/etc/default/tftpd-hpa`` file:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:59
+msgid "Set TFTP_DIRECTORY to your TFTP server root directory"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:60
+msgid ""
+"Set TFTP_ADDRESS to the host address the server is listening to (set to "
+"0.0.0.0:69 to listen to all local IPs)"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:62
+msgid "Set TFTP_OPTIONS, the following command shows the available options:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:68
+msgid "Restart the services to pick up the configuration changes:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:75
+msgid ""
+"Now connect the ethernet port of the board to your host system. We also "
+"need a network connection between the embedded board and the TFTP server."
+" The server should be set to IP 192.168.3.10 and netmask 255.255.255.0."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:81
+msgid "NFS Server Setup"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:83
+msgid "Create an nfs directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:89
+msgid ""
+"The NFS server is not restricted to a certain file system location, so "
+"all we have to do on most distributions is modify the file "
+"``/etc/exports`` and export our root file system to the embedded network."
+" In this example file, the whole directory is exported and the \"lab "
+"network\" address of the development host is 192.168.3.10. The IP address"
+" has to be adapted to the local needs:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:99
+msgid "Now the NFS-Server has to read the ``/etc/exportfs`` file again:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:106
+msgid "DHCP Server setup"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:108
+msgid ""
+"Create or edit the ``/etc/kea/kea-dhcp4.conf`` file; Using the internal "
+"subnet sample. Replace <network-interface> with the name for the physical"
+" network interface:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:138
+msgid ""
+"Be careful when creating subnets as this may interfere with the company "
+"network policy. To be on the safe side, use a different network and "
+"specify that via the ``interfaces`` configuration option."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:143
+msgid ""
+"Now the DHCP-Server has to read the ``/etc/kea/kea-dhcp4.conf`` file "
+"again:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/host_network_setup.rsti:149
+msgid ""
+"When you boot/restart your host PC and don't have the network interface, "
+"as specified in the kea-dhcp4 config, already active the kea-dhcp4-server"
+" will fail to start. Make sure to start/restart the systemd service when "
+"you connect the interface."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:2
+#: ../../source/bsp/imx8/development/netboot.rsti:2
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:601
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:805
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:601
+msgid "Booting the Kernel from a Network"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:4
+#: ../../source/bsp/imx8/development/netboot.rsti:4
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:603
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:807
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:603
+msgid ""
+"Booting from a network means loading the kernel and device tree over TFTP"
+" and the root file system over NFS. The bootloader itself must already be"
+" loaded from another available boot device."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:9
+#: ../../source/bsp/imx8/development/netboot.rsti:9
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:608
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:812
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:608
+msgid "Place Images on Host for Netboot"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:11
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:610
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:814
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:610
+msgid "Copy the kernel image to your tftp directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:17
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:616
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:820
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:616
+msgid "Copy the devicetree to your tftp directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:23
+msgid "Copy all the overlays you want to use into your tftp directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:29
+#: ../../source/bsp/imx8/development/netboot.rsti:23
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:622
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:826
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:622
+msgid ""
+"Make sure other users have read access to all the files in the tftp "
+"directory, otherwise they are not accessible from the target:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:36
+#: ../../source/bsp/imx8/development/netboot.rsti:30
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:629
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:833
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:629
+msgid "Extract the rootfs to your nfs directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:44
+#: ../../source/bsp/imx8/development/netboot.rsti:38
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:637
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:841
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:637
+msgid "Make sure you extract with sudo to preserve the correct ownership."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:47
+#: ../../source/bsp/imx8/development/netboot.rsti:41
+msgid "Set the bootenv.txt for Netboot"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:49
+#: ../../source/bsp/imx8/development/netboot.rsti:43
+msgid ""
+"Create a bootenv.txt file in your tftp directory and write the following "
+"variables into it."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:58
+msgid ""
+"<overlayfilenames> has to be replaced with the devicetree overlay "
+"filenames that you want to use. Separate the filenames by spaces. For "
+"example:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:67
+msgid "All supported devicetree overlays are in the |ref-dt| chapter."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:70
+#: ../../source/bsp/imx8/development/netboot.rsti:67
+msgid "Network Settings on Target"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:72
+#: ../../source/bsp/imx8/development/netboot.rsti:69
+msgid ""
+"To customize the targets ethernet configuration, please follow the "
+"description here: |ref-network|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:76
+#: ../../source/bsp/imx8/development/netboot.rsti:73
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:640
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:844
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:640
+msgid "Booting from an Embedded Board"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:78
+#: ../../source/bsp/imx8/development/netboot.rsti:75
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:642
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:846
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:642
+msgid "Boot the board into the U-boot prompt and press any key to hold."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/netboot.rsti:80
+#: ../../source/bsp/imx8/development/netboot.rsti:77
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:644
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:848
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:644
+msgid "To boot from a network, call:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:2
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:855
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:966
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:850
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:959
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:652
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:863
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:868
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:976
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:856
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:652
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:244
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:253
+msgid "Working with UUU-Tool"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:4
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:857
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:968
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:852
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:961
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:654
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:865
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:870
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:978
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:858
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:654
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:246
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:255
+msgid ""
+"The Universal Update Utility Tool (UUU-Tool) from NXP is a software to "
+"execute on the host to load and run the bootloader on the board through "
+"SDP (Serial Download Protocol). For detailed information visit "
+"https://github.com/nxp-imx/mfgtools or download the `Official UUU-tool "
+"documentation "
+"<https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-"
+"processors/140261/1/UUU.pdf>`_."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:11
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:864
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:975
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:859
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:968
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:661
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:872
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:877
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:985
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:865
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:661
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:253
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:262
+msgid "Host preparations for UUU-Tool Usage"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:13
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:866
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:977
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:861
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:970
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:663
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:874
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:879
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:987
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:867
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:663
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:255
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:264
+msgid "Follow the instructions from https://github.com/nxp-imx/mfgtools#linux."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:15
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:868
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:979
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:863
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:972
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:665
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:876
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:881
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:989
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:869
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:665
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:257
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:266
+msgid "If you built UUU from source, add it to ``PATH``:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:17
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:870
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:981
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:865
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:974
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:667
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:878
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:883
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:991
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:871
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:667
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:259
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:268
+msgid ""
+"This BASH command adds UUU only temporarily to ``PATH``. To add it "
+"permanently, add this line to ``~/.bashrc``."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:24
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:877
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:988
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:872
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:981
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:674
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:885
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:890
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:998
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:878
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:674
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:266
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:275
+msgid "Set udev rules (documented in ``uuu -udev``):"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:32
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:885
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:996
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:880
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:989
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:682
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:893
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:898
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1006
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:886
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:682
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:274
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:283
+msgid "Get Images"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:34
+msgid ""
+"Download imx-boot from our server or get it from your Yocto build "
+"directory at build/deploy/images/|yocto-machinename|/. For flashing a wic"
+" image to eMMC, you will also need |yocto-imagename|-|yocto-"
+"machinename|.rootfs.wic."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:39
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:892
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1003
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:887
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:996
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:689
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:900
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:905
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1013
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:893
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:689
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:281
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:290
+msgid "Prepare Target"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:41
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:894
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1005
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:889
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:998
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:691
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:902
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:907
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1015
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:895
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:691
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:283
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:292
+msgid ""
+"Set the |ref-bootswitch| to **USB Serial Download**. Also, connect USB "
+"port |ref-usb-otg| to your host."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:45
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:898
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1009
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:893
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1002
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:695
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:906
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:911
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1019
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:899
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:695
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:287
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:296
+msgid "Starting bootloader via UUU-Tool"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:47
+#: ../../source/bsp/imx-common/development/uuu.rsti:92
+#: ../../source/bsp/imx-common/development/uuu.rsti:101
+#: ../../source/bsp/imx-common/development/uuu.rsti:111
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:900
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:945
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:954
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1011
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1056
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1065
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:895
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:940
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:949
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1004
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1049
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1058
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:697
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:742
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:751
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:908
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:953
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:962
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:913
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:958
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:967
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1021
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1066
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1075
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:901
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:946
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:955
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:697
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:742
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:751
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:289
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:334
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:343
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:298
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:343
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:352
+msgid "Execute and power up the board:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:53
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:906
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1017
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:901
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1010
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:703
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:914
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:919
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1027
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:907
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:703
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:295
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:304
+msgid ""
+"You can see the bootlog on the console via |ref-debugusbconnector|, as "
+"usual."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:56
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:909
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1020
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:904
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1013
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:706
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:917
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:922
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1030
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:910
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:706
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:298
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:307
+msgid ""
+"The default boot command when booting with UUU-Tool is set to fastboot. "
+"If you want to change this, please adjust the environment variable "
+"bootcmd_mfg in U-boot prompt with setenv bootcmd_mfg. Please note, when "
+"booting with UUU-tool the default environment is loaded. Saveenv has no "
+"effect. If you want to change the boot command permanently for UUU-boot, "
+"you need to change this in U-Boot code."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:64
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:917
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1028
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:912
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1021
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:714
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:925
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:930
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1038
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:918
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:714
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:306
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:315
+msgid "Flashing U-boot Image to eMMC via UUU-Tool"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:68
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:921
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1032
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:916
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1025
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:718
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:929
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:934
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1042
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:922
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:718
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:310
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:319
+msgid ""
+"UUU flashes U-boot into eMMC BOOT (hardware) boot partitions, and it sets"
+" the BOOT_PARTITION_ENABLE in the eMMC! This is a problem since we want "
+"the bootloader to reside in the eMMC USER partition. Flashing next U-Boot"
+" version .wic image and not disabling BOOT_PARTITION_ENABLE bit will "
+"result in device always using U-boot saved in BOOT partitions. To fix "
+"this in U-Boot:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:84
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:937
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1048
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:932
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1041
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:734
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:945
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:950
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1058
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:938
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:734
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:326
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:335
+msgid "or check |ref-disable-emmc-part| from Linux."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:86
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:939
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1050
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:934
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1043
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:736
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:947
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:952
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1060
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:940
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:736
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:328
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:337
+msgid ""
+"This way the bootloader is still flashed to eMMC BOOT partitions but it "
+"is not used!"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:89
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:942
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1053
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:937
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1046
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:739
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:950
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:955
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1063
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:943
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:739
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:331
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:340
+msgid ""
+"When using **partup** tool and ``.partup`` package for eMMC flashing this"
+" is done by default, which makes partup again superior flash option."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:99
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:952
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1063
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:947
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1056
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:749
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:960
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:965
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1073
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:953
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:749
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:341
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:350
+msgid "Flashing wic Image to eMMC via UUU-Tool"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:109
+msgid "Flashing SPI NOR Flash via UUU-Tool"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/uuu.rsti:118
+msgid ""
+"This will update the U-Boot on SPI NOR Flash but not the environment. You"
+" may need to erase the old environment so the default environment of the "
+"new U-Boot gets loaded:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:2
+msgid "Standalone Build"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:4
+msgid ""
+"In this section, we describe how to build the U-Boot and the Linux kernel"
+" without using the `Yocto Project <https://www.yoctoproject.org/>`__. "
+"This procedure makes the most sense for development. The U-Boot source "
+"code, the Linux kernel, and all other git repositories are available on "
+"our `Git server <https://git.phytec.de/>`__ at git://git.phytec.de."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:11
+msgid ""
+"Should your company firewall/gateway inhibit the git protocol, you may "
+"use HTTP or HTTPS instead (e.g. git clone |u-boot-repo-url|)"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:15
+msgid "Git Repositories"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:17
+msgid "Used U-Boot repository:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:24
+msgid ""
+"Our U-Boot is based on the |u-boot-repo-name| and adds board-specific "
+"patches."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:25
+msgid "Used Linux kernel repository:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:32
+msgid "Our |soc| kernel is based on the |kernel-repo-name| kernel."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:34
+msgid ""
+"To find out which u-boot and kernel tags to use for a specific board, "
+"have a look at your BSP source folder:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:46
+msgid "Get the SDK"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:48
+msgid ""
+"You can download the SDK `here <dl-sdk_>`_, or build it yourself with "
+"Yocto:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:50
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:970
+msgid "Move to the Yocto build directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:4
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:61
+msgid "Install the SDK"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:6
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:63
+msgid "Set correct permissions and install the SDK:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:21
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:78
+msgid "Using the SDK"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:23
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:80
+msgid ""
+"Activate the toolchain for your shell by sourcing the *environment-setup*"
+" file in the toolchain directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:32
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:89
+msgid "Installing Required Tools"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:34
+#: ../../source/bsp/imx-common/development/standalone_build_preface.rsti:91
+msgid ""
+"Building Linux and U-Boot out-of-tree requires some additional host tool "
+"dependencies to be installed. For Ubuntu you can install them with:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:2
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:2
+msgid "Build imx-boot"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:5
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:5
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:39
+msgid "Get the needed binaries"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:7
+msgid ""
+"To build the imx-boot, you need to **copy** these **files** to your |u"
+"-boot-repo-name| **build directory** and rename them to fit with *mkimage"
+" tool* script:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:10
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:10
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:44
+msgid ""
+"**ARM Trusted firmware binary** (*mkimage tool* compatible format "
+"**bl31.bin**): bl31-|kernel-socname|.bin"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:12
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:12
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:46
+msgid "**OPTEE image** (optional): tee.bin"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:13
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:13
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:47
+msgid ""
+"**DDR firmware files** (*mkimage tool* compatible format "
+"**lpddr4_[i,d]mem_\\*d_\\*.bin**): lpddr4_dmem_1d_*.bin, "
+"lpddr4_dmem_2d_*.bin, lpddr4_imem_1d_*.bin, lpddr4_imem_2d_*.bin"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:18
+msgid ""
+"If you already build our BSP with Yocto, you can get the bl31-|kernel-"
+"socname|.bin, tee.bin and lpddr4_*.bin from the directory mentioned here:"
+" |ref-bsp-images|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:22
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:56
+msgid "Or you can download the files here: |link-boot-tools|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:26
+msgid ""
+"Make sure you rename the files you need so that they are compatible with "
+"the *mkimage tool*."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:30
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:40
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:5
+msgid "Build U-Boot"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:3
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:34
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:44
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:12
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:965
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:960
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:973
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:978
+msgid "Get the U-Boot sources:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:10
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:41
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:50
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:19
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:971
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:966
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:979
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:984
+msgid ""
+"To get the correct *U-Boot* **tag** you need to take a look at our "
+"release notes, which can be found here: `release notes <releasenotes_>`_"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:12
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:43
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:52
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:973
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:968
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:981
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:986
+msgid "The **tag** needed at this release is called |u-boot-tag|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:13
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:44
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:53
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:22
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:974
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:969
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:982
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:987
+msgid "Check out the needed *U-Boot* **tag**:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:22
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:53
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:62
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:983
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:978
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:991
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:996
+msgid ""
+"Technically, you can now build the U-Boot, but practically there are some"
+" further steps necessary:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:25
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:56
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:65
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:986
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:981
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:994
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:999
+msgid "Create your own development branch:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:34
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:65
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:73
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:994
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:989
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1002
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1007
+msgid "You can name your development branch as you like, this is just an example."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:36
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:67
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:996
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:991
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1004
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1009
+msgid "Copy all binaries into the U-Boot build directory"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:24
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:37
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:68
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:75
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:31
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:31
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:997
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:992
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1005
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1010
+msgid "Set up a build environment:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:44
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:75
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:61
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1011
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1006
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1019
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1024
+msgid "build flash.bin (imx-boot):"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:52
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:83
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:73
+msgid ""
+"The flash.bin can be found at |u-boot-repo-name|/ directory and now can "
+"be flashed. A chip-specific offset is needed:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:58
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:89
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:143
+#: ../../source/bsp/imx-common/emmc.rsti:70
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:79
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1025
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1020
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1038
+msgid "SoC"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:58
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:89
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:143
+#: ../../source/bsp/imx-common/emmc.rsti:70
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:79
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1025
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1020
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1038
+msgid "Offset User Area"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:58
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:89
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:143
+#: ../../source/bsp/imx-common/emmc.rsti:70
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:79
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1025
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1020
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1038
+msgid "Offset Boot Partition"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:58
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:89
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:143
+#: ../../source/bsp/imx-common/emmc.rsti:70
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:79
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1025
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1020
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1038
+msgid "eMMC Device"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:60
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:91
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:145
+#: ../../source/bsp/imx-common/emmc.rsti:73
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:81
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1022
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1035
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1040
+msgid "|soc|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:60
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:91
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:145
+#: ../../source/bsp/imx-common/emmc.rsti:73
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:81
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1022
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1035
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1040
+msgid "|u-boot-offset| kiB"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:60
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:91
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:145
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:81
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1022
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1035
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1040
+msgid "|u-boot-offset-boot-part| kiB"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:60
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:91
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:145
+#: ../../source/bsp/imx-common/emmc.rsti:73
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:81
+msgid "/dev/|emmcdev|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:63
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:94
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:148
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:84
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1030
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1025
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1038
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1043
+msgid "E.g. flash SD card:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:71
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:102
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:162
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:92
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1038
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1046
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1051
+msgid ""
+"The specific offset values are also declared in the Yocto variables "
+"\"BOOTLOADER_SEEK\" and \"BOOTLOADER_SEEK_EMMC\""
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:4
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:76
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:107
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:98
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1054
+msgid "Build U-Boot With a Fixed RAM Size"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:6
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:78
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:109
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:100
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1056
+msgid ""
+"If you cannot boot your system anymore because the hardware introspection"
+" in the EEPROM is damaged or deleted, you can create a flash.bin with a "
+"fixed ram size. You should still contact support and flash the correct "
+"EEPROM data, as this could lead to unexpected behavior."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:11
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:83
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:114
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:105
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1061
+msgid ""
+"Follow the steps to get the U-boot sources and check the correct branch "
+"in the **Build U-Boot** section."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:14
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:86
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:117
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:108
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1064
+msgid "Edit the file configs/phycore-|kernel-socname|\\_defconfig:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:25
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:97
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_binman.rsti:128
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:119
+msgid ""
+"Choose the correct RAM size as populated on the board and uncomment the "
+"line for this ram size. After saving the changes, follow the remaining "
+"steps from Build U-Boot."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:2
+msgid "Build Kernel"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:4
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:11
+msgid ""
+"The used |kernel-repo-name| branch can be found in the `release notes "
+"<releasenotes_>`_"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:6
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:13
+msgid "The tag needed for this release is called |kernel-tag|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:7
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:14
+msgid "Check out the needed |kernel-repo-name| tag:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:17
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:24
+msgid ""
+"For committing changes, it is highly recommended to switch to a new "
+"branch:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:31
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:41
+msgid "Build the linux kernel:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:39
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:49
+msgid "Install kernel modules to e.g. NFS directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:46
+msgid "The Image can be found at ~/|kernel-repo-name|/arch/arm64/boot/Image"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:47
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:57
+msgid ""
+"The dtb can be found at ~/|kernel-repo-"
+"name|/arch/arm64/boot/dts/freescale/|dt-carrierboard|.dtb"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:49
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:59
+msgid "For (re-)building only Devicetrees and -overlays, it is sufficient to run"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:58
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:68
+msgid "If you are facing the following build issue:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:64
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:74
+msgid "Make sure you installed the package *\"libyaml-dev\"* on your host system:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:71
+msgid "Copy Kernel to SD Card"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_kernel.rsti:73
+msgid ""
+"When one-time boot via netboot is not sufficient, the kernel along with "
+"its modules and the corresponding device tree blob may be copied directly"
+" to a mounted SD card."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:2
+msgid "Accessing the Development states"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:5
+msgid "Development state of current release"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:7
+msgid ""
+"These release manifests exist to give you access to the development "
+"states of the *Yocto* BSP. They will not be displayed in the phyLinux "
+"selection menu but need to be selected manually. This can be done using "
+"the following command line:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:17
+msgid ""
+"This will initialize a BSP that will track the latest development state "
+"of the current release (|yocto-manifestname|). From now on *repo sync* in"
+" this folder will pull all the latest changes from our Git repositories:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:26
+msgid "Development state of upcoming release"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/development_manifests.rsti:28
+msgid ""
+"Also development states of upcoming releases can be accessed this way. "
+"For this execute the following command and look for a release with a "
+"higher PDXX.Y number than the latest one (|yocto-manifestname|) and "
+"``.y`` at the end:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/upstream_manifest.rsti:2
+msgid "Accessing the Latest Upstream Support"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/upstream_manifest.rsti:4
+msgid ""
+"We have a vanilla manifest that makes use of the Yocto master branches "
+"(not an NXP release), Linux, and U-Boot. This can be used to test the "
+"latest upstream kernel/U-Boot."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/upstream_manifest.rsti:10
+msgid ""
+"The master manifest reflects the latest state of development. This tends "
+"to be broken from time to time. We try to fix the master on a regular "
+"basis."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:2
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:798
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:988
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:798
+msgid "Format SD-Card"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:4
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:800
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:990
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:800
+msgid ""
+"Most images are larger than the default root partition. To flash any "
+"storage device with SD Card, the rootfs needs to be expanded or a "
+"separate partition needs to be created. There are some different ways to "
+"format the SD Card.  The easiest way to do this is to use the UI program "
+"Gparted."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:10
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:806
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:996
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:806
+msgid "Gparted"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:12
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:808
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:998
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:808
+msgid "Get GParted:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:18
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:814
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1004
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:814
+msgid "Insert the SD Card into your host and get the device name:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:28
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:824
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1014
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:824
+msgid "Unmount all SD Card partitions."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:29
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:825
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1015
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:825
+msgid "Launch GParted:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:38
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:834
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1024
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:834
+msgid "Expand rootfs"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:41
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:837
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:837
+msgid ""
+"Running gparted on host systems which are using resize2fs version 1.46.6 "
+"and older (e.g. Ubuntu 22.04) are not able to expand the ext4 partition "
+"created with Yocto Mickledore and newer. This is due to a new default "
+"option in resize2fs which causes a incompatibility. See `release notes "
+"<https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.47.0>`_."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:47
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:74
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:843
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:870
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1033
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1060
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:843
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:870
+msgid "Choose your SD Card device at the drop-down menu on the top right"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:48
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:844
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1034
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:844
+msgid "Choose the ext4 root partition and click on resize:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:53
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:849
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1039
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:849
+msgid "Drag the slider as far as you like or enter the size manually."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:57
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:853
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1043
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:853
+msgid "Confirm your entry by clicking on the \"Change size\" button."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:61
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:857
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1047
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:857
+msgid "To apply your changes, press the green tick."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:62
+msgid ""
+"Now you can mount the root partition and copy e.g. the |yocto-imagename"
+"|-|yocto-machinename|.wic image to it. Then unmount it again:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:72
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:868
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1058
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:868
+msgid "Create the Third Partition"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:78
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:874
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1064
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:874
+msgid "Choose the bigger unallocated  area and press \"New\":"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:82
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:878
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1068
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:878
+msgid "Click \"Add\""
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:86
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:882
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1072
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:882
+msgid "Confirm your changes by pressing the green tick."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/format_sd-card.rsti:90
+msgid ""
+"Now you can mount the new partition and copy e.g. |yocto-imagename"
+"|-|yocto-machinename|.wic image to it. Then unmount it again:"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:2
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1055
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1050
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1066
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1096
+msgid "Device Tree (DT)"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:5
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1058
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1053
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1069
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1099
+msgid "Introduction"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:7
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1060
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1055
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1071
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1101
+msgid ""
+"The following text briefly describes the Device Tree and can be found in "
+"the Linux kernel Documentation (https://docs.kernel.org/devicetree/usage-"
+"model.html)"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:11
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1064
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1059
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1075
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1105
+msgid ""
+"*\"The “Open Firmware Device Tree”, or simply Devicetree (DT), is a data "
+"structure and language for describing hardware. More specifically, it is "
+"a description of hardware that is readable by an operating system so that"
+" the operating system doesn't need to hard code details of the "
+"machine.\"*"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:16
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1069
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1064
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1080
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1110
+msgid ""
+"The kernel documentation is a really good source for a DT introduction. "
+"An overview of the device tree data format can be found on the device "
+"tree usage page at `devicetree.org <https://www.devicetree.org/>`_."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:21
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1074
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1069
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1085
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1115
+msgid "PHYTEC |soc| BSP Device Tree Concept"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:23
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1076
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1071
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1087
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1117
+msgid ""
+"The following sections explain some rules PHYTEC has defined on how to "
+"set up device trees for our |soc| SoC-based boards."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:27
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1080
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1075
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1091
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1121
+msgid "Device Tree Structure"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:29
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1082
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1077
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1093
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1123
+msgid ""
+"*Module.dtsi* - Module includes all devices mounted on the SoM, such as "
+"PMIC and RAM."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:31
+msgid ""
+"*Board.dts* - include the module dtsi file. Devices that come from the "
+"|soc| SoC but are just routed down to the carrier board and used there "
+"are included in this dts."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:34
+msgid ""
+"*Overlay.dtso* - enable/disable features depending on optional hardware "
+"that may be mounted or missing on SoM or baseboard (e.g SPI flash or PEB-"
+"AV-10)"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:37
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1093
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1088
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1104
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1134
+msgid ""
+"From the root directory of the Linux Kernel our devicetree files for "
+"|socfamily| platforms can be found in ``arch/arm64/boot/dts/freescale/``."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:41
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1097
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1092
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1108
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1138
+msgid "Device Tree Overlay"
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:43
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1099
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1094
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1110
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1140
+msgid ""
+"Device Tree overlays are device tree fragments that can be merged into a "
+"device tree during boot time. These are for example hardware descriptions"
+" of an expansion board. They are instead of being added to the device "
+"tree as an extra include, now applied as an overlay. They also may only "
+"contain setting the status of a node depending on if it is mounted or "
+"not. The device tree overlays are placed next to the other device tree "
+"files in our Linux kernel repository in the subfolder "
+"``arch/arm64/boot/dts/freescale/overlays``."
+msgstr ""
+
+#: ../../source/bsp/device-tree.rsti:51
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1107
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1102
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1118
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1148
+msgid "Available overlays for |yocto-machinename|.conf are:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:1
+#: ../../source/bsp/imx9/dt-overlays.rsti:1
+msgid ""
+"The usage of overlays can be configured during runtime in Linux or "
+"U-Boot. Overlays are applied during the boot process in the bootloader "
+"after the boot command is called and before the kernel is loaded. The "
+"next sections explain the configuration in more detail."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:7
+#: ../../source/bsp/imx9/dt-overlays.rsti:7
+msgid "Set ``${overlays}`` variable"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:9
+#: ../../source/bsp/imx9/dt-overlays.rsti:9
+msgid ""
+"The ``${overlays}`` U-Boot environment variable contains a space-"
+"separated list of overlays that will be applied during boot. Depending on"
+" the boot source the overlays have to either be placed in the boot "
+"partition of eMMC/SD-Card or are loaded over tftp. Overlays set in the "
+"$KERNEL_DEVICETREE Yocto machine variable will be automatically added to "
+"the boot partition of the final WIC image."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:15
+#: ../../source/bsp/imx9/dt-overlays.rsti:15
+msgid ""
+"The ``${overlays}`` variable can be either set directly in the U-Boot "
+"environment or can be part of the external ``bootenv.txt`` environment "
+"file. By default, the ``${overlays}`` variable comes from the external "
+"``bootenv.txt`` environment file which is located in the boot partition. "
+"You can read and write the file on booted target from linux:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:27
+#: ../../source/bsp/imx9/dt-overlays.rsti:36
+msgid ""
+"Changes will take effect after the next reboot. If no ``bootenv.txt`` "
+"file is available the overlays variable can be set directly in the U-Boot"
+" environment."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:38
+#: ../../source/bsp/imx9/dt-overlays.rsti:47
+msgid ""
+"If a user defined ``${overlays}`` variable should be directly loaded from"
+" U-Boot environment but there is still an external ``bootenv.txt`` "
+"available, the ``${no_bootenv}`` variable needs to be set as a flag:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:49
+#: ../../source/bsp/imx9/dt-overlays.rsti:58
+msgid ""
+"More information about the external environment can be found in "
+"|ubootexternalenv|."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:52
+msgid ""
+"We use the ``${overlays}`` variable for overlays describing expansion "
+"boards and cameras that can not be detected during run time. To prevent "
+"applying overlays listed in the ``${overlays}`` variable during boot, the"
+" ``${no_overlays}`` variable can be set to `1` in the bootloader "
+"environment."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:64
+msgid "Extension Command"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:66
+msgid ""
+"The U-Boot extension command makes it possible to easily apply overlays "
+"that have been detected and added to a list by the board code callback "
+"`extension_board_scan() <overlaycallback_>`_. Overlays applied this way "
+"disable components that are not populated on the SoM. The detection is "
+"done with the EEPROM data (EEPROM SoM Detection) found on the SoM i2c "
+"EEPROM."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:73
+msgid ""
+"It depends on the SoM variant if any device tree overlays will be "
+"applied. To check if an overlay will be applied on the running SoM in "
+"U-Boot, run:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:88
+msgid "If the EEPROM data is not available, no device tree overlays are applied."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:90
+msgid ""
+"To prevent running the extension command during boot the "
+"``${no_extensions}`` variable can be set to `1` in the bootloader "
+"environment::"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:97
+#: ../../source/bsp/imx9/dt-overlays.rsti:73
+msgid "U-boot External Environment"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:99
+#: ../../source/bsp/imx9/dt-overlays.rsti:75
+msgid ""
+"During the start of the Linux Kernel the external environment "
+"``bootenv.txt`` text file will be loaded from the boot partition of an "
+"MMC device or via TFTP. The main intention of this file is to store the "
+"``${overlays}`` variable. This makes it easy to pre-define the overlays "
+"in Yocto depending on the used machine. The content from the file is "
+"defined in the Yocto recipe bootenv found in meta-phytec: |yocto-bootenv-"
+"link|"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:107
+#: ../../source/bsp/imx9/dt-overlays.rsti:83
+msgid ""
+"Other variables can be set in this file, too. They will overwrite the "
+"existing settings in the environment. But only variables evaluated after "
+"issuing the boot command can be overwritten, such as ``${nfsroot}`` or "
+"``${mmcargs}``. Changing other variables in that file will not have an "
+"effect. See the usage during netboot as an example."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:113
+#: ../../source/bsp/imx9/dt-overlays.rsti:89
+msgid ""
+"If the external environment can not be loaded the boot process will be "
+"anyway continued with the values of the existing environment settings."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:117
+#: ../../source/bsp/imx9/dt-overlays.rsti:93
+msgid "Change U-boot Environment from Linux on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:119
+#: ../../source/bsp/imx9/dt-overlays.rsti:95
+msgid ""
+"Libubootenv is a tool included in our images to modify the U-Boot "
+"environment of Linux on the target machine."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:122
+#: ../../source/bsp/imx9/dt-overlays.rsti:98
+msgid "Print the U-Boot environment using the following command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:128
+#: ../../source/bsp/imx9/dt-overlays.rsti:104
+msgid "Modify a U-Boot environment variable using the following command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:135
+#: ../../source/bsp/imx9/dt-overlays.rsti:111
+msgid ""
+"Libubootenv takes the environment selected in a configuration file. The "
+"environment to use is inserted there, and by default it is configured to "
+"use the eMMC environment (known as the default used environment)."
+msgstr ""
+
+#: ../../source/bsp/imx8/dt-overlays.rsti:139
+#: ../../source/bsp/imx9/dt-overlays.rsti:115
+msgid ""
+"If the eMMC is not flashed or the eMMC environment is deleted, "
+"libubootenv will not work. You should modify the ``/etc/fw_env.config`` "
+"file to match the environment source that you want to use."
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:2
+msgid "Accessing Peripherals"
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:4
+msgid ""
+"To find out which boards and modules are supported by the release of "
+"PHYTEC's phyCORE-|soc| BSP described herein, visit |dlpage-bsp|_ web page"
+" and click the corresponding BSP release in the download section. Here "
+"you can find all hardware supported in the columns \"Hardware Article "
+"Number\" and the correct machine name in the corresponding cell under "
+"\"Machine Name\"."
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:10
+msgid ""
+"To achieve maximum software reuse, the Linux kernel offers a "
+"sophisticated infrastructure that layers software components into board-"
+"specific parts. The BSP tries to modularize the kit features as much as "
+"possible. When a customized baseboard or even a customer-specific module "
+"is developed, most of the software support can be re-used without error-"
+"prone copy-and-paste. The kernel code corresponding to the boards can be "
+"found in device trees (DT) in the kernel repository under "
+"``arch/arm64/boot/dts/freescale/*.dts``."
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:18
+msgid ""
+"In fact, software reuse is one of the most important features of the "
+"Linux kernel, especially of the ARM implementation which always has to "
+"fight with an insane number of possibilities of the System-on-Chip CPUs. "
+"The whole board-specific hardware is described in DTs and is not part of "
+"the kernel image itself. The hardware description is in its own separate "
+"binary, called the Device Tree Blob (DTB) (section |ref-dt|)."
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:25
+msgid ""
+"Please read section PHYTEC |soc| BSP Device Tree Concept to get an "
+"understanding of our |socfamily| BSP device tree model."
+msgstr ""
+
+#: ../../source/bsp/peripherals/introduction.rsti:28
+msgid ""
+"The following sections provide an overview of the supported hardware "
+"components and their operating system drivers on the |socfamily| "
+"platform. Further changes can be ported upon customer request."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/pin-muxing.rsti:2
+msgid "|soc| Pin Muxing"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/pin-muxing.rsti:4
+msgid ""
+"The |soc| SoC contains many peripheral interfaces. In order to reduce "
+"package size and lower overall system cost while maintaining maximum "
+"functionality, many of the |soc| terminals can multiplex up to eight "
+"signal functions. Although there are many combinations of pin "
+"multiplexing that are possible, only a certain number of sets, called IO "
+"sets, are valid due to timing limitations. These valid IO sets were "
+"carefully chosen to provide many possible application scenarios for the "
+"user."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/pin-muxing.rsti:12
+msgid ""
+"Please refer to our Hardware Manual or the NXP |soc| Reference Manual for"
+" more information about the specific pins and the muxing capabilities."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/pin-muxing.rsti:15
+msgid ""
+"The IO set configuration, also called muxing, is done in the Device Tree."
+" The driver pinctrl-single reads the DT's node fsl,pins, and does the "
+"appropriate pin muxing."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:285
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1130
+#: ../../source/bsp/imx8/imx8mn/head.rst:279
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1110
+#: ../../source/bsp/imx8/imx8mp/head.rst:323
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:911
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1162
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1101
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:911
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:381
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:401
+msgid ""
+"The following is an example of the pin muxing of the UART1 device in |dt-"
+"carrierboard|.dts:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:299
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1147
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1144
+msgid ""
+"The first part of the string MX8MM_IOMUXC_SAI2_RXFS_UART1_DCE_TX names "
+"the pad (in this example SAI2_RXFS). The second part of the string "
+"(UART1_DCE_RX) is the desired muxing option for this pad. The pad setting"
+" value (hex value on the right) defines different modes of the pad, for "
+"example, if internal pull resistors are activated or not. In this case, "
+"the internal resistors are disabled."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:305
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1153
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1150
+#: ../../source/bsp/imx8/imx8mn/head.rst:300
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1149
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1131
+#: ../../source/bsp/imx8/imx8mp/head.rst:346
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:934
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1177
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1207
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1185
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1124
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:934
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:527
+msgid "RS232/RS485"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:307
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1155
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1152
+#: ../../source/bsp/imx8/imx8mn/head.rst:302
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1151
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1133
+msgid ""
+"The |soc| SoC provides up to 4 UART units. PHYTEC boards support "
+"different numbers of these UART units. UART1 can also be used as RS-485. "
+"For this, |ref-bootswitch| needs to be set correctly:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:315
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1163
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1160
+#: ../../source/bsp/imx8/imx8mn/head.rst:310
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1159
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1141
+msgid "**UART1 RS485**"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:319
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1167
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1164
+#: ../../source/bsp/imx8/imx8mn/head.rst:314
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1163
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1145
+msgid "**UART1 RS232**"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs232.rsti:2
+msgid "RS232"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs232.rsti:4
+msgid "Display the current settings of a terminal in a human-readable format:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs232.rsti:10
+msgid "Configuration of the UART interface can be done with stty. For example:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs232.rsti:17
+msgid "With a simple echo and cat, basic communication can be tested. Example:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs232.rsti:28
+msgid "The host should print out \"123\"."
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs485.rsti:2
+msgid "RS485"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs485.rsti:4
+msgid ""
+"For easy testing, look at the linux-serial-test. This tool is called the "
+"IOCTL for RS485 and sends a constant stream of data."
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs485.rsti:12
+msgid ""
+"More information about the linux-serial-test tool and its parameters can "
+"be found here: `linux-serial-test <https://github.com/cbrake/linux-"
+"serial-test>`_"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rs485.rsti:15
+msgid ""
+"Documentation for calling the IOCTL within c-code is described in the "
+"Linux kernel documentation: "
+"https://www.kernel.org/doc/Documentation/serial/serial-rs485.txt"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:324
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1169
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mm-"
+"phyboard-polis-rdk.dts?h=v5.15.71_2.2.2-phy3#n291`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:330
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1178
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1175
+#: ../../source/bsp/imx8/imx8mn/head.rst:325
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1174
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1156
+#: ../../source/bsp/imx8/imx8mp/head.rst:373
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:961
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1204
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1234
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1212
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1151
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:961
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:406
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:426
+msgid "Network"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:332
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1180
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1177
+#: ../../source/bsp/imx8/imx8mn/head.rst:327
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1176
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1158
+msgid "|sbc|-|soc| provides one Gigabit Ethernet interface."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:1
+msgid ""
+"All interfaces offer a standard Linux network port that can be programmed"
+" using the BSD socket interface. The whole network configuration is "
+"handled by the systemd-networkd daemon. The relevant configuration files "
+"can be found on the target in ``/lib/systemd/network/`` as well as the "
+"BSP in ``meta-ampliphy/recipes-core/systemd/systemd-conf``."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:7
+msgid ""
+"IP addresses can be configured within \\*.network files. The default IP "
+"address and netmask for eth0 is:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:14
+msgid ""
+"The DT Ethernet setup might be split into two files depending on your "
+"hardware configuration: the module DT and the board-specific DT. The "
+"device tree set up for the FEC ethernet IP core where the ethernet PHY is"
+" populated on the SoM can be found here: |dt-somnetwork|."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:19
+msgid "|sbc-network|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:22
+msgid "Network Environment Customization"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:27
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:979
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1169
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:979
+msgid "U-boot network-environment"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:29
+msgid "To find the Ethernet settings in the target bootloader:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:35
+msgid ""
+"With your development host set to IP 192.168.3.10 and netmask "
+"255.255.255.0, the target should return:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:45
+msgid "If you need to make any changes:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:51
+msgid ""
+"<parameter> should be one of ipaddr, netmask, gatewayip or serverip. "
+"<value> will be the actual value of the chosen parameter."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:54
+msgid "The changes you made are temporary for now. To save these:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:60
+msgid ""
+"Here you can also change the IP address to DHCP instead of using a static"
+" one."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:62
+msgid "Configure:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:68
+msgid "Set up paths for TFTP and NFS. A modification could look like this:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:74
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:994
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1184
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:994
+msgid ""
+"Please note that these modifications will only affect the bootloader "
+"settings."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:78
+msgid ""
+"Variables like nfsroot and netargs can be overwritten by the U-boot "
+"External Environment. For netboot, the external environment will be "
+"loaded from tftp. For example, to locally set the nfsroot variable in a "
+"``bootenv.txt`` file, locate the tftproot directory:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:87
+msgid ""
+"There is no need to store the info on the target. Please note that this "
+"does not work for variables like ipaddr or serveraddr as they need to be "
+"already set when the external environment is being loaded."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:4
+#: ../../source/bsp/imx-common/peripherals/network.rsti:94
+msgid "Kernel network-environment"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:6
+#: ../../source/bsp/imx-common/peripherals/network.rsti:96
+msgid "Find the ethernet settings for eth0 in the target kernel:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/network.rsti:18
+#: ../../source/bsp/imx-common/peripherals/network.rsti:108
+msgid "Temporary adaption of the eth0 configuration:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:337
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1185
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1182
+#: ../../source/bsp/imx8/imx8mn/head.rst:332
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1181
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1163
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:2
+msgid "WLAN"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:339
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1187
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1184
+#: ../../source/bsp/imx8/imx8mn/head.rst:334
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1183
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1165
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:32
+msgid ""
+"For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. "
+"This module supports 2,4 GHz bandwidth and can be run in several modes, "
+"like client mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption,"
+" and more. More information about the module can be found at https"
+"://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-"
+"SterlingLWB%20v7_2.pdf"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:2
+msgid "Connecting to a WLAN Network"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:4
+msgid "First set the correct regulatory domain for your country:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1242
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1238
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1271
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1301
+#: ../../source/bsp/peripherals/emmc.rsti:32
+#: ../../source/bsp/peripherals/wireless-network.rsti:11
+msgid "You will see:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:22
+msgid "Set up the wireless interface:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:29
+msgid "Now you can scan for available networks:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:35
+msgid ""
+"You can use a cross-platform supplicant with support for WEP, WPA, and "
+"WPA2 called wpa_supplicant for an encrypted connection."
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:37
+msgid ""
+"To do so, add the network-credentials to the file "
+"``/etc/wpa_supplicant.conf``:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:48
+msgid "Now a connection can be established:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:54
+msgid "This should result in the following output:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:61
+msgid ""
+"To finish the configuration you can configure DHCP to receive an IP "
+"address (supported by most WLAN access points). For other possible IP "
+"configurations, see section `Changing the Network Configuration` in the "
+"|yocto-ref-manual|_."
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:65
+msgid "First, create the directory:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:71
+msgid ""
+"Then add the following configuration snippet in "
+"``/etc/systemd/network/10-wlan0.network``:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:82
+msgid "Now, restart the network daemon so that the configuration takes effect:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:89
+msgid "Bluetooth"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:91
+msgid ""
+"Bluetooth is connected to UART2 interface. More information about the "
+"module can be found at https://connectivity-staging.s3.us-"
+"east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf. The Bluetooth "
+"device needs to be set up manually:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:109
+msgid ""
+"Now you can scan your environment for visible Bluetooth devices. "
+"Bluetooth is not visible during a default startup."
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:119
+msgid "Visibility"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:121
+msgid "To activate visibility:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:127
+msgid "To disable visibility:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/wireless-network.rsti:134
+msgid "Connect"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:349
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1197
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1194
+#: ../../source/bsp/imx8/imx8mn/head.rst:344
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1193
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1175
+#: ../../source/bsp/imx8/imx8mp/head.rst:395
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1226
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1256
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1234
+msgid ""
+"If the connection fails with the error message: \"Failed to connect: "
+"org.bluez.Error.Failed\" try restarting PulseAudio with:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:2
+msgid "SD/MMC Card"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:4
+msgid ""
+"The |soc| supports a slot for Secure Digital Cards and MultiMedia Cards "
+"to be used as general-purpose block devices. These devices can be used in"
+" the same way as any other block device."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:10
+msgid ""
+"These kinds of devices are hot-pluggable. Nevertheless, you must ensure "
+"not to unplug the device while it is still mounted. This may result in "
+"data loss!"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:13
+msgid ""
+"After inserting an SD/MMC card, the kernel will generate new device nodes"
+" in /dev. The full device can be reached via its /dev/mmcblk1 device "
+"node. SD/MMC card partitions will show up as:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:21
+msgid ""
+"<Y> counts as the partition number starting from 1 to the max count of "
+"partitions on this device. The partitions can be formatted with any kind "
+"of file system and also handled in a standard manner, e.g. the mount and "
+"umount command work as expected."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/sd-card.rsti:28
+msgid ""
+"These partition device nodes will only be available if the card contains "
+"a valid partition table (”hard disk” like handling). If no partition "
+"table is present, the whole device can be used as a file system (”floppy”"
+" like handling). In this case, /dev/mmcblk1 must be used for formatting "
+"and mounting. The cards are always mounted as being writable."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:358
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1203
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mm-phyboard-polis-rdk.dts?h=v5.15.71_2.2.2-phy3#n383`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:361
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1206
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mm-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n335`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1213
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1209
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1242
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1272
+#: ../../source/bsp/peripherals/emmc.rsti:2
+msgid "eMMC Devices"
+msgstr ""
+
+#: ../../source/bsp/peripherals/emmc.rsti:4
+msgid ""
+"PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip "
+"as the main storage. eMMC devices contain raw Multi-Level Cells (MLC) or "
+"Triple-Level Cells (TLC) combined with a memory controller that handles "
+"ECC and wear leveling. They are connected via an SD/MMC interface to the "
+"|soc| and are represented as block devices in the Linux kernel like SD "
+"cards, flash drives, or hard disks."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1221
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1217
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1250
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1280
+#: ../../source/bsp/peripherals/emmc.rsti:11
+msgid ""
+"The electric and protocol specifications are provided by JEDEC "
+"(https://www.jedec.org/standards-documents/technology-focus-areas/flash-"
+"memory-ssds-ufs-emmc/e-mmc). The eMMC manufacturer's datasheet is "
+"relatively short and meant to be read together with the supported version"
+" of the JEDEC eMMC standard."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1226
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1222
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1255
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1285
+#: ../../source/bsp/peripherals/emmc.rsti:16
+msgid "PHYTEC currently utilizes the eMMC chips with JEDEC Version 5.0 and 5.1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1229
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1225
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1258
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1288
+#: ../../source/bsp/peripherals/emmc.rsti:19
+msgid "Extended CSD Register"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1231
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1227
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1260
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1290
+#: ../../source/bsp/peripherals/emmc.rsti:21
+msgid ""
+"eMMC devices have an extensive amount of extra information and settings "
+"that are available via the Extended CSD registers. For a detailed list of"
+" the registers, see manufacturer datasheets and the JEDEC standard."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1235
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1231
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1264
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1294
+#: ../../source/bsp/peripherals/emmc.rsti:25
+msgid "In the Linux user space, you can query the registers:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1254
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1250
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1283
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1313
+#: ../../source/bsp/peripherals/emmc.rsti:44
+msgid "Enabling Background Operations (BKOPS)"
+msgstr ""
+
+#: ../../source/bsp/peripherals/emmc.rsti:46
+msgid ""
+"In contrast to raw NAND Flash, an eMMC device contains a Flash Transfer "
+"Layer (FTL) that handles the wear leveling, block management, and ECC of "
+"the raw MLC or TLC. This requires some maintenance tasks (for example "
+"erasing unused blocks) that are performed regularly. These tasks are "
+"called **Background Operations (BKOPS)**."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1262
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1258
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1291
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1321
+#: ../../source/bsp/peripherals/emmc.rsti:52
+msgid ""
+"By default (depending on the chip), the background operations may or may "
+"not be executed periodically, impacting the worst-case read and write "
+"latency."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1265
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1261
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1294
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1324
+#: ../../source/bsp/peripherals/emmc.rsti:55
+msgid ""
+"The JEDEC Standard has specified a method since version v4.41 that the "
+"host can issue BKOPS manually. See the JEDEC Standard chapter Background "
+"Operations and the description of registers BKOPS_EN (Reg: 163) and "
+"BKOPS_START (Reg: 164) in the eMMC datasheet for more details."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1270
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1266
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1299
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1329
+#: ../../source/bsp/peripherals/emmc.rsti:60
+msgid "Meaning of Register BKOPS_EN (Reg: 163) Bit MANUAL_EN (Bit 0):"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1272
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1268
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1301
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1331
+#: ../../source/bsp/peripherals/emmc.rsti:62
+msgid ""
+"Value 0: The host does not support the manual trigger of BKOPS. Device "
+"write performance suffers."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1274
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1270
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1303
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1333
+#: ../../source/bsp/peripherals/emmc.rsti:64
+msgid ""
+"Value 1: The host does support the manual trigger of BKOPS. It will issue"
+" BKOPS from time to time when it does not need the device."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1277
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1273
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1306
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1336
+#: ../../source/bsp/peripherals/emmc.rsti:67
+msgid ""
+"The mechanism to issue background operations has been implemented in the "
+"Linux kernel since v3.7. You only have to enable BKOPS_EN on the eMMC "
+"device (see below for details)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1281
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1277
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1310
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1340
+#: ../../source/bsp/peripherals/emmc.rsti:71
+msgid ""
+"The JEDEC standard v5.1 introduces a new automatic BKOPS feature. It "
+"frees the host to trigger the background operations regularly because the"
+" device starts BKOPS itself when it is idle (see the description of bit "
+"AUTO_EN in register BKOPS_EN (Reg: 163))."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1289
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1285
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1318
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1348
+#: ../../source/bsp/peripherals/emmc.rsti:76
+msgid "To check whether *BKOPS_EN* is set, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1296
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1292
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1325
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1355
+#: ../../source/bsp/peripherals/emmc.rsti:83
+msgid "The output will be, for example:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1304
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1300
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1333
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1363
+#: ../../source/bsp/peripherals/emmc.rsti:91
+msgid ""
+"Where value 0x00 means BKOPS_EN is disabled and device write performance "
+"suffers. Where value 0x01 means BKOPS_EN is enabled and the host will "
+"issue background operations from time to time."
+msgstr ""
+
+#: ../../source/bsp/peripherals/emmc.rsti:95
+msgid "Enabling can be done with this command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1308
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1304
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1337
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1367
+#: ../../source/bsp/peripherals/emmc.rsti:108
+msgid "To set the BKOPS_EN bit, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1315
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1311
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1344
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1374
+#: ../../source/bsp/peripherals/emmc.rsti:115
+msgid ""
+"To ensure that the new setting is taken over and the kernel triggers "
+"BKOPS by itself, shut down the system:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1324
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1320
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1353
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1383
+#: ../../source/bsp/peripherals/emmc.rsti:124
+msgid "The BKOPS_EN bit is one-time programmable only. It cannot be reversed."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1327
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1323
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1356
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1386
+#: ../../source/bsp/peripherals/emmc.rsti:127
+msgid "Reliable Write"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1329
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1325
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1358
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1388
+#: ../../source/bsp/peripherals/emmc.rsti:129
+msgid "There are two different Reliable Write options:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1331
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1327
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1360
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1390
+#: ../../source/bsp/peripherals/emmc.rsti:131
+msgid "Reliable Write option for a whole eMMC device/partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1332
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1328
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1361
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1391
+#: ../../source/bsp/peripherals/emmc.rsti:132
+msgid "Reliable Write for single write transactions."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1336
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1332
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1365
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1395
+#: ../../source/bsp/peripherals/emmc.rsti:136
+msgid ""
+"Do not confuse eMMC partitions with partitions of a DOS, MBR, or GPT "
+"partition table (see the previous section)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1339
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1335
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1368
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1398
+#: ../../source/bsp/peripherals/emmc.rsti:139
+msgid ""
+"The first Reliable Write option is mostly already enabled on the eMMCs "
+"mounted on the phyCORE-|soc| SoMs. To check this on the running target:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1361
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1357
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1390
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1420
+#: ../../source/bsp/peripherals/emmc.rsti:161
+msgid "Otherwise, it can be enabled with the mmc tool:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1370
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1366
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1399
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1429
+#: ../../source/bsp/peripherals/emmc.rsti:174
+msgid ""
+"The second Reliable Write option is the configuration bit Reliable Write "
+"Request parameter (bit 31) in command CMD23. It has been used in the "
+"kernel since v3.0 by file systems, e.g. ext4 for the journal and user "
+"space applications such as fdisk for the partition table. In the Linux "
+"kernel source code, it is handled via the flag REQ_META."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1376
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1372
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1405
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1435
+#: ../../source/bsp/peripherals/emmc.rsti:180
+msgid ""
+"**Conclusion**: ext4 file system with mount option data=journal should be"
+" safe against power cuts. The file system check can recover the file "
+"system after a power failure, but data that was written just before the "
+"power cut may be lost. In any case, a consistent state of the file system"
+" can be recovered. To ensure data consistency for the files of an "
+"application, the system functions fdatasync or fsync should be used in "
+"the application."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:110
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1384
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1380
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1413
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1443
+#: ../../source/bsp/peripherals/emmc.rsti:188
+msgid "Resizing ext4 Root Filesystem"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1386
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1382
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1415
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1445
+#: ../../source/bsp/peripherals/emmc.rsti:190
+msgid ""
+"When flashing the sdcard image to eMMC the ext4 root partition is not "
+"extended to the end of the eMMC. parted can be used to expand the root "
+"partition. The example works for any block device such as eMMC, SD card, "
+"or hard disk."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:115
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1390
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1386
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1419
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1449
+#: ../../source/bsp/peripherals/emmc.rsti:194
+msgid "Get the current device size:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1397
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1393
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1426
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1456
+#: ../../source/bsp/peripherals/emmc.rsti:201
+msgid "The output looks like this:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1413
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1409
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1442
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1472
+#: ../../source/bsp/peripherals/emmc.rsti:217
+msgid "Use parted to resize the root partition to the max size of the device:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1433
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1429
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1462
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1492
+#: ../../source/bsp/peripherals/emmc.rsti:237
+msgid ""
+"Increasing the filesystem size can be done while it is mounted.  But you "
+"can also boot the board from an SD card and then resize the file system "
+"on the eMMC partition while it is not mounted."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1437
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1433
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1466
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1496
+#: ../../source/bsp/peripherals/emmc.rsti:241
+msgid "Resize the filesystem to a new partition size:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1452
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1448
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1481
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1511
+#: ../../source/bsp/peripherals/emmc.rsti:256
+msgid "Enable pseudo-SLC Mode"
+msgstr ""
+
+#: ../../source/bsp/peripherals/emmc.rsti:258
+msgid ""
+"eMMC devices use MLC or TLC (https://en.wikipedia.org/wiki/Multi-"
+"level_cell) to store the data. Compared with SLC used in NAND Flash, MLC "
+"or TLC have lower reliability and a higher error rate at lower costs."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1459
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1455
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1488
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1518
+#: ../../source/bsp/peripherals/emmc.rsti:263
+msgid ""
+"If you prefer reliability over storage capacity, you can enable the "
+"pseudo-SLC mode or SLC mode. The method used here employs the enhanced "
+"attribute, described in the JEDEC standard, which can be set for "
+"continuous regions of the device. The JEDEC standard does not specify the"
+" implementation details and the guarantees of the enhanced attribute. "
+"This is left to the chipmaker. For the Micron chips, the enhanced "
+"attribute increases the reliability but also halves the capacity."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1469
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1465
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1498
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1528
+#: ../../source/bsp/peripherals/emmc.rsti:273
+msgid "When enabling the enhanced attribute on the device, all data will be lost."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1471
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1467
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1500
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1530
+#: ../../source/bsp/peripherals/emmc.rsti:275
+msgid "The following sequence shows how to enable the enhanced attribute."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1473
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1469
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1502
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1532
+#: ../../source/bsp/peripherals/emmc.rsti:277
+msgid "First obtain the current size of the eMMC device with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1480
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1476
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1509
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1539
+#: ../../source/bsp/peripherals/emmc.rsti:284
+#: ../../source/bsp/peripherals/pcie.rsti:14
+msgid "You will receive:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1488
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1484
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1517
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1547
+#: ../../source/bsp/peripherals/emmc.rsti:292
+msgid "As you can see this device has 63652757504 Byte = 60704 MiB."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1490
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1486
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1519
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1549
+#: ../../source/bsp/peripherals/emmc.rsti:294
+msgid "To get the maximum size of the device after pseudo-SLC is enabled use:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1497
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1493
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1526
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1556
+#: ../../source/bsp/peripherals/emmc.rsti:301
+msgid "which shows, for example:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1507
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1503
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1536
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1566
+#: ../../source/bsp/peripherals/emmc.rsti:311
+msgid "Here the maximum size is 3719168 KiB = 3632 MiB."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1509
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1505
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1538
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1568
+#: ../../source/bsp/peripherals/emmc.rsti:313
+msgid ""
+"Now, you can set enhanced attribute for the whole device, e.g. 3719168 "
+"KiB, by typing:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1517
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1513
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1546
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1576
+#: ../../source/bsp/peripherals/emmc.rsti:321
+msgid "You will get:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1528
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1524
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1557
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1587
+#: ../../source/bsp/peripherals/emmc.rsti:332
+msgid "To ensure that the new setting has taken over, shut down the system:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1534
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1530
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1563
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1593
+#: ../../source/bsp/peripherals/emmc.rsti:338
+msgid ""
+"and perform a power cycle. It is recommended that you verify the settings"
+" now."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1536
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1532
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1565
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1595
+#: ../../source/bsp/peripherals/emmc.rsti:340
+msgid "First, check the value of ENH_SIZE_MULT which must be 3719168 KiB:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1543
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1539
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1572
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1602
+#: ../../source/bsp/peripherals/emmc.rsti:347
+msgid "You should receive::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1551
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1547
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1580
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1610
+#: ../../source/bsp/peripherals/emmc.rsti:355
+msgid "Finally, check the size of the device:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1561
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1557
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1590
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1620
+#: ../../source/bsp/peripherals/emmc.rsti:365
+msgid "Erasing the Device"
+msgstr ""
+
+#: ../../source/bsp/peripherals/emmc.rsti:367
+msgid ""
+"It is possible to erase the eMMC device directly rather than overwriting "
+"it with zeros. The eMMC block management algorithm will erase the "
+"underlying MLC or TLC or mark these blocks as discard. The data on the "
+"device is lost and will be read back as zeros."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1568
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1564
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1597
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1627
+#: ../../source/bsp/peripherals/emmc.rsti:372
+msgid "After booting from SD Card execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1575
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1571
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1604
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1634
+#: ../../source/bsp/peripherals/emmc.rsti:379
+msgid ""
+"The option --secure ensures that the command waits until the eMMC device "
+"has erased all blocks. The -f (force) option disables all checking before"
+" erasing and it is needed when the eMMC device contains existing "
+"partitions with data."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1585
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1581
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1614
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1644
+#: ../../source/bsp/peripherals/emmc.rsti:389
+msgid ""
+"also destroys all information on the device, but this command is bad for "
+"wear leveling and takes much longer!"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:2
+msgid "eMMC Boot Partitions"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:4
+msgid ""
+"An eMMC device contains four different hardware partitions: user, boot1, "
+"boot2, and rpmb."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:7
+msgid ""
+"The user partition is called the User Data Area in the JEDEC standard and"
+" is the main storage partition. The partitions boot1 and boot2 can be "
+"used to host the bootloader and are more reliable. Which partition the "
+"|soc| uses to load the bootloader is controlled by the boot configuration"
+" of the eMMC device. The partition rpmb is a small partition and can only"
+" be accessed via a trusted mechanism."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:14
+msgid ""
+"Furthermore, the user partition can be divided into four user-defined "
+"General Purpose Area Partitions. An explanation of this feature exceeds "
+"the scope of this document. For further information, see the JEDEC "
+"Standard Chapter 7.2 Partition Management."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:21
+msgid ""
+"Do not confuse eMMC partitions with partitions of a DOS, MBR, or GPT "
+"partition table."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:24
+msgid ""
+"The current PHYTEC BSP does not use the extra partitioning feature of "
+"eMMC devices. The U-Boot is flashed at the beginning of the user "
+"partition. The U-Boot environment is placed at a fixed location after the"
+" U-Boot. An MBR partition table is used to create two partitions, a FAT32"
+" boot, and ext4 rootfs partition. They are located right after the U-Boot"
+" and the U-Boot environment. The FAT32 boot partition contains the kernel"
+" and device tree."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:31
+msgid ""
+"With eMMC flash storage it is possible to use the dedicated boot "
+"partitions for redundantly storing the bootloader. The U-Boot environment"
+" still resides in the user area before the first partition. The user area"
+" also still contains the bootloader which the image first shipped during "
+"its initialization process. Below is an example, to flash the bootloader "
+"to one of the two boot partitions and switch the boot device via "
+"userspace commands."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:39
+msgid "Via userspace Commands"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:41
+msgid "On the host, run:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:47
+msgid ""
+"The partitions boot1 and boot2 are read-only by default. To write to them"
+" from user space, you have to disable force_ro in the sysfs."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:50
+msgid ""
+"To manually write the bootloader to the eMMC boot partitions, first "
+"disable the write protection:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:59
+msgid "Write the bootloader to the eMMC boot partitions:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:67
+msgid "The following table is for the offset of the |soc| SoC:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:70
+msgid "Bootloader Filename"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:73
+msgid "0 kiB"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:73
+msgid "imx-boot"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:76
+msgid "After that set the boot partition from user space using the mmc tool:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:78
+msgid "(for 'boot0') :"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:85
+msgid "(for 'boot1') :"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:94
+msgid ""
+"To disable booting from the eMMC boot partitions simply enter the "
+"following command:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:102
+msgid "To choose back to the user area u-boot environment:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:112
+msgid ""
+"fdisk can be used to expand the root filesystem. The example works for "
+"any block device such as eMMC, SD Card, or hard disk."
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:122
+msgid "The output looks like:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:134
+msgid "Use fdisk to delete and create a partition with a max size of the device:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/emmc.rsti:188
+msgid ""
+"Increasing the file system size can be done while it is mounted. An "
+"online resizing operation is performed. But you can also boot the board "
+"from an SD card and then resize the file system on the eMMC partition "
+"while it is not mounted. Furthermore, the board has to be rebooted so "
+"that the new partition table will be read."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:2
+msgid "SPI Master"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:4
+msgid ""
+"The |soc| controller has a FlexSPI and an ECSPI IP core included. The "
+"FlexSPI host controller supports two SPI channels with up to 4 devices. "
+"Each channel supports Single/Dual/Quad/Octal mode data transfer (1/2/4/8 "
+"bidirectional data lines). The ECSPI controller supports 3 SPI interfaces"
+" with one dedicated chip selected for each interface. As chip selects "
+"should be realized with GPIOs, more than one device on each channel is "
+"possible."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:14
+msgid "SPI NOR Flash"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:16
+msgid ""
+"phyCORE-|soc| is equipped with a QSPI NOR Flash which connects to the "
+"|soc|'s FlexSPI interface. The QSPI NOR Flash is suitable for booting. "
+"Please see different sections for flashing and bootmode setup. Due to "
+"limited space on the SPI NOR Flash, only the bootloader is stored inside."
+" By default, the kernel, device tree, and rootfs are taken from eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:22
+msgid ""
+"The Bootloader does detect with the help of the EEPROM Introspection data"
+" if an SPI flash is mounted or not. If no SPI flash is mounted a device "
+"tree overlay is applied with the expansion command to disable the SPI "
+"flash device tree node during boot. If no introspection data is available"
+" the SPI NOR flash node is always enabled. Find more information in the "
+"device tree overlay section."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:28
+msgid ""
+"The bootloader also passes the SPI MTD partition table to Linux by fixing"
+" up the device tree based on the mtdparts boot parameter. The default "
+"partition layout in the BSP is set to:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:36
+msgid ""
+"This is a bootloader environment variable that is defined here and can be"
+" changed during runtime. From Linux userspace, the NOR Flash partitions "
+"are accessible via /dev/mtd<N> devices where <N> is the MTD device number"
+" associated with the NOR flash partition to access. To find the correct "
+"MTD device number for a partition, run on the target:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/spi-master.rsti:94
+msgid ""
+"It lists all MTD devices and the corresponding partition names. The flash"
+" node is defined inside of the SPI master node in the module DTS. The SPI"
+" node contains all devices connected to this SPI bus which is in this "
+"case only the SPI NOR Flash."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:370
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1592
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1215
+#: ../../source/bsp/imx8/imx8mn/head.rst:365
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1588
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1196
+#: ../../source/bsp/imx8/imx8mp/head.rst:416
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1621
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1651
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1255
+msgid ""
+"The definition of the SPI master node in the device tree can be found "
+"here:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:372
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1217
+msgid ":imx-dt:`imx8mm-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n87`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1597
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1220
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1593
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1201
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1626
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1656
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1260
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:2
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:2
+msgid "GPIOs"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1599
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1222
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1595
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1203
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1628
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1658
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1262
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:4
+msgid ""
+"The |sbc| has a set of pins especially dedicated to user I/Os. Those pins"
+" are connected directly to |soc| pins and are muxed as GPIOs. They are "
+"directly usable in Linux userspace. The processor has organized its GPIOs"
+" into five banks of 32 GPIOs each (GPIO1 – GPIO5) GPIOs. gpiochip0, "
+"gpiochip32, gpiochip64, gpiochip96, and gpiochip128 are the sysfs "
+"representation of these internal |soc| GPIO banks GPIO1 – GPIO5."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1606
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1229
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1602
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1210
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1635
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1665
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1269
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:11
+msgid ""
+"The GPIOs are identified as GPIO<X>_<Y> (e.g. GPIO5_07). <X> identifies "
+"the GPIO bank and counts from 1 to 5, while <Y> stands for the GPIO "
+"within the bank. <Y> is being counted from 0 to 31 (32 GPIOs on each "
+"bank)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1610
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1233
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1606
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1214
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1639
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1669
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1273
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:15
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:14
+msgid ""
+"By contrast, the Linux kernel uses a single integer to enumerate all "
+"available GPIOs in the system. The formula to calculate the right number "
+"is:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1617
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1240
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1613
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1221
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1646
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1676
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1280
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:22
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:21
+msgid ""
+"Accessing GPIOs from userspace will be done using the libgpiod. It "
+"provides a library and tools for interacting with the Linux GPIO "
+"character device. Examples of some usages of various tools:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1621
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1244
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1617
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1225
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1650
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1680
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1284
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:26
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:25
+msgid "Detecting the gpiochips on the chip:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1632
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1255
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1628
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1236
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1661
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1691
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1295
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:37
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:52
+msgid ""
+"Show detailed information about the gpiochips. Like their names, "
+"consumers, direction, active state, and additional flags:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1639
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1262
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1635
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1243
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1668
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1698
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1302
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:44
+msgid "Read the value of a GPIO (e.g GPIO 20 from chip0):"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1645
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1268
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1641
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1249
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1674
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1704
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1308
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:50
+msgid "Set the value of GPIO 20 on chip0 to 0 and exit tool:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1651
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1274
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1647
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1255
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1680
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1710
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1314
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:56
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:71
+msgid "Help text of gpioset shows possible options:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1684
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1307
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1680
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1288
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1713
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1743
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1347
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:112
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:104
+msgid ""
+"Some of the user IOs are used for special functions. Before using a user "
+"IO, refer to the schematic or the hardware manual of your board to ensure"
+" that it is not already in use."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:4
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:119
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:109
+msgid "GPIOs via sysfs"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:8
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:123
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:113
+msgid ""
+"Accessing gpios via sysfs is deprecated and we encourage to use libgpiod "
+"instead."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:11
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:126
+msgid ""
+"Support to access GPIOs via sysfs is not enabled by default any more. It "
+"is only possible with manually enabling ``CONFIG_GPIO_SYSFS`` in the "
+"kernel configuration. To make ``CONFIG_GPIO_SYSFS`` visible in menuconfig"
+" the option ``CONFIG_EXPERT`` has to be enabled first."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:16
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:131
+msgid ""
+"You can also add this option for example to the defconfig you use in "
+"``arch/arm64/configs/`` in the linux kernel sources. For our NXP based "
+"releases, this could be for example ``imx8_phytec_distro.config``::"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:25
+#: ../../source/bsp/imx8/peripherals/gpios.rsti:140
+msgid ""
+"Otherwise you can create a new config fragment. This is described in our "
+"`Yocto Reference Manual <yocto-ref-manual-kernel-and-bootloader-"
+"config_>`_."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:376
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1314
+#: ../../source/bsp/imx8/imx8mn/head.rst:371
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1295
+msgid "Pinmuxing of some GPIO pins in the device tree |dt-carrierboard|.dts:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1702
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1698
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1721
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1751
+#: ../../source/bsp/imx9/peripherals/leds.rsti:2
+#: ../../source/bsp/peripherals/leds.rsti:2
+msgid "LEDs"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1704
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1700
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1723
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1753
+#: ../../source/bsp/imx9/peripherals/leds.rsti:4
+#: ../../source/bsp/peripherals/leds.rsti:4
+msgid ""
+"If any LEDs are connected to GPIOs, you have the possibility to access "
+"them by a special LED driver interface instead of the general GPIO "
+"interface (section GPIOs). You will then access them using "
+"``/sys/class/leds/`` instead of ``/sys/class/gpio/``. The maximum "
+"brightness of the LEDs can be read from the ``max_brightness`` file. The "
+"brightness file will set the brightness of the LED (taking a value from 0"
+" up to max_brightness). Most LEDs do not have hardware brightness support"
+" and will just be turned on by all non-zero brightness settings."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1713
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1709
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1732
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1762
+#: ../../source/bsp/imx9/peripherals/leds.rsti:13
+#: ../../source/bsp/peripherals/leds.rsti:13
+msgid "Below is a simple example."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1715
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1711
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1734
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1764
+#: ../../source/bsp/imx9/peripherals/leds.rsti:15
+#: ../../source/bsp/peripherals/leds.rsti:15
+msgid "To get all available LEDs, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1722
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1718
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1741
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1771
+#: ../../source/bsp/peripherals/leds.rsti:22
+msgid "Here the LEDs blue-mmc, green-heartbeat, and red-emmc are on the |sbc|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1724
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1720
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1743
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1773
+#: ../../source/bsp/imx9/peripherals/leds.rsti:26
+#: ../../source/bsp/peripherals/leds.rsti:24
+msgid "To toggle the LEDs ON:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1730
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1726
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1749
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1779
+#: ../../source/bsp/imx9/peripherals/leds.rsti:32
+#: ../../source/bsp/peripherals/leds.rsti:30
+msgid "To toggle OFF:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:390
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1328
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mm-phyboard-polis-rdk.dts?h=v5.15.71_2.2.2-phy3#n36`"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/i2c-bus.rsti:2
+msgid "I²C Bus"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/i2c-bus.rsti:4
+msgid ""
+"The |soc| contains several Multimaster fast-mode I²C modules. PHYTEC "
+"boards provide plenty of different I²C devices connected to the I²C "
+"modules of the |soc|. This section describes the basic device usage and "
+"its DT representation of some I²C devices integrated into our |sbc|."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/i2c-bus.rsti:9
+msgid ""
+"The device tree node for i2c contains settings such as clock-frequency to"
+" set the bus frequency and the pin control settings including scl-gpios "
+"and sda-gpios which are alternate pin configurations used for bus "
+"recovery."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:395
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1333
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mm-"
+"phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n119`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:398
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1336
+msgid ""
+"General I²C4 bus configuration (e.g. |dt-carrierboard|.dts): :imx-dt"
+":`imx8mm-phyboard-polis-rdk.dts?h=v5.15.71_2.2.2-phy3#n244`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:403
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1749
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1341
+#: ../../source/bsp/imx8/imx8mn/head.rst:398
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1745
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1322
+#: ../../source/bsp/imx8/imx8mp/head.rst:437
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1034
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1768
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1798
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1369
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1224
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1034
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:442
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:485
+msgid "EEPROM"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:405
+#: ../../source/bsp/imx8/imx8mn/head.rst:400
+#: ../../source/bsp/imx8/imx8mp/head.rst:439
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1036
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1226
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1036
+msgid ""
+"On the |som| there is an i2c EEPROM flash populated. It has two "
+"addresses. The main EEPROM space (bus: I2C-0 address: 0x51) can be "
+"accessed via the sysfs interface in Linux. The first 256 bytes of the "
+"main EEPROM and the ID-page (bus: I2C-0 address: 0x59) are used for board"
+" detection and must not be overwritten. Therefore the ID-page can not be "
+"accessed via the sysfs interface. Overwriting reserved spaces will result"
+" in boot issues."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:414
+#: ../../source/bsp/imx8/imx8mn/head.rst:409
+#: ../../source/bsp/imx8/imx8mp/head.rst:448
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1045
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1235
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1045
+msgid "If you deleted reserved EEPROM spaces, please contact our support!"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:2
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:2
+msgid "I2C EEPROM on |som|"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:6
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:52
+msgid ""
+"The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 265 bytes of the"
+" normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or "
+"overwritten. As this will influence the behavior of the bootloader. The "
+"board might not boot correctly anymore."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:12
+msgid ""
+"The I2C EEPROM on the |som| SoM is connected to I2C address 0x51 on the "
+"I2C-0 bus. It is possible to read and write directly to the device "
+"populated:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:19
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:15
+msgid ""
+"To read and print the first 1024 bytes of the EEPROM as a hex number, "
+"execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:26
+msgid ""
+"To fill the 4KiB EEPROM (bus: I2C-0 addr: 0x51) with zeros leaving out "
+"the EEPROM data use:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:34
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:41
+msgid "EEPROM SoM Detection"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:36
+msgid ""
+"The I2C EEPROM, populated on the |som|, has a separate ID page that is "
+"addressable over I2C address 0x59 on bus 0 and a normal area that is "
+"addressable over I2C address 0x51 on bus 0. PHYTEC uses this data area of"
+" 32 Bytes to store information about the SoM. This includes PCB revision "
+"and mounting options."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:41
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:46
+msgid ""
+"The EEPROM data is read at a really early stage during startup. It is "
+"used to select the correct RAM configuration. This makes it possible to "
+"use the same bootloader image for different RAM sizes and choose the "
+"correct DTS overlays automatically."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:46
+msgid ""
+"If the EEPROM ID page data and the first 265 bytes of the normal area are"
+" deleted, the bootloader will fall back to the |som| Kit RAM setup, which"
+" is |kit-ram-size| RAM."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/eeprom.rsti:57
+msgid ""
+"SoMs that are flashed with data format API revision 2 will print out "
+"information about the module in the early stage."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:418
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1366
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be found "
+"in our PHYTEC git: :imx-dt:`imx8mm-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n311`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1054
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1244
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1054
+#: ../../source/bsp/peripherals/rtc.rsti:2
+msgid "RTC"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1056
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1246
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1056
+#: ../../source/bsp/peripherals/rtc.rsti:4
+msgid ""
+"RTCs can be accessed via ``/dev/rtc*``. Because PHYTEC boards have often "
+"more than one RTC, there might be more than one RTC device file."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1059
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1249
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1059
+#: ../../source/bsp/peripherals/rtc.rsti:7
+msgid "To find the name of the RTC device, you can read its sysfs entry with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1065
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1255
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1065
+#: ../../source/bsp/imx8/peripherals/tm.rsti:38
+#: ../../source/bsp/imx9/peripherals/tm.rsti:38
+#: ../../source/bsp/peripherals/rtc.rsti:13
+msgid "You will get, for example:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1074
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1264
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1074
+#: ../../source/bsp/peripherals/rtc.rsti:22
+msgid ""
+"This will list all RTCs including the non-I²C RTCs. Linux assigns RTC "
+"device IDs based on the device tree/aliases entries if present."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1077
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1267
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1077
+#: ../../source/bsp/peripherals/rtc.rsti:25
+msgid ""
+"Date and time can be manipulated with the ``hwclock`` tool and the date "
+"command. To show the current date and time set on the target:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1085
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1275
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1085
+#: ../../source/bsp/peripherals/rtc.rsti:33
+msgid ""
+"Change the date and time with the date command. The date command sets the"
+" time with the following syntax \"YYYY-MM-DD hh:mm:ss (+|-)hh:mm\":"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1095
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1285
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1095
+#: ../../source/bsp/peripherals/rtc.rsti:43
+msgid "Your timezone (in this example +0100) may vary."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1097
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1287
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1097
+#: ../../source/bsp/peripherals/rtc.rsti:45
+msgid ""
+"Using the date command does not change the time and date of the RTC, so "
+"if we were to restart the target those changes would be discarded. To "
+"write to the RTC we need to use the ``hwclock`` command. Write the "
+"current date and time (set with the date command) to the RTC using the "
+"``hwclock`` tool and reboot the target to check if the changes were "
+"applied to the RTC:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1113
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1303
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1113
+#: ../../source/bsp/peripherals/rtc.rsti:61
+msgid "To set the time and date from the RTC use:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rtc.rsti:72
+msgid "RTC Wakealarm"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rtc.rsti:74
+msgid ""
+"It is possible to issue an interrupt from the RTC to wake up the system. "
+"The format uses the Unix epoch time, which is the number of seconds since"
+" UTC midnight on 1 January 1970. To wake up the system after 4 minutes "
+"from suspend to ram state, type:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/rtc.rsti:86
+msgid ""
+"Internally the wake alarm time will be rounded up to the next minute "
+"since the alarm function doesn't support seconds."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1374
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1355
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1402
+#: ../../source/bsp/peripherals/rtc.rsti:4
+#: ../../source/bsp/peripherals/rtc.rsti:92
+msgid "RTC Parameters"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1376
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1357
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1404
+#: ../../source/bsp/peripherals/rtc.rsti:6
+#: ../../source/bsp/peripherals/rtc.rsti:94
+msgid ""
+"RTCs have a few abilities which can be read/set with the help of "
+"``hwclock`` tool."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1379
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1360
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1407
+#: ../../source/bsp/peripherals/rtc.rsti:9
+#: ../../source/bsp/peripherals/rtc.rsti:97
+msgid "We can check RTC supported features with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1386
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1367
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1414
+#: ../../source/bsp/peripherals/rtc.rsti:16
+#: ../../source/bsp/peripherals/rtc.rsti:104
+msgid "What this value means is encoded in kernel, each set bit translates to:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1399
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1380
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1427
+#: ../../source/bsp/peripherals/rtc.rsti:30
+#: ../../source/bsp/peripherals/rtc.rsti:118
+msgid "We can check RTC BSM (Backup Switchover Mode) with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1406
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1387
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1434
+#: ../../source/bsp/peripherals/rtc.rsti:37
+#: ../../source/bsp/peripherals/rtc.rsti:125
+msgid "We can set RTC BSM with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1413
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1394
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1441
+#: ../../source/bsp/peripherals/rtc.rsti:44
+#: ../../source/bsp/peripherals/rtc.rsti:132
+msgid "What BSM values mean translates to these values:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1423
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1404
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1451
+#: ../../source/bsp/peripherals/rtc.rsti:54
+#: ../../source/bsp/peripherals/rtc.rsti:142
+msgid ""
+"You should set BSM mode to DSM or LSM for RTC to switch to backup power "
+"source when the initial power source is not available. Check **RV-3028** "
+"RTC datasheet to read what LSM (Level Switching Mode) and DSM (Direct "
+"Switching Mode) actually mean."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:424
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1428
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mm-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n319`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:428
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1785
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1432
+#: ../../source/bsp/imx8/imx8mn/head.rst:423
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1781
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1413
+#: ../../source/bsp/imx8/imx8mp/head.rst:462
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1130
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1804
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1834
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1460
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1320
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1130
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:459
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:503
+msgid "USB Host Controller"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:430
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1787
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1434
+msgid ""
+"The USB controller of the |soc| SoC provides a low-cost connectivity "
+"solution for numerous consumer portable devices by providing a mechanism "
+"for data transfer between USB devices with a line/bus speed up to 480 "
+"Mbps (HighSpeed 'HS'). The USB subsystem has two independent USB "
+"controller cores. Both cores are On-The-Go (OTG) controller cores and are"
+" capable of acting as a USB peripheral device or a USB host. Each is "
+"connected to a USB 2.0 PHY."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-host.rsti:1
+msgid ""
+"The unified BSP includes support for mass storage devices and keyboards. "
+"Other USB-related device drivers must be enabled in the kernel "
+"configuration on demand. Due to udev, all mass storage devices connected "
+"get unique IDs and can be found in ``/dev/disk/by-id``. These IDs can be "
+"used in ``/etc/fstab`` to mount the different USB memory devices in "
+"different ways."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:439
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1443
+msgid ""
+"User USB2 (host) configuration is in the kernel device tree |dt-"
+"carrierboard|.dts:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:451
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1455
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx8mm-phyboard-polis-"
+"rdk.dts?h=v5.15.71_2.2.2-phy3#n347`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:46
+#: ../../source/bsp/peripherals/usb-otg.rsti:2
+msgid "USB OTG"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:4
+msgid ""
+"Most PHYTEC boards provide a USB OTG interface. USB OTG ports "
+"automatically act as a USB device or USB host. The mode depends on the "
+"USB hardware attached to the USB OTG port. If, for example, a USB mass "
+"storage device is attached to the USB OTG port, the device will show up "
+"as ``/dev/sda``."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:10
+msgid "USB Device"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:12
+msgid ""
+"In order to connect the board's USB device to a USB host port (for "
+"example a PC), you need to configure the appropriate USB gadget. With USB"
+" configfs you can define the parameters and functions of the USB gadget. "
+"The BSP includes USB configfs support as a kernel module."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:21
+msgid "**Example**:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:23
+msgid ""
+"First, define the parameters such as the USB vendor and product IDs, and "
+"set the information strings for the English (0x409) language:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:28
+msgid "To save time, copy these commands and execute them in a script"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:42
+msgid "Next, create a file for the mass storage gadget:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:48
+msgid "Now you should create the functions you want to use:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:58
+msgid "*acm*: Serial gadget, creates serial interface like ``/dev/ttyGS0``."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:59
+msgid "*ecm*: Ethernet gadget, creates ethernet interface, e.g. usb0"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:60
+msgid ""
+"*mass_storage*: The host can partition, format, and mount the gadget mass"
+" storage the same way as any other USB mass storage."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:63
+msgid "Bind the defined functions to a configuration:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:75
+msgid "Finally, start the USB gadget with the following commands:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:84
+msgid ""
+"If your system has more than one USB Device or OTG port, you can pass the"
+" right one to the USB Device Controller (UDC)."
+msgstr ""
+
+#: ../../source/bsp/peripherals/usb-otg.rsti:87
+msgid "To stop the USB gadget and unbind the used functions, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:456
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1460
+msgid ""
+"Both USB interfaces are configured as host in the kernel device tree |dt-"
+"carrierboard|.dts. See: :imx-dt:`imx8mm-phyboard-polis-"
+"rdk.dts?h=v5.15.71_2.2.2-phy3#n335`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:461
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1816
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1465
+#: ../../source/bsp/imx8/imx8mn/head.rst:442
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1800
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1432
+#: ../../source/bsp/imx8/imx8mp/head.rst:477
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1145
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1819
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1849
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1475
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1335
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1145
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:482
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:542
+msgid "CAN FD"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:463
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1818
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1467
+#: ../../source/bsp/imx8/imx8mn/head.rst:444
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1802
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1434
+#: ../../source/bsp/imx8/imx8mp/head.rst:479
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1147
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1821
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1851
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1477
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1337
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1147
+msgid ""
+"The |sbc| two flexCAN interfaces supporting CAN FD. They are supported by"
+" the Linux standard CAN framework which builds upon then the Linux "
+"network layer. Using this framework, the CAN interfaces behave like an "
+"ordinary Linux network device, with some additional features special to "
+"CAN. More information can be found in the Linux Kernel documentation: "
+"https://www.kernel.org/doc/html/latest/networking/can.html"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:472
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1827
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1476
+#: ../../source/bsp/imx8/imx8mn/head.rst:453
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1811
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1443
+msgid ""
+"phyBOARD-Polis has an external CANFD chip MCP2518FD connected over SPI. "
+"There are different interfaces involved, which limits the datarate "
+"capabilities of CANFD."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:478
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1833
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1482
+msgid ""
+"On phyBOARD-Polis-i.MX8MM a terminating resistor can be enabled by "
+"setting S5 to ON if required."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:1
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:1
+msgid "Use:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:7
+msgid ""
+"to see the state of the interfaces. The two CAN interfaces should show up"
+" as can0 and can1."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:10
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:10
+msgid "To get information on can0, such as bit rate and error counters, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:16
+msgid "The information for can0 will look like:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:35
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:30
+msgid ""
+"The output contains a standard set of parameters also shown for Ethernet "
+"interfaces, so not all of these are necessarily relevant for CAN (for "
+"example the MAC address). The following output parameters contain useful "
+"information:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:40
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:35
+msgid "can0"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:40
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:35
+msgid "Interface Name"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:42
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:37
+msgid "NOARP"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:42
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:37
+msgid "CAN cannot use ARP protocol"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:43
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:38
+msgid "MTU"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:43
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:38
+msgid "Maximum Transfer Unit"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:44
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:39
+msgid "RX packets"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:44
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:39
+msgid "Number of Received Packets"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:45
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:40
+msgid "TX packets"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:45
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:40
+msgid "Number of Transmitted Packets"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:46
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:41
+msgid "RX bytes"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:46
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:41
+msgid "Number of Received Bytes"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:47
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:42
+msgid "TX bytes"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:47
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:42
+msgid "Number of Transmitted Bytes"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:48
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:43
+msgid "errors..."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:48
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:43
+msgid "Bus Error Statistics"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:52
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:47
+msgid ""
+"The CAN configuration is done in the systemd configuration file "
+"``/lib/systemd/network/can0.network``. For a persistent change of (as an "
+"example, the default bitrates), change the configuration in the BSP under"
+" ``./meta-ampliphy/recipes-core/systemd/systemd-conf/can0.network`` in "
+"the root filesystem and rebuild the root filesystem."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:66
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:61
+msgid ""
+"The bitrate can also be changed manually, for example, to make use of the"
+" flexible bitrate:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:74
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:69
+msgid "You can send messages with cansend or receive messages with candump:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:81
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:76
+msgid "To generate random CAN traffic for testing purposes, use cangen:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:87
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:82
+msgid ""
+"``cansend --help`` and ``candump --help`` provide help messages for "
+"further information on options and usage."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/canfd.rsti:92
+msgid ""
+"The mcp2518fd SPI to CANfd supports only baudrates starting from 125kB/s."
+" Slower rates can be selected but may not work correctly."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:483
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1487
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :imx-dt:`imx8mm-"
+"phyboard-polis-rdk.dts?h=v5.15.71_2.2.2-phy3#n175`"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:2
+msgid "PCIe"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:4
+msgid ""
+"The phyCORE-|soc| has one Mini-PCIe slot. In general, PCIe autodetects "
+"new devices on the bus. After connecting the device and booting up the "
+"system, you can use the command lspci to see all PCIe devices recognized."
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:8
+#: ../../source/bsp/peripherals/pcie.rsti:62
+msgid "Type:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:44
+msgid ""
+"In this example, the PCIe device is the *Intel Corporation WiFi Link "
+"5100*."
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:46
+msgid ""
+"For PCIe devices, you have to enable the correct driver in the kernel "
+"configuration. This WLAN card, for example, is manufactured by Intel. The"
+" option for the driver, which must be enabled, is named "
+"``CONFIG_IWLWIFI`` and can be found under *Intel Wireless WiFi Next Gen "
+"AGN - Wireless-N/Advanced-N/Ultimat* in the kernel configuration."
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:52
+msgid ""
+"In order to activate the driver, follow the instructions from our Yocto "
+"manual: `Kernel and Bootloader Configuration <https://phytec.github.io"
+"/doc-bsp-yocto/yocto/kirkstone.html#kernel-and-bootloader-"
+"configuration>`__"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:56
+msgid "The linux-imx is represented by: **virtual/kernel**"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:58
+msgid ""
+"For some devices like the WLAN card, additional binary firmware blobs are"
+" needed. These firmware blobs have to be placed in ``/lib/firmware/`` "
+"before the device can be used."
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:68
+msgid "For example, if you try to bring up the network interface:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:74
+msgid "You will get the following output on the serial console:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/pcie.rsti:88
+msgid ""
+"Some PCIe devices, e.g. the Ethernet card, may function properly even if "
+"no firmware blob is loaded from ``/lib/firmware/`` and you received an "
+"error message as shown in the first line of the output above. This is "
+"because some manufacturers provide the firmware as a fallback on the card"
+" itself. In this case, the behavior and output depend strongly on the "
+"manufacturer's firmware."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:489
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1844
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1493
+#: ../../source/bsp/imx8/imx8mp/head.rst:497
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1839
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1869
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1495
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:497
+msgid "Audio"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:491
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1846
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1495
+msgid ""
+"The PEB-AV-10-Connector exists in two versions and the 1531.1 version is "
+"populated with a TI TLV320AIC3007 audio codec. Audio support is done via "
+"the I2S interface and controlled via I2C."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:495
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1850
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1499
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:617
+msgid ""
+"There is a 3.5mm headset jack with OMTP standard and an 8-pin header to "
+"connect audio devices with the AV-Connector.  The 8-pin header contains a"
+" mono speaker, headphones, and line-in signals."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1854
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1851
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1881
+#: ../../source/bsp/peripherals/audio.rsti:1
+msgid ""
+"To check if your soundcard driver is loaded correctly and what the device"
+" is called, type for playback devices:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1861
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1858
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1888
+#: ../../source/bsp/peripherals/audio.rsti:8
+msgid "Or type for recording devices:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1868
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1865
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1895
+#: ../../source/bsp/peripherals/audio.rsti:15
+msgid "Alsamixer"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1870
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1867
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1897
+#: ../../source/bsp/peripherals/audio.rsti:17
+msgid "To inspect the capabilities of your soundcard, call:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:23
+msgid ""
+"You should see a lot of options as the audio-IC has many features you can"
+" experiment with. It might be better to open alsamixer via ssh instead of"
+" the serial console, as the console graphical effects are better. You "
+"have either mono or stereo gain controls for all mix points. \"MM\" means"
+" the feature is muted (both output, left & right), which can be toggled "
+"by hitting '**m**'. You can also toggle by hitting '**<**' for left and "
+"'**>**' for right output. With the **tab** key, you can switch between "
+"controls for playback and recording."
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:32
+msgid "Restore default volumes"
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:34
+msgid ""
+"There are some default settings stored in ``/var/lib/alsa/asound.state``."
+" You can save your current alsa settings with:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:41
+msgid "You can restore saved alsa settings with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1885
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1882
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1912
+#: ../../source/bsp/peripherals/audio.rsti:50
+msgid "ALSA configuration"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1887
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1884
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1914
+#: ../../source/bsp/peripherals/audio.rsti:52
+msgid "Our BSP comes with a ALSA configuration file ``/etc/asound.conf``."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1889
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1886
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1916
+#: ../../source/bsp/peripherals/audio.rsti:54
+msgid ""
+"The ALSA configuration file can be edited as desired or deleted since it "
+"is not required for ALSA to work properly."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1893
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1923
+#: ../../source/bsp/peripherals/audio.rsti:61
+msgid ""
+"To set PEB-AV-10 as output, set *playback.pcm* from \"dummy\" to "
+"\"pebav10\":"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1910
+#: ../../source/bsp/peripherals/audio.rsti:75
+msgid ""
+"If the sound is not audible change playback devices to the software "
+"volume control playback devices, set *playback.pcm* to the respective "
+"softvol playback device e.g. \"softvol_pebav10\". Use alsamixer controls "
+"to vary the volume levels."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1927
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1924
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1954
+#: ../../source/bsp/peripherals/audio.rsti:92
+msgid "Pulseaudio Configuration"
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:94
+msgid "For applications using *Pulseaudio*, check for available sinks:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/audio.rsti:100
+msgid "To select the output device, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1944
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1941
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1971
+#: ../../source/bsp/peripherals/audio.rsti:4
+#: ../../source/bsp/peripherals/audio.rsti:109
+msgid "Playback"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1946
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1943
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1973
+#: ../../source/bsp/peripherals/audio.rsti:6
+#: ../../source/bsp/peripherals/audio.rsti:111
+msgid "Run speaker-test to check playback availability:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1952
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1949
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1979
+#: ../../source/bsp/peripherals/audio.rsti:12
+#: ../../source/bsp/peripherals/audio.rsti:117
+msgid ""
+"To playback simple audio streams, you can use aplay. For example to play "
+"the ALSA test sounds:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1959
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1956
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1986
+#: ../../source/bsp/peripherals/audio.rsti:19
+#: ../../source/bsp/peripherals/audio.rsti:124
+msgid "To playback other formats like mp3 for example, you can use Gstreamer:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1966
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1963
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1993
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:525
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:587
+#: ../../source/bsp/peripherals/audio.rsti:133
+msgid "Capture"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1968
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1965
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1995
+#: ../../source/bsp/peripherals/audio.rsti:135
+msgid ""
+"``arecord`` is a command-line tool for capturing audio streams which use "
+"Line In as the default input source. To select a different audio source "
+"you can use ``alsamixer``. For example, switch on *Right PGA Mixer Mic3R*"
+" and *Left PGA Mixer Mic3R* in order to capture the audio from the "
+"microphone input of the TLV320-Codec using the 3.5mm jack."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1985
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1982
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2012
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:536
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:598
+#: ../../source/bsp/peripherals/audio.rsti:152
+msgid ""
+"Since playback and capture share hardware interfaces, it is not possible "
+"to use different sampling rates and formats for simultaneous playback and"
+" capture operations."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:501
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1505
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`overlays/imx8mm-phyboard-polis-"
+"peb-av-010.dtsi?h=v5.15.71_2.2.2-phy3#n54`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1993
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1160
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1990
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2020
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1350
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1160
+#: ../../source/bsp/peripherals/video.rsti:2
+msgid "Video"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1996
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1163
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1993
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2023
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1353
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1163
+#: ../../source/bsp/peripherals/video.rsti:5
+msgid "Videos with Gstreamer"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1165
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1355
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1165
+#: ../../source/bsp/peripherals/video.rsti:7
+msgid ""
+"One example video is installed by default in the BSP at "
+"`/usr/share/qtphy/videos/`. Start the video playback with one of these "
+"commands:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2004
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2012
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1172
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2001
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2009
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2031
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2039
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1362
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1172
+#: ../../source/bsp/peripherals/video.rsti:14
+#: ../../source/bsp/peripherals/video.rsti:20
+msgid "Or:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:507
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2063
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1511
+#: ../../source/bsp/imx8/imx8mp/display.rsti:2
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1182
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2060
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2090
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1372
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1182
+#: ../../source/bsp/imx9/imx93/display.rsti:2
+msgid "Display"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:509
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2065
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1513
+msgid ""
+"The 10\" Display is always active. If the PEB-AV-Connector is not "
+"connected, an error message may occur at boot."
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:2 ../../source/bsp/qt6.rsti:2
+msgid "Qt Demo"
+msgstr ""
+
+#: ../../source/bsp/qt6.rsti:4
+msgid ""
+"With the ``phytec-qt6demo-image``, Weston starts during boot. Our Qt6 "
+"demo application named \"qtphy\" can be stopped with:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:11 ../../source/bsp/qt6.rsti:11
+msgid "To start the demo again, run:"
+msgstr ""
+
+#: ../../source/bsp/qt6.rsti:17
+msgid "To disable autostart of the demo, run:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:23 ../../source/bsp/qt6.rsti:23
+msgid "To enable autostart of the demo, run:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:29 ../../source/bsp/qt6.rsti:29
+msgid "Weston can be stopped with:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:37 ../../source/bsp/qt6.rsti:37
+msgid "The Qt demo must be closed before Weston can be closed."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:2
+msgid "Backlight Control"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:4
+msgid ""
+"If a display is connected to the PHYTEC board, you can control its "
+"backlight with the Linux kernel sysfs interface. All available backlight "
+"devices in the system can be found in the folder /sys/class/backlight. "
+"Reading the appropriate files and writing to them allows you to control "
+"the backlight."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:10
+msgid ""
+"Some boards with multiple display connectors might have multiple "
+"backlight controls in /sys/class/backlight. For example: backlight0 and "
+"backlight1"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:13
+msgid ""
+"To get, for example, the maximum brightness level (max_brightness) "
+"execute:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:19
+msgid "Valid brightness values are 0 to <max_brightness>."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:21
+msgid "To obtain the current brightness level, type:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:27
+msgid "Write to the file brightness to change the brightness:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:33
+msgid "turns the backlight off for example."
+msgstr ""
+
+#: ../../source/bsp/imx-common/peripherals/display.rsti:35
+msgid ""
+"For documentation of all files, see "
+"https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-"
+"backlight."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/head.rst:516
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1520
+msgid ""
+"The device tree of PEB-AV-10 can be found here: :imx-dt:`overlays/imx8mm-"
+"phyboard-polis-peb-av-010.dtsi?h=v5.15.71_2.2.2-phy3`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1205
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1395
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1205
+#: ../../source/bsp/imx8/peripherals/pm.rsti:2
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:2
+msgid "Power Management"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1208
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1398
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1208
+#: ../../source/bsp/imx8/peripherals/pm.rsti:5
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:5
+msgid "CPU Core Frequency Scaling"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1210
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1400
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1210
+#: ../../source/bsp/imx8/peripherals/pm.rsti:7
+msgid ""
+"The CPU in the |soc| SoC is able to scale the clock frequency and the "
+"voltage. This is used to save power when the full performance of the CPU "
+"is not needed. Scaling the frequency and the voltage is referred to as "
+"'Dynamic Voltage and Frequency Scaling' (DVFS). The |soc| BSP supports "
+"the DVFS feature. The Linux kernel provides a DVFS framework that allows "
+"each CPU core to have a min/max frequency and a governor that governs it."
+" Depending on the |socfamily| variant used, several different frequencies"
+" are supported."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1220
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1410
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1220
+#: ../../source/bsp/imx8/peripherals/pm.rsti:17
+msgid ""
+"Although the DVFS framework provides frequency settings for each CPU "
+"core, a change in the frequency settings of one CPU core always affects "
+"all other CPU cores too. So all CPU cores always share the same DVFS "
+"setting. An individual DVFS setting for each core is not possible."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1226
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1416
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1226
+#: ../../source/bsp/imx8/peripherals/pm.rsti:23
+msgid "To get a complete list type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1232
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1422
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1232
+#: ../../source/bsp/imx8/peripherals/pm.rsti:29
+msgid ""
+"In case you have, for example, i.MX 8MPlus CPU with a maximum of "
+"approximately 1,6 GHz, the result will be:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1239
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1429
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1239
+#: ../../source/bsp/imx8/peripherals/pm.rsti:36
+msgid "To ask for the current frequency type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1245
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1435
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1245
+#: ../../source/bsp/imx8/peripherals/pm.rsti:42
+msgid ""
+"So-called governors are automatically selecting one of these frequencies "
+"in accordance with their goals."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1248
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1438
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1248
+#: ../../source/bsp/imx8/peripherals/pm.rsti:45
+msgid "List all governors available with the following command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1254
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1444
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1254
+#: ../../source/bsp/imx8/peripherals/pm.rsti:51
+msgid "The result will be:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/pm.rsti:57
+msgid ""
+"**conservative** is much like the ondemand governor. It differs in "
+"behavior in that it gracefully increases and decreases the CPU speed "
+"rather than jumping to max speed the moment there is any load on the CPU."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1260
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1450
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1260
+#: ../../source/bsp/imx8/peripherals/pm.rsti:60
+msgid ""
+"**ondemand** (default) switches between possible CPU core frequencies in "
+"reference to the current system load. When the system load increases "
+"above a specific limit, it increases the CPU core frequency immediately."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/pm.rsti:63
+msgid "**powersave** always selects the lowest possible CPU core frequency."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1263
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1453
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1263
+#: ../../source/bsp/imx8/peripherals/pm.rsti:64
+msgid "**performance** always selects the highest possible CPU core frequency."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1264
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1454
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1264
+#: ../../source/bsp/imx8/peripherals/pm.rsti:65
+msgid ""
+"**userspace** allows the user or userspace program running as root to set"
+" a specific frequency (e.g. to 1600000). Type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1267
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1457
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1267
+#: ../../source/bsp/imx8/peripherals/pm.rsti:68
+msgid "In order to ask for the current governor, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1273
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1463
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1273
+#: ../../source/bsp/imx8/peripherals/pm.rsti:74
+msgid "You will normally get:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1279
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1469
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1279
+#: ../../source/bsp/imx8/peripherals/pm.rsti:80
+msgid "Switching over to another governor (e.g. userspace) is done with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1285
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1475
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1285
+#: ../../source/bsp/imx8/peripherals/pm.rsti:86
+msgid "Now you can set the speed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1291
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1481
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1291
+#: ../../source/bsp/imx8/peripherals/pm.rsti:92
+msgid ""
+"For more detailed information about the governors, refer to the Linux "
+"kernel documentation in the linux kernel repository at ``Documentation"
+"/admin-guide/pm/cpufreq.rst``."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1296
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1486
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1296
+#: ../../source/bsp/imx8/peripherals/pm.rsti:97
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:79
+msgid "CPU Core Management"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1298
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1488
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1298
+#: ../../source/bsp/imx8/peripherals/pm.rsti:99
+msgid ""
+"The |soc| SoC can have multiple processor cores on the die. The |soc|, "
+"for example, has 4 ARM Cores which can be turned on and off individually "
+"at runtime."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1301
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1491
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1301
+#: ../../source/bsp/imx8/peripherals/pm.rsti:102
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:84
+msgid "To see all available cores in the system, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1307
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1497
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1307
+#: ../../source/bsp/imx8/peripherals/pm.rsti:108
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:90
+msgid "This will show, for example:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1314
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1504
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1314
+#: ../../source/bsp/imx8/peripherals/pm.rsti:115
+msgid ""
+"Here the system has four processor cores. By default, all available cores"
+" in the system are enabled to get maximum performance."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1317
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1507
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1317
+#: ../../source/bsp/imx8/peripherals/pm.rsti:118
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:102
+msgid "To switch off a single-core, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1323
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1513
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1323
+#: ../../source/bsp/imx8/peripherals/pm.rsti:124
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:108
+msgid "As confirmation, you will see:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1329
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1519
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1329
+#: ../../source/bsp/imx8/peripherals/pm.rsti:130
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:114
+msgid ""
+"Now the core is powered down and no more processes are scheduled on this "
+"core."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1331
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1521
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1331
+#: ../../source/bsp/imx8/peripherals/pm.rsti:132
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:116
+msgid "You can use top to see a graphical overview of the cores and processes:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1337
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1527
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1337
+#: ../../source/bsp/imx8/peripherals/pm.rsti:138
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:122
+msgid "To power up the core again, execute:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/pm.rsti:147
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:129
+msgid "Suspend to RAM"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/pm.rsti:149
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:131
+msgid ""
+"The |som| supports basic suspend and resume. Different wake-up sources "
+"can be used. Suspend/resume is possible with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/pm.rsti:157
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:139
+msgid "To wake up with serial console run"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:2
+#: ../../source/bsp/imx9/peripherals/tm.rsti:2
+msgid "Thermal Management"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:2
+#: ../../source/bsp/imx8/peripherals/tm.rsti:5
+#: ../../source/bsp/imx9/peripherals/tm.rsti:5
+msgid "U-Boot"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:7
+#: ../../source/bsp/imx9/peripherals/tm.rsti:7
+msgid ""
+"The previous temperature control in the U-Boot was not satisfactory. Now "
+"the u-boot has a temperature shutdown to prevent the board from getting "
+"too hot during booting. The temperatures at which the shutdown occurs are"
+" identical to those in the kernel."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:12
+#: ../../source/bsp/imx9/peripherals/tm.rsti:12
+msgid ""
+"The individual temperature ranges with the current temperature are "
+"displayed in the boot log:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:2
+#: ../../source/bsp/imx8/peripherals/tm.rsti:20
+#: ../../source/bsp/imx9/peripherals/tm.rsti:20
+msgid "Kernel"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:22
+#: ../../source/bsp/imx9/peripherals/tm.rsti:22
+msgid ""
+"The Linux kernel has integrated thermal management that is capable of "
+"monitoring SoC temperatures, reducing the CPU frequency, driving fans, "
+"advising other drivers to reduce the power consumption of devices, and – "
+"worst-case – shutting down the system gracefully "
+"(https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt)."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:28
+#: ../../source/bsp/imx9/peripherals/tm.rsti:28
+msgid ""
+"This section describes how the thermal management kernel API is used for "
+"the |soc| SoC platform. The |socfamily| has internal temperature sensors "
+"for the SoC."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:32
+#: ../../source/bsp/imx9/peripherals/tm.rsti:32
+msgid "The current temperature can be read in millicelsius with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:44
+msgid ""
+"There are two trip points registered by the imx_thermal kernel driver. "
+"These differ depending on the CPU variant. A distinction is made between "
+"Industrial and Commercial."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:49
+#: ../../source/bsp/imx9/peripherals/tm.rsti:49
+msgid "Commercial"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:49
+#: ../../source/bsp/imx9/peripherals/tm.rsti:49
+msgid "Industrial"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:51
+#: ../../source/bsp/imx9/peripherals/tm.rsti:51
+msgid "passive (warning)"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:51
+#: ../../source/bsp/imx9/peripherals/tm.rsti:51
+msgid "85°C"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:51
+#: ../../source/bsp/imx9/peripherals/tm.rsti:51
+msgid "95°C"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:52
+#: ../../source/bsp/imx9/peripherals/tm.rsti:52
+msgid "critical (shutdown)"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:52
+#: ../../source/bsp/imx9/peripherals/tm.rsti:52
+msgid "90°C"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:52
+#: ../../source/bsp/imx9/peripherals/tm.rsti:52
+msgid "100°C"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:55
+#: ../../source/bsp/imx9/peripherals/tm.rsti:55
+msgid "(see kernel sysfs folder ``/sys/class/thermal/thermal_zone0/``)"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:57
+msgid ""
+"The kernel thermal management uses these trip points to trigger events "
+"and change the cooling behavior. The following thermal policies (also "
+"named thermal governors) are available in the kernel: Step Wise, Fair "
+"Share, Bang Bang, and Userspace. The default policy used in the BSP is "
+"step_wise. If the value of the SoC temperature in the sysfs file temp is "
+"above *trip_point_0*, the CPU frequency is set to the lowest CPU "
+"frequency. When the SoC temperature drops below *trip_point_0* again, the"
+" throttling is released."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:67
+#: ../../source/bsp/imx9/peripherals/tm.rsti:72
+msgid ""
+"The actual values of the thermal trip points may differ since we mount "
+"CPUs with different temperature grades."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:73
+msgid "GPIO Fan"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:77
+msgid "|pollux-fan-note|"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:79
+msgid ""
+"A GPIO fan can be connected to the |sbc|-|soc|. The SoC only contains one"
+" temperature sensor which is already used by the thermal frequency "
+"scaling. The fan can not be controlled by the kernel. We use lmsensors "
+"with hwmon for this instead. lmsensors reads the temperature periodically"
+" and enables or disables the fan at a configurable threshold. For the "
+"|sbc|-|soc|, this is 60°C."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:85
+msgid "The settings can be configured in the configuration file:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/tm.rsti:91
+msgid ""
+"Fan control is started by a systemd service during boot. This can be "
+"disabled with:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:2
+msgid "Watchdog"
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:4
+msgid ""
+"The PHYTEC |soc| modules include a hardware watchdog that is able to "
+"reset the board when the system hangs. The watchdog is started on default"
+" in U-Boot with a timeout of 60s. So even during early kernel start, the "
+"watchdog is already up and running. The Linux kernel driver takes control"
+" over the watchdog and makes sure that it is fed. This section explains "
+"how to configure the watchdog in Linux using systemd to check for system "
+"hangs and during reboot."
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:12
+msgid "Watchdog Support in systemd"
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:14
+msgid "Systemd has included hardware watchdog support since version 183."
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:16
+msgid ""
+"To activate watchdog support, the file system.conf in ``/etc/systemd/`` "
+"has to be adapted by enabling the options:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/watchdog.rsti:24
+msgid ""
+"*RuntimeWatchdogSec* defines the timeout value of the watchdog, while "
+"*ShutdownWatchdogSec* defines the timeout when the system is rebooted. "
+"For more detailed information about hardware watchdogs under systemd can "
+"be found at http://0pointer.de/blog/projects/watchdog.html. The changes "
+"will take effect after a reboot or run:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:2
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:2
+msgid "On-Chip OTP Controller (OCOTP_CTRL) - eFuses"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:4
+msgid ""
+"The |soc| provides one-time programmable fuses to store information such "
+"as the MAC address, boot configuration, and other permanent settings "
+"(\"On-Chip OTP Controller (OCOTP_CTRL)\" in the |soc| Reference Manual). "
+"The following list is an abstract from the |soc| Reference Manual and "
+"includes some useful registers in the OCOTP_CTRL (at base address "
+"0x30350000):"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:11
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:11
+msgid "Name"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:11
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:11
+msgid "Bank"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:11
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:11
+msgid "Word"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:11
+msgid "Memory offset at 0x30350000"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:11
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:11
+msgid "Description"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:14
+msgid "OCOTP_MAC_ADDR0"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:14
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:16
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:20
+msgid "9"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:14
+msgid "0"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:14
+msgid "0x640"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:14
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:18
+msgid "contains lower 32 bits of ENET0 MAC address"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:16
+msgid "OCOTP_MAC_ADDR1"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:16
+msgid "1"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:16
+msgid "0x650"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:16
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:20
+msgid ""
+"contains upper 16 bits of ENET0 MAC address and the lower 16 bits of "
+"ENET1 MAC address"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:20
+msgid "OCOTP_MAC_ADDR2"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:20
+msgid "2"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:20
+msgid "0x660"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:20
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:24
+msgid "contains upper 32 bits of ENET1 MAC address"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:24
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:28
+msgid ""
+"A complete list and a detailed mapping between the fuses in the "
+"OCOTP_CTRL and the boot/mac/... configuration are available in the "
+"section \"Fuse Map\" of the |soc| Security Reference Manual."
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:29
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:33
+msgid "Reading Fuse Values in uBoot"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:31
+msgid ""
+"You can read the content of a fuse using memory-mapped shadow registers. "
+"To calculate the memory address, use the fuse Bank and Word in the "
+"following formula:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:35
+msgid "OCOTP_MAC_ADDR:"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:42
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:42
+msgid "Reading Fuse Values in Linux"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/ocotp-ctrl.rsti:44
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:44
+msgid ""
+"To access the content of the fuses in Linux NXP provides the "
+"NVMEM_IMX_OCOTP module. All fuse content of the memory-mapped shadow "
+"registers is accessible via sysfs:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:2 ../../source/bsp/imx9/mcu.rsti:2
+msgid "|soc| |mcore|"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:4
+msgid ""
+"In addition to the Cortex-A53 cores, there is a Cortex-|mcore| as MCU "
+"integrated into the |soc| SoC. Our Yocto-Linux-BSP runs on the A53-Cores "
+"and the |mcore| can be used as a secondary core for additional tasks "
+"using bare-metal or RTOS firmware. Both cores have access to the same "
+"peripherals and thus peripheral usage needs to be limited either in the "
+"|mcore|'s firmware or the devicetree for the Linux operating system. This"
+" section describes how to build firmware examples and how to run them on "
+"|sbc|."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:13
+msgid ""
+"The |sbc| is currently supported by the NXP MCUXpresso SDK and by The "
+"Zephyr Project. This section only describes the NXP MCUXpresso SDK "
+"because the MCUXpresso SDK has more supported features at the moment."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:17
+msgid ""
+"If you want to use the |mcore| with The Zephyr Project, please refer to "
+"the The Zephyr Project documentation:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:20
+msgid "|mcore-zephyr-docs|"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:23
+msgid "Getting the Firmware Examples"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:25
+msgid ""
+"The firmware can be built using the NXP MCUxpresso SDK with a compatible "
+"compiler toolchain using command-line tools."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:29
+msgid "Getting the Sources"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:31
+msgid ""
+"The MCUX SDK and the examples for the |soc| can be obtained from PHYTEC's"
+" GitHub page:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:34
+msgid "https://github.com/phytec/mcux-sdk/"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:35
+msgid "https://github.com/phytec/mcux-sdk-phytec-examples/"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:37
+msgid "Initialize the MCUX SDK via west:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:43
+msgid ""
+"This will create a mcuxsdk directory with the mcux-sdk repository in it. "
+"The ``mcux-sdk-phytec-examples`` repository will be automatically cloned "
+"into the mcuxsdk directory. The given argument <VERSION> is a the branch "
+"name of the mcux-sdk repository that represents the MCUX SDK version. For"
+" the newest tested version you can use |mcore-sdk-version|."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:52
+msgid ""
+"``west`` is a repository management tool and a part of the Zephyr "
+"Project. To install west, you can use pip. In this example west is "
+"installed in a python virtual environment::"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:62
+msgid "Update the dependencies:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:69
+msgid ""
+"The directory ``examples-phytec`` contains all examples ported and tested"
+" for |sbc| with version |mcore-sdk-version| of MCUX."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:72
+msgid ""
+"To build the firmware, a compiler toolchain and make/cmake are required. "
+"The GNU Arm Embedded Toolchain may be available in your distribution's "
+"repositories, e.g. for Ubuntu."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:80
+msgid ""
+"The compiler toolchain can also be obtained directly from "
+"https://developer.arm.com/. After the archive has been extracted, the "
+"``ARMGCC_DIR`` has to be added to the environment, e.g. for the ARM "
+"toolchain 10-2020-q4-major release located in the home directory:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:90
+msgid "Building the Firmware"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:92
+msgid "To build the PHYTEC samples an environment has to be sourced"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:98
+msgid ""
+"The scripts to build the firmware are located in <sdk-directory>/phytec-"
+"mcux-boards/phyboard-pollux/<example_category>/<example>/armgcc. There "
+"are scripts for each memory location the firmware is supposed to run in, "
+"e.g."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:107
+msgid ""
+"to build the firmware for the |mcore|'s TCM. The output will be placed "
+"under release/ in the armgcc directory. .bin files and can be run in "
+"U-Boot and .elf files within Linux."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:111
+msgid ""
+"To build the firmware for the DRAM, run the script build_ddr_release. The"
+" script of the firmware that is supposed to run, e.g."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:118
+msgid ""
+"The output will be placed under ddr_release/ in the armgcc directory. "
+".bin files and can be run in U-Boot and .elf files within Linux."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:123 ../../source/bsp/imx9/mcu.rsti:17
+msgid "Running |mcore| Examples"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:125
+msgid ""
+"There are two ways to run the |mcore| with the built firmware, U-Boot and"
+" Remoteproc within a running Linux."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:128 ../../source/bsp/imx9/mcu.rsti:22
+msgid ""
+"To receive debug messages start your favorite terminal software (e.g. "
+"Minicom, Tio, or Tera Term) on your host PC and configure it for 115200 "
+"baud, 8 data bits, no parity, and 1 stop bit (8n1) with no handshake."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:132
+msgid ""
+"Once a micro-USB cable is connected to the USB-debug port on the |sbc|, "
+"two ttyUSB devices are registered. One prints messages from A53-Core's "
+"debug UART and the other one from the |mcore|'s debug UART."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:137 ../../source/bsp/imx9/mcu.rsti:42
+msgid "Running Examples from U-Boot"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:139
+msgid ""
+"To load firmware using the bootloader U-Boot, the bootaux command can be "
+"used:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:141 ../../source/bsp/imx9/mcu.rsti:47
+msgid "Prepare an SD Card with our Yocto-BSP"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:142
+msgid "Copy the generated .bin file to the SD Cards first partition"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:143 ../../source/bsp/imx9/mcu.rsti:48
+msgid "Stop the autoboot by pressing any key"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:144
+msgid "Type the command depending on the type of firmware:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:146
+msgid "For firmware built to run in the |mcore|'s TCM::"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:152
+msgid "For firmware built to run in the DRAM::"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:159 ../../source/bsp/imx9/mcu.rsti:71
+msgid "The program's output should appear on the |mcore|'s debug UART."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:162 ../../source/bsp/imx9/mcu.rsti:74
+msgid "Running Examples from Linux using Remoteproc"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:164
+msgid ""
+"Remoteproc is a module that allows you to control the |mcore| from Linux "
+"during runtime. Firmware built for TCM can be loaded and the execution "
+"started or stopped. To use Remoteproc a devicetree overlay needs to be "
+"set:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:168
+msgid ""
+"Edit the bootenv.txt file located in the /boot directory on the target by"
+" adding |dtbo-rpmsg|:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:176 ../../source/bsp/imx9/mcu.rsti:89
+msgid "Restart the target and execute in U-Boot::"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:180
+msgid ""
+"Firmware .elf files for the |mcore| can be found under /lib/firmware. To "
+"load the firmware, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:188 ../../source/bsp/imx9/mcu.rsti:107
+msgid "To load a different firmware, the |mcore| needs to be stopped:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:196
+msgid ""
+"The samples found in ``/lib/firmware`` on the target come from NXP's "
+"Yocto layer meta-imx. To use the samples you built yourself through MCUX "
+"SDK, please copy them to ``/lib/firmware`` on the target after building "
+"them."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:202
+msgid "Debugging Using J-Link"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:204
+msgid ""
+"The Segger software can be obtained from "
+"https://www.segger.com/downloads/jlink/. As of version V7.20a of the "
+"Segger software, accessing the |soc|' |mcore| requires additional "
+"configuration files to be copied into the J-Link software directory: NXP "
+"J-Link files for |soc|"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:209
+msgid ""
+"Together with the J-Link, GDB Server can be used for running and "
+"debugging the software.  On the |sbc|, the JTAG-Pins are accessible via "
+"the |expansion-connector| Expansion Connector. The simplest way is to use"
+" a PEB-EVAL-01 board that has the JTAG-Pins reachable with a pin header "
+"on the top."
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:219
+msgid "To start the J-Link software, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/mcu.rsti:229
+msgid "To start GDB with a firmware example in another window, type:"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:2
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2094
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1838
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2197
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2227
+msgid "BSP Extensions"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:5
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2097
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1841
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2200
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2230
+msgid "Chromium"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:7
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2099
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1843
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2202
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2232
+msgid ""
+"Our BSP for the |sbc|-|soc| supports Chromium. You can include it in the "
+"|yocto-imagename| with only a few steps."
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:11
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2103
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1847
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2206
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2236
+msgid "Adding Chromium to Your local.conf"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:13
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2105
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1849
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2208
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2238
+msgid ""
+"To include Chromium you have to add the following line into your "
+"local.conf. You can find it in <yocto_dir>/build/conf/local.conf. This "
+"adds Chromium to your next image build. ::"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:21
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2113
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1857
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2216
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2246
+msgid "Compiling Chromium takes a long time."
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:24
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2116
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1860
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2219
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2249
+msgid "Get Chromium Running on the Target"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:26
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2118
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1862
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2221
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2251
+msgid ""
+"To run Chromium, it needs a few arguments to use the hardware graphics "
+"acceleration::"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:31
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2123
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1867
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2226
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2256
+msgid ""
+"If you want to start Chromium via SSH, you must first define the display "
+"on which Chromium will run. For example::"
+msgstr ""
+
+#: ../../source/bsp/bsp-extensions.rsti:36
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2128
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1872
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2231
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2261
+msgid ""
+"After you have defined this, you can start it via virtual terminal on "
+"Weston as shown above."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:8
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:18
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:28
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:8
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:18
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:28
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:8
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:18
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:28
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:38
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:49
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:59
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:69
+#: ../../source/bsp/imx9/imx93/imx93.rst:8
+#: ../../source/bsp/imx9/imx93/imx93.rst:18
+msgid "Table of Contents"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:6
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:6
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:6
+msgid "HEAD"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:16
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:16
+msgid "BSP-Yocto-NXP-i.MX8MM-PD23.1.0"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/imx8mm.rst:26
+#: ../../source/bsp/imx8/imx8mn/imx8mn.rst:26
+msgid "BSP-Yocto-NXP-i.MX8MM-PD22.1.1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:103
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:105
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:112
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:114
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:122
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:97
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:99
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:107
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:104
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:106
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:114
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:113
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:115
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:113
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:115
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:125
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:133
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:106
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:108
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:116
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:107
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:109
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:117
+msgid "|soc| BSP Manual"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:111
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:105
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:121
+msgid "2023/05/25"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:122
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:131
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:116
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:142
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:135
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:125
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:126
+msgid "|yocto-manifestname|"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:122
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:116
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:135
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:126
+msgid "Minor"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:122
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:116
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:132
+msgid "2023/05/23"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:122
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:131
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:116
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:132
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:142
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:135
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:135
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:125
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:126
+msgid "Released"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:148
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:141
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:156
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:161
+msgid ""
+"The |kit| is shipped with a pre-flashed SD card. It contains the |yocto-"
+"imagename| and can be used directly as a boot source. The eMMC is "
+"programmed with only a U-boot by default. You can get all sources from "
+"the `PHYTEC download server <dl-server_>`_. This chapter explains how to "
+"flash a BSP image to SD card and how to start the board."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:157
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:150
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:165
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:170
+msgid ""
+"The WIC image contains all BSP files in several, correctly pre-formatted "
+"partitions and can be copied to an SD card easily using the single Linux "
+"command ``dd``. It can be built by Yocto or downloaded from the PHYTEC "
+"download server."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:162
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:155
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:170
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:175
+msgid "Get the WIC file from the download server:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:173
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:166
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:181
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:186
+msgid ""
+"To create your bootable SD card with the ``dd`` command, you must have "
+"root privileges. Be very careful when specifying the destination device "
+"with ``dd``! All files on the selected destination device will be erased "
+"immediately without any further query!"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:178
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:171
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:186
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:191
+msgid ""
+"Selecting the wrong device may result in **data loss** and e.g. could "
+"erase your currently running system!"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:181
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:174
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:189
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:194
+msgid ""
+"To create your bootable SD card, you must first find the correct device "
+"name of your SD card and possible partitions. Unmount any mounted "
+"partitions before you start copying the image to the SD card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:185
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:178
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:193
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:198
+msgid "In order to get the correct device name, remove your SD card and execute::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:190
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:183
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:198
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:203
+msgid "Now insert your SD card and execute the command again::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:213
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:206
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:221
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:226
+msgid "Unmount all partitions, e.g.::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:217
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:210
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:225
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:230
+msgid ""
+"After having unmounted all partitions, you can create your bootable SD "
+"card::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:221
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:214
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:229
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:234
+msgid ""
+"Again, make sure to replace ``/dev/sdX`` with your actual device name "
+"found previously."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:230
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:223
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:238
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:243
+msgid ""
+"An alternative and much faster way to prepare an SD card can be done by "
+"using `bmap-tools <https://github.com/intel/bmap-tools>`_ from Intel. "
+"Yocto automatically creates a block map file "
+"(``<IMAGENAME>-<MACHINE>.wic.bmap``) for the WIC image that describes the"
+" image content and includes checksums for data integrity. *bmaptool* is "
+"packaged by various Linux distributions. For Debian-based systems install"
+" it by issuing::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:239
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:232
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:247
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:252
+msgid "Flash a WIC image to SD card by calling::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:287
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:291
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:296
+msgid "**phytec-qt5demo-image\\*.tar.gz**: Root file system"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:288
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:292
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:297
+msgid "**phytec-qt5demo-image\\*.wic**: SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:309
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:304
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:317
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:322
+msgid ""
+"To boot from eMMC, make sure that the BSP image is flashed correctly to "
+"the eMMC and the |ref-bootswitch| is set to **Default SOM boot**."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:337
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:332
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:345
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:350
+msgid "Flash eMMC from Network in u-boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:339
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:334
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:347
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:352
+msgid ""
+"These steps will show how to update the eMMC via a network. However, they"
+" only work if the size of the image file is less than 1GB. If the image "
+"file is larger, go to the section Format SD Card. Configure the |ref-"
+"bootswitch| to boot from SD Card and put in an SD card. Power on the "
+"board and stop in U-Boot prompt."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:389
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:408
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:434
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:682
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:384
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:403
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:429
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:677
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:397
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:416
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:442
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:690
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:402
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:421
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:447
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:695
+msgid "A working network is necessary! Setup Network Host."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:391
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:386
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:399
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:404
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:495
+msgid ""
+"Take a compressed or uncompressed image on the host and send it with ssh "
+"through the network (then uncompress it, if necessary) to the eMMC of the"
+" target with a one-line command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:418
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:413
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:426
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:431
+msgid ""
+"Send the image with the command dd command combined with ssh through the "
+"network to the eMMC of your device:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:427
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:422
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:435
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:440
+msgid "Flash eMMC u-boot image via Network from running u-boot"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:429
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:424
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:437
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:442
+msgid ""
+"Update the standalone u-boot image imx-boot is also possible from u-boot."
+" This can be used if the bootloader on eMMC is located in the eMMC user "
+"area."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:452
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:447
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:460
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:465
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:556
+#: ../../source/bsp/imx9/installing-os.rsti:196
+msgid "Flash eMMC from USB"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:455
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:450
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:463
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:468
+msgid "Flash eMMC from USB in u-boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:459
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:454
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:467
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:472
+msgid ""
+"This step only works if the size of the image file is less than 1GB due "
+"to limited usage of RAM size in Bootloader after enabling the OPTEE."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:462
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:457
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:470
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:475
+msgid ""
+"These steps will show how to update the eMMC via a USB device. Configure "
+"the bootmode switch to |ref-bootswitch| and put in an SD card. Power on "
+"the board and stop in u-boot prompt. Insert a USB device with the copied "
+"WIC image to the USB slot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:495
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:490
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:503
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:508
+msgid ""
+"These steps will show how to flash the eMMC on Linux with a USB stick. "
+"You only need a complete image saved on the USB stick and a bootable WIC "
+"image. (e.g. |yocto-imagename|-|yocto-machinename|.wic). Set the bootmode"
+" switch to |ref-bootswitch|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:524
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:624
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:519
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:619
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:532
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:632
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:537
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:637
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:631
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:737
+#: ../../source/bsp/imx9/installing-os.rsti:47
+#: ../../source/bsp/imx9/installing-os.rsti:229
+msgid "Show list of available MMC devices:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:539
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:534
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:547
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:552
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:646
+msgid ""
+"The eMMC device can be recognized by the fact that it contains two boot "
+"partitions: (mmcblk2boot0; mmcblk2boot1)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:552
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:547
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:560
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:565
+msgid ""
+"Before this will work, you need to configure the multi-port switch to "
+"**Default SOM Boot** to |ref-bootswitch|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:558
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:553
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:566
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:571
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:665
+msgid ""
+"Even if there is no network available, you can update the eMMC. For that,"
+" you only need a ready-to-use image file (``*.wic``) located on the SD "
+"card. Because the image file is quite large, you have to enlarge your SD "
+"card to use its full space (if it was not enlarged before). To enlarge "
+"your SD card, see Resizing ext4 Root Filesystem."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:565
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:560
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:573
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:578
+msgid "Flash eMMC from SD card in u-boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:569
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:564
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:577
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:582
+msgid ""
+"This step only works if the size of the image file is less than 1GB due "
+"to limited usage of RAM size in Bootloader after enabling the OPTEE. If "
+"the image file is too large use the `Updating eMMC from SD card in Linux "
+"on Target` subsection."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:574
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:569
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:582
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:587
+msgid ""
+"Flash an SD card with a working image and create a third FAT partition. "
+"Copy the WIC image (for example |yocto-imagename|.wic) to this partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:577
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:572
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:585
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:590
+msgid ""
+"Configure the bootmode switch to boot from the SD Card and insert the SD "
+"card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:579
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:574
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:587
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:592
+msgid "Power on the board and stop in u-boot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:580
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:716
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:575
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:709
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:588
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:593
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:726
+msgid ""
+"Flash your WIC image (for example |yocto-imagename|.wic) from the SD card"
+" to eMMC. This will partition the card and copy imx-boot, Image, dtb, "
+"dtbo, and root file system to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:592
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:587
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:600
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:605
+msgid "Switch the mmc dev:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:607
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:602
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:615
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:620
+msgid ""
+"Power off the board and change the multi-port switch to Default SOM Boot "
+"to boot from eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:613
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:608
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:621
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:626
+msgid ""
+"You can also flash the eMMC on Linux. You only need a complete image "
+"saved on the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:616
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:611
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:624
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:629
+msgid "Show your saved image files on the SD card:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:639
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:634
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:647
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:652
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:752
+msgid ""
+"The eMMC device can be recognized by the fact that it contains two boot "
+"partitions: (mmcblk2\\ **boot0**; mmcblk2\\ **boot1**)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:641
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:636
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:649
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:654
+msgid ""
+"Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without** "
+"partition):"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:653
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:648
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:661
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:666
+msgid ""
+"Before this will work, you need to configure the |ref-bootswitch| to "
+"Default SOM Boot to boot from eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:659
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:654
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:667
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:672
+msgid ""
+"The |som| modules are optionally equipped with SPI NOR Flash. To boot "
+"from SPI Flash, set |ref-bootswitch| to **QSPI boot** to boot from QSPI. "
+"The SPI Flash is usually quite small. The phyBOARD-Pollux-i.MX8MP kit "
+"only has 32MB SPI NOR flash populated. Only the bootloader and the "
+"environment can be stored. The kernel, device tree, and file system are "
+"taken from eMMC by default."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:685
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:680
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:693
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:698
+msgid "Flash SPI NOR from Network in u-boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:687
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:682
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:695
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:700
+msgid ""
+"Similar to updating the eMMC over a network, be sure to set up the "
+"development host correctly. The IP needs to be set to 192.168.3.10, the "
+"netmask to 255.255.255.0, and a TFTP server needs to be available. Before"
+" reading and writing is possible, the SPI-NOR flash needs to be probed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:697
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:692
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:705
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:710
+msgid ""
+"A specially formatted u-boot image for the SPI NOR flash is used. Ensure "
+"you use the correct image file. Load the image over tftp, erase and write"
+" the bootloader to the flash:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:718
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:794
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:713
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:789
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:726
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:802
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:731
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:807
+msgid ""
+"Erasing the complete SPI NOR flash when it is fully written will take "
+"quite some time. This can trigger the watchdog to reset. Due to this, "
+"erase the full flash in Linux."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:732
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:727
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:740
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:745
+msgid "Find the number of erase blocks of the U-boot partition:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:762
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:757
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:770
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:775
+msgid "Flash SPI NOR from SD Card in u-boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:764
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:759
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:772
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:777
+msgid ""
+"Copy the SPI NOR flash U-boot image imx-boot-|yocto-machinename|-fspi"
+".bin-flash_evk_flexspi to the FAT partition on the SD Card. Before "
+"reading and writing are possible, the SPI-NOR flash needs to be probed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:808
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:803
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:816
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:821
+msgid "Find the number of erase blocks of the u-boot partition:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:835
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:830
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:843
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:848
+msgid ""
+"The RAUC (Robust Auto-Update Controller) mechanism support has been added"
+" to meta-ampliphy. It controls the procedure of updating a device with "
+"new firmware. This includes updating the Linux kernel, Device Tree, and "
+"root filesystem. PHYTEC has written an online manual on how we have "
+"intergraded RAUC into our BSPs: `L-1006e.A3 RAUC Update & Device "
+"Management Manual <https://www.phytec.de/cdocuments/?doc=BKXvGQ>`__."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:887
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:998
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:882
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:991
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:895
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:900
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1008
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:276
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:285
+msgid ""
+"Download imx-boot from our server or get it from your Yocto build "
+"directory at build/deploy/images/|yocto-machinename|/. For flashing a wic"
+" image to eMMC, you will also need |yocto-imagename|-|yocto-"
+"machinename|.wic."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1004
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:999
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1012
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1017
+msgid "Set this environment variable before building the Image:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1019
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1014
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1032
+msgid ""
+"The flash.bin can be found at u-boot-imx/ directory and now can be "
+"flashed. A chip-specific offset is needed:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1027
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1022
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1035
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1040
+msgid "/dev/mmcblk2"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1084
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1079
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1095
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1125
+msgid ""
+"*Carrierboard.dtsi* - Devices that come from the |soc| SoC but are just "
+"routed down to the carrier board and used there are included in this "
+"dtsi."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1086
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1081
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1097
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1127
+msgid ""
+"*Board.dts* - include the carrier board and module dtsi files. There may "
+"also be some hardware configuration nodes enabled on the carrier board or"
+" the module (i.e. the Board .dts shows the special characteristics of the"
+" board configuration). For example, there are phyCORE-|soc| SOMs which "
+"may or may not have a MIPI DSI to LVDS converter mounted. The converter "
+"is enabled (if available) in the Board .dts and not in the Module .dtsi"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1133
+msgid ""
+"The following is an example of the pin muxing of the UART1 device in "
+"imx8mm-phyboard-polis.dtsi:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1172
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mm-"
+"phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n188`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1206
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mm-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n266`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1209
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mm-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n315`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1215
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1211
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1244
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1274
+msgid ""
+"PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip "
+"as the main storage. eMMC devices contain raw MLC memory cells combined "
+"with a memory controller that handles ECC and wear leveling. They are "
+"connected via an SD/MMC interface to the |soc| and are represented as "
+"block devices in the Linux kernel like SD cards, flash drives, or hard "
+"disks."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1256
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1252
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1285
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1315
+msgid ""
+"In contrast to raw NAND Flash, an eMMC device contains a Flash Transfer "
+"Layer (FTL) that handles the wear leveling, block management, and ECC of "
+"the raw MLC cells. This requires some maintenance tasks (for example "
+"erasing unused blocks) that are performed regularly. These tasks are "
+"called **Background Operations (BKOPS)**."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1286
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1282
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1315
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1345
+msgid ""
+"The userspace tool mmc does not currently support enabling automatic "
+"BKOPS features."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1454
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1450
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1483
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1513
+msgid ""
+"eMMC devices use MLC memory cells (https://en.wikipedia.org/wiki/Multi-"
+"level_cell) to store the data. Compared with SLC memory cells used in "
+"NAND Flash, MLC memory cells have lower reliability and a higher error "
+"rate at lower costs."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1563
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1559
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1592
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1622
+msgid ""
+"It is possible to erase the eMMC device directly rather than overwriting "
+"it with zeros. The eMMC block management algorithm will erase the "
+"underlying MLC memory cells or mark these blocks as discard. The data on "
+"the device is lost and will be read back as zeros."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1594
+msgid ":imx-dt:`imx8mm-phycore-som.dtsi?h=v5.10.72_2.2.0-phy9#n71`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1691
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1687
+msgid "Pinmuxing of some GPIO pins in the device tree |dt-carrierboard|.dtsi::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1736
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mm-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n37`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1741
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mm-"
+"phycore-som.dtsi?h=v5.10.72_2.2.0-phy#n102`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1744
+msgid ""
+"General I²C4 bus configuration (e.g. |dt-carrierboard|.dtsi): :imx-dt"
+":`imx8mm-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n149`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1751
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1343
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1747
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1324
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1770
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1800
+msgid ""
+"On the |som| there is an i2c EEPROM flash populated. It has two "
+"addresses. The main EEPROM space (bus: I2C-0 address: 0x51) and the ID-"
+"page (bus: I2C-0 address: 0x59) can be accessed via the sysfs interface "
+"in Linux. The first 256 bytes of the main EEPROM and the ID-page are used"
+" for board detection and must not be overwritten. Overwriting reserved "
+"spaces will result in boot issues."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1760
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1352
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1756
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1333
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1779
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1809
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1380
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:61
+msgid "Rescue EEPROM Data"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1762
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1354
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1758
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1335
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1781
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1811
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1382
+msgid ""
+"The hardware introspection data is pre-written on both EEPROM data "
+"spaces. If you have accidentally deleted or overwritten the normal area, "
+"you can copy the hardware introspection from the ID area to the normal "
+"area."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1772
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1364
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1768
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1345
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1791
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1821
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1392
+msgid "If you deleted both EEPROM spaces, please contact our support!"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1774
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be found "
+"in our PHYTEC git: :imx-dt:`imx8mm-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy17#n271`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1781
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mm-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy9#n277`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1796
+msgid ""
+"User USB2 (host) configuration is in the kernel device tree |kernel-"
+"socname|.dtsi::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1806
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx8mm-phyboard-"
+"polis.dtsi?h=v5.10.72_2.2.0-phy9#n240`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1811
+msgid ""
+"Both USB interfaces are configured as host in the kernel device tree "
+"imx8mm-phyboard-polis.dtsi. See: :imx-dt:`imx8mm-phyboard-"
+"polis.dtsi?h=v5.10.72_2.2.0-phy17#n228`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1838
+msgid ""
+"Device Tree CAN configuration of imx8mm-phyboard-polis.dtsi: :imx-dt"
+":`imx8mm-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n106`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1876
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1873
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1903
+msgid ""
+"You should see a lot of options as the audio-IC has many features you can"
+" experiment with. It might be better to open alsamixer via ssh instead of"
+" the serial console, as the console graphical effects are better. You "
+"have either mono or stereo gain controls for all mix points. \"MM\" means"
+" the feature is muted (both output, left & right), which can be toggled "
+"by hitting **m**. You can also toggle by hitting '**<**' for left and "
+"'**>**' for right output. With the **tab** key, you can switch between "
+"controls for playback and recording."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1896
+msgid ""
+"To set PEB-AV-10 as output, set playback.pcm from \"dummy\" to "
+"\"pebav10\":"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1929
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1926
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1956
+msgid "For applications using Pulseaudio, check for available sinks:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1937
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1934
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1964
+msgid "To select PEB-AV-10, type:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1989
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`overlays/imx8mm-phyboard-polis-"
+"peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n56`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:1998
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1995
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2025
+msgid "The video is installed by default in the BSP:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2019
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2016
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2046
+msgid "kmssink Plugin ID Evaluation"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2021
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2018
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2048
+msgid ""
+"The kmssink plugin needs a connector ID. To get the connector ID, you can"
+" use the tool modetest."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2028
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2025
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2055
+msgid "The output will show something like:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:4
+msgid ""
+"With the phytec-qt5demo-image, Weston starts during boot. The phytec-"
+"qt5demo can be stopped with:"
+msgstr ""
+
+#: ../../source/bsp/qt5.rsti:17
+msgid "To disable autostart of the demo run:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd22.1.1.rst:2072
+msgid ""
+"The device tree of PEB-AV-10 can be found here: :imx-dt:`overlays/imx8mm-"
+"phyboard-polis-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:118
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:110
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:129
+msgid "Kirkstone"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:112
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:131
+msgid "2024/01/10"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:128
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:120
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:139
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:132
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:122
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:123
+msgid "BSP Release Date"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:131
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:142
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:135
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:125
+msgid "Major"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:131
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:142
+msgid "2023/12/12"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:275
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:266
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:285
+msgid ""
+"*partup* has the advantage of allowing to clear specific raw areas in the"
+" MMC user area, which is used in our provided partup packages to erase "
+"any existing U-Boot environments. This is a known issue *bmaptool* does "
+"not solve, as mentioned below."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:287
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:278
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:297
+msgid ""
+"An alternative and also fast way to prepare an SD card is using `bmap-"
+"tools <https://github.com/yoctoproject/bmaptool>`_. Yocto automatically "
+"creates a block map file (``<IMAGENAME>-<MACHINE>.wic.bmap``) for the WIC"
+" image that describes the image content and includes checksums for data "
+"integrity. *bmaptool* is packaged by various Linux distributions. For "
+"Debian-based systems install it by issuing:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:386
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:392
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:389
+msgid "**phytec-qt6demo-image\\*.wic**: SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:524
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:517
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:534
+msgid ""
+"Take a compressed or uncompressed image with accompanying block map on "
+"the host and send it with ssh through the network to the eMMC of the "
+"target with a one-line command:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:596
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:589
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:606
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:571
+msgid ""
+"These steps will show how to update the eMMC via a USB device. Configure "
+"the |ref-bootswitch| to SD Card and insert an SD card. Power on the board"
+" and stop in U-Boot prompt. Insert a USB device with the copied WIC image"
+" to the USB slot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:628
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:621
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:638
+#: ../../source/bsp/imx9/installing-os.rsti:201
+msgid ""
+"These steps will show how to flash the eMMC on Linux with a USB stick. "
+"You only need a complete image saved on the USB stick and a bootable WIC "
+"image. (e.g. |yocto-imagename|-|yocto-machinename|.wic). Set the |ref-"
+"bootswitch| to SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:691
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:684
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:701
+msgid ""
+"Flash an SD card with a working image and create a third ext4 partition. "
+"Copy the WIC image (for example |yocto-imagename|.wic) to this partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:1077
+msgid ""
+"The regulator for the SD card reset pin has been disabled to ensure "
+"compatibility with 1532.1 revision baseboards. If you have a revision "
+"1532.2(a) or higher baseboard, you may enable the device tree nodes for "
+"highest performance. In the imx8mm-phyboard-polis-rdk-u-boot.dtsi file, "
+"remove the following lines::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:137
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:124
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:131
+msgid "The |sbc| populated with the |soc| SoC is supported."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:170
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:253
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:349
+msgid "SD Card Boot"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:189
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:368
+msgid "**bl31-imx8mn.bin**: ARM Trusted Firmware binary"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:197
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:376
+msgid "**imx8mn-phyboard-polis*.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:198
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:281
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:377
+msgid "**imx8mn-phy*.dtbo**: Kernel device tree overlay files"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:199
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:282
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:378
+msgid "**phytec-headless-image\\*.tar.gz**: Root file system"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:200
+msgid "**phytec-headless-image\\*.rootfs.wic.xz**: compressed SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:1
+msgid "Hardware revision baseboard: 1532.2 and newer"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:15
+msgid "USB Serial Downloader"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:25
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:9
+#: ../../source/bsp/imx9/imx93/bootmode-switch.rsti:9
+msgid "Internal Fuses"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:32
+msgid "\\"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:35
+msgid "Switch between USB HOST/OTG using Pos5 of switch(S1)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:41
+msgid "USB HOST"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/bootmode-switch.rsti:48
+msgid "Switch between UART1 RS485/RS232 using Pos4 of switch(S1)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:293
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1142
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1124
+msgid ""
+"The first part of the string MX8MN_IOMUXC_SAI2_RXFS_UART1_DCE_TX names "
+"the pad (in this example SAI2_RXFS). The second part of the string "
+"(UART1_DCE_RX) is the desired muxing option for this pad. The pad setting"
+" value (hex value on the right) defines different modes of the pad, for "
+"example, if internal pull resistors are activated or not. In this case, "
+"the internal resistors are disabled."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:319
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1150
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mn-"
+"phyboard-polis.dts?h=v5.15.71_2.2.2-phy3#n220`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:353
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1184
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mn-phyboard-polis.dts?h=v5.15.71_2.2.2-phy3#n301`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:356
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1187
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n309`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:367
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1198
+msgid ":imx-dt:`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n78`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:385
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1309
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mn-phyboard-polis.dts?h=v5.15.71_2.2.2-phy3#n45`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:390
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1314
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mn-"
+"phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n106`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:393
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1317
+msgid ""
+"General I²C3 bus configuration (e.g. |dt-carrierboard|.dts): :imx-dt"
+":`imx8mn-phyboard-polis.dts?h=v5.15.71_2.2.2-phy3#n196`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:413
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1347
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be found "
+"in our PHYTEC git: :imx-dt:`imx8mn-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n259`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:419
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1409
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mn-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n267`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:425
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1783
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1415
+msgid ""
+"The USB controller of the |soc| SoC provides a low-cost connectivity "
+"solution for numerous consumer portable devices by providing a mechanism "
+"for data transfer between USB devices with a line/bus speed up to 480 "
+"Mbps (HighSpeed 'HS')."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:430
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1788
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1420
+msgid ""
+"The |soc| SoC has a single USB controller core that is set to OTG mode. "
+"To use the micro USB / OTG port dip switch S1 Pos5 has to be set to on."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:437
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1427
+msgid ""
+"The USB interface is configured as host in the kernel device tree |dt-"
+"carrierboard|.dts. See: :imx-dt:`imx8mn-phyboard-"
+"polis.dts?h=v5.15.71_2.2.2-phy3#n264`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:459
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1817
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1449
+msgid ""
+"On phyBOARD-Polis-i.MX8MN a terminating resistor can be enabled by "
+"setting S5 to ON if required."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/head.rst:464
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:1454
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :imx-dt:`imx8mn-"
+"phyboard-polis.dts?h=v5.15.71_2.2.2-phy3#n125`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:280
+msgid "**imx8mn-phyboard-polis-dsi*.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:283
+#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:379
+msgid "**phytec-headless-image\\*.wic**: SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1128
+msgid ""
+"The following is an example of the pin muxing of the UART1 device in "
+"imx8mn-phyboard-polis.dtsi:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1168
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mn-"
+"phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n166`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1202
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mn-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n238`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1205
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mn-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n293`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1590
+msgid ":imx-dt:`imx8mn-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n75`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1732
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mn-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n35`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1737
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mn-"
+"phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n98`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1740
+msgid ""
+"General I²C3 bus configuration (e.g. |dt-carrierboard|.dtsi): :imx-dt"
+":`imx8mn-phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n147`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1770
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be found "
+"in our PHYTEC git: :imx-dt:`imx8mn-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy17#n248`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1777
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mn-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy9#n254`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1795
+msgid ""
+"Both USB interfaces are configured as host in the kernel device tree |dt-"
+"carrierboard|.dtsi. See: :imx-dt:`imx8mn-phyboard-"
+"polis.dtsi?h=v5.10.72_2.2.0-phy17#n206`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mn/pd22.1.1.rst:1822
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dtsi: :imx-dt:`imx8mn-"
+"phyboard-polis.dtsi?h=v5.10.72_2.2.0-phy17#n104`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:125
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:111
+msgid "|doc-id| |soc| BSP ManualHead"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:158
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:144
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:140
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:140
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:151
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:144
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:144
+msgid ""
+"On our web page, you can see all supported Machines with the available "
+"Article Numbers for this release: |yocto-manifestname| `download <dlpage-"
+"bsp_>`_."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:161
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:147
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:143
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:143
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:154
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:147
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:147
+msgid ""
+"If you choose a specific **Machine Name** in the section **Supported "
+"Machines**, you can see which **Article Numbers** are available under "
+"this machine and also a short description of the hardware information. In"
+" case you only have the **Article Number** of your hardware, you can "
+"leave the **Machine Name** drop-down menu empty and only choose your "
+"**Article Number**. Now it should show you the necessary **Machine Name**"
+" for your specific hardware"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/components.rsti:8
+msgid "**phyBOARD-Pollux Components (top)**"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/components.rsti:14
+msgid "**phyBOARD-Pollux Components (bottom)**"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:181
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:168
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:359
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:358
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:168
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:157
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:163
+msgid ""
+"To boot from an SD card, the |ref-bootswitch| needs to be set to the "
+"following position:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:203
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:190
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:281
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:286
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:381
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:380
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:190
+msgid "**bl31-imx8mp.bin**: ARM Trusted Firmware binary"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:209
+msgid "**fitImage**: Linux kernel FIT image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:210
+msgid "**fitImage-its\\*.its**"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:213
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:197
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:289
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:294
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:389
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:387
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:197
+msgid "**imx8mp-phyboard-pollux-rdk*.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:214
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:290
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:295
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:390
+msgid "**imx8mp-phy*.dtbo**: Kernel device tree overlay files"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:216
+msgid "**phytec-qt6demo-image\\*.rootfs.wic.xz**: compressed SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:226
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:215
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:302
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:307
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:402
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:399
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:215
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:217
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:223
+msgid "Bootmode Switch (S3)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:230
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:219
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:306
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:311
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:406
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:403
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:219
+msgid "Hardware revision baseboard: 1552.2"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:232
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:221
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:308
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:313
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:408
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:405
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:221
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:223
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:232
+msgid ""
+"The |sbc| features a boot switch with four individually switchable ports "
+"to select the phyCORE-|soc| default bootsource."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:5
+#: ../../source/bsp/imx9/imx93/bootmode-switch.rsti:5
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:88
+msgid "eMMC"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/bootmode-switch.rsti:25
+msgid "Test Mode"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:249
+msgid ""
+"Starting with this release, the boot behaviour in U-Boot changes. Before,"
+" kernel and device tree came as separate blobs. Now, both will be "
+"included in a single FIT image blob. Further, the logic for booting the "
+"PHYTEC ampliphy distributions is moved to a boot script which itself is "
+"part of a separate FIT image blob. To revert to the old style of booting,"
+" you may do"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:261
+msgid ""
+"This way of booting is deprecated and will be removed in the next "
+"release. By default, booting via this command will return an error as "
+"kernel and device tree are missing in the boot partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:10
+msgid "Get the source code"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:21
+msgid "The **tag** used in this release is called |u-boot-tag|"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:41
+msgid ""
+"To build the bootloader, you need to copy these files to your |u-boot-"
+"repo-name| build directory and rename them to fit with *mkimage* script:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:52
+msgid ""
+"If you already built our BSP with Yocto, you can get the bl31-|kernel-"
+"socname|.bin, tee.bin and lpddr4_*.bin from the directory mentioned here:"
+" |ref-bsp-images|"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:59
+msgid "Build the bootloader"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:71
+msgid "Flash the bootloader to a block device"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:124
+msgid "Build U-Boot With a Fixed RAM Frequency"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:126
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:766
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:766
+msgid ""
+"Starting with PD23.1.0 NXP or PD24.1.2 mainline release, the "
+"phyCORE-|soc| SoMs with revision 1549.3 and newer also support 2GHz RAM "
+"timings. These will be enabled for supported boards automatically, but "
+"they can also be enabled or disabled manually."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:131
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:770
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1094
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:770
+msgid ""
+"Edit the file configs/phycore-|kernel-socname|\\_defconfig. The fixed RAM"
+" size with 2GHz timings will be used:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/uboot-standalone.rsti:145
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:784
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:784
+msgid ""
+"Choose the correct RAM size as populated on the board and uncomment the "
+"line for this ram size. When not specifying the "
+"``CONFIG_PHYCORE_IMX8MP_RAM_FREQ_FIX`` option, the 1.5GHz timings will be"
+" chosen by default. After saving the changes, follow the remaining steps "
+"from |ref-build-uboot|."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:4
+msgid ""
+"The kernel is packaged in a FIT image together with the device tree. "
+"U-Boot has been adapted to be able to load a FIT image and boot the "
+"kernel contained in it. As a result, the kernel Image has to packaged in "
+"a FIT image."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:9
+msgid "Setup sources"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:39
+msgid "Build the kernel"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:56
+msgid "The Image can be found at ~/|kernel-repo-name|/arch/arm64/boot/Image.gz"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:81
+msgid "Package the kernel in a FIT image"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:83
+msgid ""
+"To simply replace the kernel, you will need an ``image tree source`` "
+"(.its) file. If you already built our BSP with Yocto, you can get the its"
+" file from the directory mentioned here: |ref-bsp-images| Or you can "
+"download the file here: |link-bsp-images|"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:88
+msgid ""
+"Copy the .its file to the current working directory, create a link to the"
+" kernel image and create the final fitImage with mkimage."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:100
+msgid "Copy FIT image and kernel modules to SD Card"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/kernel-standalone.rsti:102
+msgid ""
+"When one-time boot via netboot is not sufficient, the FIT image along "
+"with the kernel modules may be copied directly to a mounted SD card."
+msgstr ""
+
+#: ../../source/bsp/imx8/development/netboot.rsti:11
+msgid "Copy the kernel fitimage to your tftp directory:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/netboot.rsti:17
+msgid "Copy the bootscript to your tftp directory:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/netboot.rsti:50
+msgid ""
+"<overlayconfignames> has to be replaced with the devicetree overlay "
+"config names that you want to use. Separate the config names by hashtag. "
+"For example:"
+msgstr ""
+
+#: ../../source/bsp/imx8/development/netboot.rsti:59
+msgid ""
+"All supported devicetree overlays are in the |ref-dt| chapter. Or can be "
+"printed with:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:335
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:923
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1169
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1199
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1174
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1113
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:923
+msgid ""
+"The first part of the string MX8MP_IOMUXC_UART1_RXD_UART1_DCE_RX names "
+"the pad (in this example UART1_RXD). The second part of the string "
+"(UART1_DCE_RX) is the desired muxing option for this pad. The pad setting"
+" value (hex value on the right) defines different modes of the pad, for "
+"example, if internal pull resistors are activated or not. In this case, "
+"the internal resistors are disabled."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:342
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1181
+msgid ""
+"The device tree representation for UART1 pinmuxing: :imx-dt:`imx8mp-"
+"phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n536`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:348
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:936
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1179
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1209
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1187
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1126
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:936
+msgid ""
+"The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level "
+"signals of UART1 (the standard console) and UART4 are routed to Silicon "
+"Labs CP2105 UART to USB converter expansion. This USB is brought out at "
+"Micro-USB connector X1. UART3 is at X6 (Expansion Connector) at TTL "
+"level. UART2 is connected to a multi-protocol transceiver for RS-232 and "
+"RS-485, available at pin header connector |ref-serial| at the RS-232 "
+"level, or at the RS-485 level. The configuration of the multi-protocol "
+"transceiver is done by jumpers |ref-jp3| and |ref-jp4| on the baseboard. "
+"For more information about the correct setup please refer to the "
+"phyCORE-|soc|/|sbc| Hardware Manual section UARTs."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:358
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:946
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1189
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1219
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1197
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1136
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:946
+msgid ""
+"We use the same device tree node for RS-232 and RS-485. RS-485 mode can "
+"be enabled with ioctl TIOCSRS485. Also, full-duplex support is also "
+"configured using ioctls. Have a look at our small example application "
+"rs485test, which is also included in the BSP. The jumpers |ref-jp3| and "
+"|ref-jp4| need to be set correctly."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:367
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1206
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mp-"
+"phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n341`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:375
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:963
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1206
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1236
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1214
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1153
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:963
+msgid ""
+"|sbc|-|soc| provides two ethernet interfaces. A gigabit Ethernet is "
+"provided by our module and board."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:380
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:968
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1211
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1241
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1219
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1158
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:968
+msgid ""
+"The naming convention of the Ethernet interfaces in the hardware "
+"(ethernet0 and ethernet1) do not align with the network interfaces (eth0 "
+"and eth1) in Linux. So, be aware of these differences:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst
+msgid "ethernet1 = eth0"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst
+msgid "ethernet0 = eth1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:4
+msgid ""
+"WLAN and Bluetooth on the |sbc| are provided by the PEB-WLBT-05 expansion"
+" card. The PEB-WLBT-05 for |sbc| Quickstart Guide shows you how to "
+"install the PEB-WLBT-05."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:10
+msgid ""
+"With the BSP Version PD22.1 and newer, the PEB-WLBT-05 overlay needs to "
+"be activated first, otherwise the PEB-WLBT-05 won't be recognized."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:17
+msgid ""
+"Afterwards the bootenv.txt file should look like this (it can also "
+"contain other devicetree overlays!):"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:24
+msgid "The changes will be applied after a reboot:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/wireless-network.rsti:30
+msgid ""
+"For further information about devicetree overlays, read the |ref-dt| "
+"chapter."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:404
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1243
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n380`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:407
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1246
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mp-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n223`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:418
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1257
+msgid ":imx-dt:`imx8mp-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n76`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:424
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1356
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n229`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:429
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1361
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mp-"
+"phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n110`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:432
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1364
+msgid ""
+"General I²C2 bus configuration (e.g. |dt-carrierboard|.dts) :imx-dt"
+":`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n212`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:452
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1394
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can"
+" be found in our PHYTEC git: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n199`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:458
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1456
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.15.71_2.2.2-phy3#n207`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:464
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1806
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1836
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1462
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1322
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1132
+msgid ""
+"The USB controller of the |soc| SoC provides a low-cost connectivity "
+"solution for numerous consumer portable devices by providing a mechanism "
+"for data transfer between USB devices with a line/bus speed of up to 4 "
+"Gbit/s (SuperSpeed 'SS'). The USB subsystem has two independent USB "
+"controller cores. Both cores are capable of acting as a USB peripheral "
+"device or a USB host. Each is connected to a USB 3.0 PHY."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:473
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1471
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx8mp-phyboard-pollux-"
+"rdk.dts?h=v5.15.71_2.2.2-phy3#n351`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:488
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1486
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :imx-dt:`imx8mp-"
+"phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n175`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:493
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1491
+msgid ""
+"Device Tree PCIe configuration of |dt-carrierboard|.dts: :imx-dt:`imx8mp-"
+"phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n287`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:499
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1841
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1871
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1497
+msgid ""
+"Playback devices supported for |sbc| are HDMI and the TI TLV320AIC3007 "
+"audio codec on the PEB-AV-10 connector. On the AV-Connector there is a "
+"3.5mm headset jack with OMTP-standard and an 8-pin header. The 8-pin "
+"header contains a mono speaker, headphones, and line in signals."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:506
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1848
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1878
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1504
+msgid ""
+"Using the PEB-AV-10 connector for display output along HDMI as audio "
+"output is not supported. The audio output device must match the video "
+"output device."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:511
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1509
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`overlays/imx8mp-phyboard-"
+"pollux-peb-av-010.dtso?h=v5.15.71_2.2.2-phy3#n58`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:4
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2062
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2092
+msgid ""
+"The |sbc| supports up to 4 different display outputs. Three can be used "
+"simultaneously. The following table shows the required extensions and "
+"devicetree overlays for the different interfaces."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:9
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2067
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2097
+msgid "Interface"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:9
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2067
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2097
+msgid "Expansion"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:9
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2067
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2097
+msgid "devicetree overlay"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:11
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2069
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2099
+msgid "HDMI"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:11
+#: ../../source/bsp/imx8/imx8mp/display.rsti:14
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2069
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2072
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2099
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2102
+msgid "|sbc|"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:11
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2069
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2099
+msgid "no overlay needed (enabled by default)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:12
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2070
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2100
+msgid "LVDS0"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:12
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2070
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2100
+msgid "PEB-AV-10"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:12
+msgid "|dtbo-peb-av-10| (loaded by default)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:14
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2072
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2102
+msgid "LVDS1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:14
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2072
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2102
+msgid "disabled if PEB-AV-10 overlay is used"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:15
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2073
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2103
+msgid "MIPI"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:15
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2073
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2103
+msgid "PEB-AV-12 (MIPI to LVDS)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:15
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2073
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2103
+msgid "imx8mp-phyboard-pollux-peb-av-012.dtbo"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:20
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2079
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2109
+msgid "When changing Weston output, make sure to match the audio output as well."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:21
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2080
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2110
+msgid "LVDS0 (PEB-AV-10) and LVDS1 (onboard)can not be used at the same time."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:23
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2082
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2112
+msgid ""
+"HDMI is always enabled in the devicetree. The other interfaces can be "
+"enabled with Device Tree Overlay."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:26
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2085
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2115
+msgid ""
+"The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-010). We "
+"support a 10'' edt,etml1010g0dka display for the PEB-AV-10 and PEB-AV-12."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:31
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2090
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2120
+msgid ""
+"The current display driver limits the pixel clock for a display connected"
+" to LVDS to 74.25Mhz (or a divider of it).  If this does not fit your "
+"display requirements, please contact Support for further help."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:36
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1188
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2095
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2125
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1378
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1188
+msgid "Weston Configuration"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:38
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2097
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2127
+msgid ""
+"In order to get an output from Weston on the correct display, it still "
+"needs to be configured correctly. This will be done at "
+"/etc/xdg/weston/weston.ini."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:42
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2101
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2131
+msgid "Single Display"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:44
+msgid "In our BSP, the default Weston output is set to HDMI."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:57
+msgid ""
+"When using the LVDS0 (PEB-AV-10) as output, set the output mode to off "
+"for HDMI-A-1 and for LVDS-1 to current."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:70
+msgid ""
+"If you want to use LVDS1 (onboard) then you need to load no overlay. "
+"Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:74
+msgid "Dual Display"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:76
+msgid ""
+"For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both "
+"modes have to be set to the:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:90
+msgid ""
+"For dual display at LVDS0 (PEB-AV-010) and MIPI (PEB-AV-012), both dtbos "
+"need to be loaded at the bootenv.txt and the weston.ini should look like "
+"this:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:106
+msgid ""
+"For dual and triple display output you can not use LVDS1 (onboard) and "
+"HDMI together."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:110
+msgid "Triple Display"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/display.rsti:112
+msgid ""
+"Three outputs: HDMI, LVDS-1 (PEB-AV-10), and LVDS-2 (PEB-AV-12). Remember"
+" to load both dtbos for LVDS interfaces."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:522
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1520
+msgid ""
+"Device tree description of LVDS-1 and HDMI can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n264` :imx-dt"
+":`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n191`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:526
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1524
+msgid ""
+"The device tree of LVDS-0 on PEB-AV-10 can be found here: :imx-"
+"dt:`overlays/imx8mp-phyboard-pollux-peb-"
+"av-010.dtso?h=v5.15.71_2.2.2-phy3#n133`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/head.rst:533
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1531
+msgid ""
+"The device tree description of GPIO Fan can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux-rdk.dts?h=v5.15.71_2.2.2-phy3#n33`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1349
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1539
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1349
+#: ../../source/bsp/imx8/peripherals/snvs-power-key.rsti:2
+msgid "snvs Power Key"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/snvs-power-key.rsti:4
+msgid ""
+"The X_ONOFF pin connected to the ON/OFF button can be pressed long to "
+"trigger Power OFF without SW intervention or used to wake up the system "
+"out of suspend. With the *snvs_pwrkey* driver, the KEY_POWER event is "
+"also reported to userspace when the button is pressed. On default, "
+"systemd is configured to ignore such events. The function of Power OFF "
+"without SW intervention and the wake-up from suspend are not configured. "
+"Triggering a power off with systemd when pushing the ON/OFF button can be"
+" configured under ``/etc/systemd/logind.conf`` and set using:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2132
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2162
+#: ../../source/bsp/imx8/peripherals/npu.rsti:2
+msgid "NPU"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/npu.rsti:4
+msgid ""
+"The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an "
+"accelerator for artificial intelligence operations. Refer to our latest "
+"phyCORE-|soc| AI Kit Guide on the phyCORE-|soc| download section to get "
+"information about the NPU: `L-1015e.A1 phyCORE-i.MX 8M Plus AI Kit Guide "
+"<https://www.phytec.de/cdocuments/?doc=9oB5Hg>`_"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/isp.rsti:2
+msgid "ISP"
+msgstr ""
+
+#: ../../source/bsp/imx8/peripherals/isp.rsti:4
+msgid ""
+"The |soc| SoC contains an Image Signal Processor (ISP). For more "
+"information see Using the ISPs on the |sbc| |soc| documentation. This "
+"documentation is also available in German."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:16
+msgid "Mainline HEAD"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:26
+msgid "BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.2"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:36
+msgid "BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:47
+msgid "BSP-Yocto-NXP-i.MX8MP-PD23.1.0"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:57
+msgid "BSP-Yocto-NXP-i.MX8MP-PD22.1.2"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/imx8mp.rst:67
+msgid "BSP-Yocto-NXP-i.MX8MP-PD22.1.1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:114
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:125
+msgid "|doc-id| |soc| BSP Mainline Manual Head"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:191
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:381
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:191
+msgid ""
+"**lpddr4_pmu_train_1d_dmem_202006.bin, "
+"lpddr4_pmu_train_1d_imem_202006.bin, lpddr4_pmu_train_2d_dmem_202006.bin,"
+" lpddr4_pmu_train_2d_imem_202006.bin**: DDR PHY firmware images"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:199
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:199
+msgid "**phytec-qt6demo-image\\*.wic.xz**: SD card image"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:268
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:397
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:492
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:268
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:397
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:492
+msgid ""
+"This step only works if the size of the image file is less than 1,28GB "
+"due to limited RAM space available in the Bootloader."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:271
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:271
+msgid "Uncompress your image:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:392
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:563
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:392
+msgid ""
+"Only the lower USB-A port is configured for storage devices and only this"
+" port will work when trying to access a storage device in U-Boot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:434
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:603
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:434
+msgid ""
+"These steps will show how to flash the eMMC on Linux with a USB stick. "
+"You only need a complete image saved on the USB stick and a bootable WIC "
+"image. (e.g. |yocto-imagename|-|yocto-machinename|.\\ |yocto-imageext|). "
+"Set the |ref-bootswitch| to SD Card."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:521
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:521
+msgid ""
+"Flash your WIC image (for example |yocto-imagename|.roots.wic) from the "
+"SD card to eMMC. This will partition the card and copy imx-boot, Image, "
+"dtb, dtbo, and root file system to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:582
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:786
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:582
+msgid ""
+"The RAUC (Robust Auto-Update Controller) mechanism support has been added"
+" to meta-ampliphy. It controls the procedure of updating a device with "
+"new firmware. This includes updating the Linux kernel, Device Tree, and "
+"root filesystem. PHYTEC has written an online manual on how we have "
+"intergraded RAUC into our BSPs: `L-1006e.A6 RAUC Update & Device "
+"Management Manual <https://www.phytec.de/cdocuments/?doc=F4DiM>`__."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:684
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:684
+msgid ""
+"Download imx-boot from our server or get it from your Yocto build "
+"directory at build/deploy/images/|yocto-machinename|/. For flashing a wic"
+" image to eMMC, you will also need |yocto-imagename|-|yocto-"
+"machinename|.rootfs.wic"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:858
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1048
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:858
+msgid ""
+"Now you can mount the root partition and copy e.g. the |yocto-imagename"
+"|-|yocto-machinename|.\\ |yocto-imageext| image to it. Then unmount it "
+"again:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:886
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1076
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:886
+msgid ""
+"Now you can mount the new partition and copy e.g. |yocto-imagename"
+"|-|yocto-machinename|.\\ |yocto-imageext| image to it. Then unmount it "
+"again:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:930
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1120
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:930
+msgid ""
+"The device tree representation for UART1 pinmuxing: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L387`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:955
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1145
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:955
+msgid ""
+"The device tree representation for RS232 and RS485: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L251`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:981
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1171
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:981
+msgid ""
+"We currently use dynamic IP addresses in U-Boot. This is enabled by this "
+"variable:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:988
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1178
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:988
+msgid "Set up path for NFS. A modification could look like this:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1001
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1001
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":linux-phytec:`/blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-"
+"phyboard-pollux-rdk.dts#L261`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1004
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1004
+msgid ""
+"DT configuration for the eMMC interface can be found here: :linux-"
+"phytec:`/blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-"
+"som.dtsi#L181`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1014
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1204
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1014
+msgid ""
+"The definition of the SPI master node in the device tree can be found "
+"here: :linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale"
+"/imx8mp-phycore-som.dtsi#L67`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1021
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1211
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1021
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale"
+"/imx8mp-phyboard-pollux-rdk.dts#L160`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1026
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1216
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1026
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-"
+"som.dtsi#L81`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1029
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1219
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1029
+msgid ""
+"General I²C2 bus configuration (e.g. |dt-carrierboard|.dts) :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L145`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1049
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1239
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1049
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can"
+" be found in our PHYTEC git: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-"
+"som.dtsi#L169`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1126
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1316
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1126
+msgid ""
+"DT representation for I²C RTCs: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-"
+"som.dtsi#L175`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1141
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1331
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1141
+msgid ""
+"DT representation for USB Host: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L220`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1156
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1346
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1156
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L130`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1179
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1369
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1179
+msgid "The mainline BSP currently only supports software rendering."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1184
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1374
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1184
+msgid ""
+"The |sbc| supports LVDS output via the LVDS1 connector on the carrier "
+"board. The LVDS interface is enabled by default."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1190
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1380
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1190
+msgid ""
+"Weston will work without any additional configuration. Configuration "
+"options are done at /etc/xdg/weston/weston.ini."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1193
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1383
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1193
+msgid ""
+"Device tree description of LVDS can be found here: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phyboard-"
+"pollux-rdk.dts#L182`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1201
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1391
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1201
+msgid ""
+"We noticed some visible backlight flickering on brightness level 1 "
+"(probably due to frequency problems with the hardware)."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/mainline-head.rst:1351
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1541
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:1351
+msgid ""
+"The X_ONOFF pin connected to the ON/OFF button can be pressed long to "
+"trigger Power OFF without SW intervention. With the *snvs_pwrkey* driver,"
+" the KEY_POWER event is also reported to userspace when the button is "
+"pressed. On default, systemd is configured to ignore such events. The "
+"function of Power OFF without SW intervention are not configured. "
+"Triggering a power off with systemd when pushing the ON/OFF button can be"
+" configured under ``/etc/systemd/logind.conf`` and set using:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1143
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1173
+msgid ""
+"There is one more overlay available for phyboard-pollux-imx8mp-2.conf: "
+"imx8mp-phyboard-pollux-1552.1.dtbo"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1157
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1187
+msgid ""
+"The following is an example of the pin muxing of the UART1 device in "
+"imx8mp-phyboard-pollux.dtsi:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1198
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mp-"
+"phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n331`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1235
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n367`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1238
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n220`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1623
+msgid ":imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n72`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1755
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n216`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1760
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mp-"
+"phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n105`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1763
+msgid ""
+"General I²C2 bus configuration (e.g. |dt-carrierboard|.dts) :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n201`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1793
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can"
+" be found in our PHYTEC git: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy17#n201`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1800
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy17#n207`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1815
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx8mp-phyboard-"
+"pollux.dtsi?h=v5.10.72_2.2.0-phy17#n341`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1830
+msgid ""
+"Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n165`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1835
+msgid ""
+"Device Tree PCIe configuration of imx8mm-phyboard-polis.dtsi: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n277`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1907
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1937
+msgid ""
+"If the sound is not audible change playback devices to the software "
+"volume control playback devices, set *playback.pcm* to the respective "
+"softvol playback device either \"softvol_hdmi\" or \"softvol_pebav10\". "
+"Use alsamixer controls to vary the volume levels."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:1986
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`overlays/imx8mp-phyboard-"
+"pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy17#n57`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2070
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2100
+msgid "imx8mp-phyboard-pollux-peb-av-010.dtbo (loaded by default)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2078
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2108
+msgid "HDMI will not work if LVDS1 (onboard) is enabled."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2103
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2133
+msgid "In our BSP, the default Weston output is set to HDMI. ::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2113
+msgid ""
+"Device tree description of LVDS-1 and HDMI can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n255` :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n180`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2117
+msgid ""
+"The device tree of LVDS-0 on PEB-AV-10 can be found here: :imx-"
+"dt:`overlays/imx8mp-phyboard-pollux-peb-"
+"av-010.dtso?h=v5.10.72_2.2.0-phy17#n132`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2124
+msgid ""
+"The device tree description of GPIO Fan can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy17#n26`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2134
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2164
+msgid ""
+"The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an "
+"accelerator for artificial intelligence operations. Refer to our latest "
+"phyCORE-|soc| AI Kit Guide on the phyCORE-|soc| download section to get "
+"information about the NPU: `L-1015e.A0 phyCORE-i.MX 8M Plus AI Kit Guide "
+"<https://www.phytec.de/cdocuments/?doc=ZQBhDw>`_"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2141
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2171
+msgid "NXP Examples for eIQ"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2143
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2173
+msgid ""
+"NXP provides a set of machine learning examples for eIQ using Python3. To"
+" add a pre-configured machine learning package group, add to your "
+"local.conf and build your BSP::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2149
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2179
+msgid ""
+"This will require about 1GB of additional space on the SD Card. "
+"Instructions on how to install and use the NXP examples can be found at "
+"https://community.nxp.com/t5/Blogs/PyeIQ-3-x-Release-User-"
+"Guide/ba-p/1305998."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2155
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2185
+msgid ""
+"The installation of the eiq examples with pip3 requires an internet "
+"connection."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2160
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2190
+msgid ""
+"On some Ubuntu 20.04 hosts, cmake uses the host's Python 3 instead of "
+"Python 3.7 from Yocto when building python3-pybind11. (see "
+"https://community.nxp.com/t5/i-MX-Processors/Yocto-L5-4-70-2-3-0-build-"
+"image-failed/m-p/1219619)"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2164
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2194
+msgid "As a workaround edit, the python3-pybind11 recipe by::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2168
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2198
+msgid "and add to the file::"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.1.rst:2176
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2206
+msgid ""
+"Reading the registers using ``/dev/mem`` will cause the system to hang "
+"unless the *ocotp_root_clk* is enabled. To enable this clock permanent, "
+"add to the device tree:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:132
+msgid "2024/08/05"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:151
+msgid ""
+"When the PCM-070 does not have the X1 extension connector populated, some"
+" Software features described here do not work. These are Wirless LAN, "
+"PCIe, CSI (cameras), PEB-AV-12, CAN, USB-OTG."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1076
+msgid ""
+"Choose the correct RAM size as populated on the board and uncomment the "
+"line for this ram size. For Article number 0F\\ **8**\\ 443I, use "
+"[...]_4GB_2GHZ, for 0F\\ **5**\\ 443I, use [...]_4GB. After saving the "
+"changes, follow the remaining steps from Build U-Boot."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1228
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx8mp-"
+"phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n331`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1265
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n367`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1268
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt"
+":`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n220`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1653
+msgid ":imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n72`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1785
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n216`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1790
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx8mp-"
+"phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n105`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1793
+msgid ""
+"General I²C2 bus configuration (e.g. |dt-carrierboard|.dts) :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n201`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1823
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can"
+" be found in our PHYTEC git: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy18#n201`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1830
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx8mp-phycore-"
+"som.dtsi?h=v5.10.72_2.2.0-phy18#n207`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1845
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx8mp-phyboard-"
+"pollux.dtsi?h=v5.10.72_2.2.0-phy18#n341`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1860
+msgid ""
+"Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n165`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:1865
+msgid ""
+"Device Tree PCIe configuration of imx8mm-phyboard-polis.dtsi: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n277`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2016
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`overlays/imx8mp-phyboard-"
+"pollux-peb-av-010.dtso?h=v5.10.72_2.2.0-phy18#n57`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2143
+msgid ""
+"Device tree description of LVDS-1 and HDMI can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n255` :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n180`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2147
+msgid ""
+"The device tree of LVDS-0 on PEB-AV-10 can be found here: :imx-"
+"dt:`overlays/imx8mp-phyboard-pollux-peb-"
+"av-010.dtso?h=v5.10.72_2.2.0-phy18#n132`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd22.1.2.rst:2154
+msgid ""
+"The device tree description of GPIO Fan can be found here: :imx-dt"
+":`imx8mp-phyboard-pollux.dtsi?h=v5.10.72_2.2.0-phy18#n26`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1090
+msgid ""
+"Starting with PD23.1.0 release, the phyCORE-|soc| SoMs with revision "
+"1549.3 and newer also support 2GHz RAM timings. These will be enabled for"
+" supported boards automatically, but they can also be enabled or disabled"
+" manually."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1106
+msgid ""
+"Choose the correct RAM size as populated on the board and uncomment the "
+"line for this ram size. When not specifying the "
+"``CONFIG_PHYCORE_IMX8MP_USE_2GHZ_RAM_TIMINGS`` option, the 1.5GHz timings"
+" will be chosen by default. After saving the changes, follow the "
+"remaining steps from |ref-build-uboot|."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:1371
+msgid ""
+"On the |som| there is an i2c EEPROM flash populated. It has two "
+"addresses. The main EEPROM space (bus: I2C-0 address: 0x51) and the ID-"
+"page (bus: I2C-0 address: 0x59) can be accessed via the sysfs interface "
+"in Linux. The first 256 bytes of the main EEPROM and the ID-page are used"
+" for board detection and must not be overwritten. Overwriting reserved "
+"spaces will result in boot issue."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:111
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:114
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:125
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:111
+msgid "|doc-id| |soc| BSP Manual"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:121
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:121
+msgid "Scarthgap"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:135
+msgid "2024/04/08"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:135
+msgid "PD24.1.1"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:522
+#: ../../source/bsp/imx9/installing-os.rsti:162
+msgid ""
+"Send the image with the ``dd`` command combined with ssh through the "
+"network to the eMMC of your device:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:559
+msgid "Flash eMMC from USB in U-Boot on Target"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:684
+msgid ""
+"Flash an SD card with a working image and create a third FAT partition. "
+"Copy the WIC image (for example |yocto-imagename|.\\ |yocto-imageext|) to"
+" this partition."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:709
+msgid ""
+"Flash your WIC image (for example |yocto-imagename|.\\ |yocto-imageext|) "
+"from the SD card to eMMC. This will partition the card and copy imx-boot,"
+" Image, dtb, dtbo, and root file system to eMMC."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:767
+msgid "Alternatively, ``dd`` may be used instead:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:774
+#: ../../source/bsp/imx9/installing-os.rsti:97
+msgid ""
+"Keep in mind that the root partition does not make use of the full space "
+"when flashing with ``dd``."
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:888
+msgid ""
+"Download imx-boot from our server or get it from your Yocto build "
+"directory at build/deploy/images/|yocto-machinename|/. For flashing a wic"
+" image to eMMC, you will also need |yocto-imagename|-|yocto-"
+"machinename|.\\ |yocto-imageext|"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:966
+msgid "Build the SDK"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:968
+msgid "You can build the SDK yourself with Yocto:"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1191
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-"
+"phyboard-pollux-rdk.dts#L261`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:1194
+msgid ""
+"DT configuration for the eMMC interface can be found here: :linux-"
+"phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-"
+"som.dtsi#L181`"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:114
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:125
+msgid "|doc-id| |soc| BSP Mainline Manual"
+msgstr ""
+
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:123
+#: ../../source/bsp/imx8/imx8mp/pd24.1.2.rst:135
+msgid "2024/06/26"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx9.rst:5 ../../source/bsp/imx9/imx93/imx93.rst:3
+msgid "i.MX 93 Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx9.rst:3 ../../source/bsp/imx9/imx9.rst:5
+msgid "i.MX 9 Manuals"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/imx93.rst:6
+msgid "BSP-Yocto-NXP-i.MX93-PD24.1.1"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/imx93.rst:16
+msgid "BSP-Yocto-NXP-i.MX93-PD24.1.0"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:112
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:113
+msgid "Mickledore"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:114
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:125
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:115
+msgid "2024/01/31"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:134
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:135
+msgid ""
+"On our web page, you can see all supported Machines with the available "
+"Article Numbers for this release: |yocto-manifestname|, see `download "
+"<dlpage-bsp_>`_."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:137
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:138
+msgid ""
+"If you choose a specific **Machine Name** in the section **Supported "
+"Machines**, you can see which **Article Numbers** are available under "
+"this machine and also a short description of the hardware information. In"
+" case you only have the **Article Number** of your hardware, you can "
+"leave the **Machine Name** drop-down menu empty and only choose your "
+"**Article Number**. Now it should show you the necessary **Machine Name**"
+" for your specific hardware."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:2
+msgid "phyBOARD-Segin i.MX 93 Components"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:8
+msgid "**phyBOARD-Segin i.MX 93 Components (top)**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:14
+msgid "**phyBOARD-Segin i.MX 93 Components (bottom)**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:17
+msgid "phyBOARD-Nash i.MX 93 Components"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:23
+msgid "**phyBOARD-Nash i.MX 93 Components (top)**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/components.rsti:29
+msgid "**phyBOARD-Nash i.MX 93 Components (bottom)**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:163
+msgid ""
+"Connect the target (|ref-debugusbconnector|) and the host with **serial "
+"cable**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:166
+msgid ""
+"Open serial port with 115200 baud and 8N1 (you should see u-boot/linux "
+"start on the console"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:180
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:186
+msgid "**bl31-imx93.bin**: ARM Trusted Firmware binary"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:181
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:187
+msgid ""
+"**lpddr4_dmem_1d_v202201.bin, lpddr4_dmem_2d_v202201.bin, "
+"lpddr4_imem_1d_v202201.bin, lpddr4_imem_2d_v202201.bin**: DDR PHY "
+"firmware images"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:189
+msgid "**imx93-phyboard-segin.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:190
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:196
+msgid "**imx93-phy\\*.dtbo**: Kernel device tree overlay files"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:191
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:197
+msgid "**phytec-\\*.tar.gz**: Root file system, of bitbake-image that was built."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:194
+msgid ""
+"**phytec-qt6demo-image-phyboard-segin-imx93-2.tar.gz**: when bitbake-"
+"build was processed for ``phytec-qt6demo-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:196
+msgid ""
+"**phytec-headless-image-phyboard-segin-imx93-2.tar.gz**: when bitbake-"
+"build was processed for ``phytec-headless-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:198
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:204
+msgid ""
+"**phytec-\\*.wic.xz**: Compressed bootable SD card image of bitbake-image"
+" that was built. Includes bootloader, DTBs, Kernel and Root file system."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:202
+msgid ""
+"**phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz**: when bitbake-"
+"build was processed for ``phytec-qt6demo-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:204
+msgid ""
+"**phytec-headless-image-phyboard-segin-imx93-2.wic.xz**: when bitbake-"
+"build was processed for ``phytec-headless-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:206
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:212
+msgid ""
+"**imx93-11x11-evk_m33_\\*.bin**, binaries of demo applications for the "
+"Cortex-M33 MCU; can be manually loaded and started with U-Boot or Linux"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:221
+msgid "Hardware revision baseboard: 1472.5"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:17
+msgid ""
+"can be run to inspect whether the current setup is affected. If "
+"|emmcdev|\\p1 and mmcblk1p1 have an identical UUID, the setup is "
+"affected."
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:23
+msgid ""
+"If there is no network available, you can update the eMMC from SD card. "
+"For that, you only need a ready-to-use image file (``*.wic``) located on "
+"the SD card. Because the image file is quite large, you have to enlarge "
+"your SD card to use its full space (if it was not enlarged before). To "
+"enlarge your SD card, see Resizing ext4 Root Filesystem."
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:35
+msgid ""
+"You can flash the eMMC on Linux. You only need a partup package or WIC "
+"image saved on the SD card."
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:38
+msgid ""
+"Show your saved partup package or WIC image or WIC.XZ image files on the "
+"SD card:"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:63
+#: ../../source/bsp/imx9/installing-os.rsti:245
+msgid ""
+"The eMMC device can be recognized by the fact that it contains two boot "
+"partitions: (|emmcdev|\\ **boot0**; |emmcdev|\\ **boot1**)"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:65
+msgid ""
+"Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without** "
+"partition) using `partup`_:"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:75
+msgid ""
+"**Using partup is highly recommended since it is easier to use and has "
+"the advantage of using the full capacity of the eMMC device, adjusting "
+"partitions accordingly.**"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:81
+msgid "Alternatively, ``dd`` may be used instead."
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:83
+msgid "For uncompressed WIC images (\\*.wic):"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:90
+msgid "For compressed WIC images (\\*.wic.xz):"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:119
+msgid ""
+"Some PHYTECs BSPs produce compressed ``.wic.xz`` images. In this case, "
+"the compressed image must first be uncompressed."
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:136
+msgid ""
+"Take an uncompressed image on the host and send it with ssh through the "
+"network to the eMMC of the target with a one-line command:"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:247
+msgid ""
+"Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without "
+"partition):"
+msgstr ""
+
+#: ../../source/bsp/imx9/installing-os.rsti:264
+msgid ""
+"The RAUC (Robust Auto-Update Controller) mechanism support has been added"
+" to meta-ampliphy. It controls the procedure of updating a device with "
+"new firmware. This includes updating the Linux kernel, Device Tree, and "
+"root filesystem. PHYTEC has written an online manual on how we have "
+"intergraded RAUC into our BSPs: `L-1006e.A5 RAUC Update & Device "
+"Management Manual <https://www.phytec.de/cdocuments/?doc=fgByJg>`__."
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:7
+msgid ""
+"To build the imx-boot, you need to **gather** these **files** for later "
+"use with **imx-mkimage tool**:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:17
+msgid "**Container image**: mx93a1-ahab-container.img"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:19
+msgid ""
+"If you already built our BSP with Yocto, you can get these files from the"
+" directory mentioned here: |ref-bsp-images|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:22
+msgid ""
+"Or you can download the files from the PHYTEC download server (|link-"
+"boot-tools|). You can use the commands below to download all the files "
+"from that server:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:82
+msgid "Build u-boot:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:93
+msgid "|u-boot-multiple-defconfig-note|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:96
+msgid "Build final flash.bin with imx-mkimage"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:98
+msgid "Get imx-mkimage:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:107
+msgid "Copy firmware binaries into imx-mkimage"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:119
+msgid "Copy u-boot binaries and DTB into imx-mkimage"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:128
+msgid "|u-boot-multiple-dtb-note|"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:130
+msgid "Build final flash.bin binary"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:137
+msgid ""
+"The flash.bin can be found at imx-mkimage/|u-boot-soc-name|/ directory "
+"and now can be flashed. A chip-specific offset is needed:"
+msgstr ""
+
+#: ../../source/bsp/imx-common/development/standalone_build_u-boot_imxmkimage.rsti:157
+msgid ""
+"In the command above, replace ``<sd-card>`` with your sd-card device "
+"name. For more information on how to find the device name, see the "
+"section |ref-getting-started-find-correct-device| in Getting Started."
+msgstr ""
+
+#: ../../source/bsp/imx9/dt-overlays.rsti:29
+msgid ""
+"Make sure the boot partition is mounted! If it is not you can mount it "
+"with:"
+msgstr ""
+
+#: ../../source/bsp/imx9/dt-overlays.rsti:61
+msgid ""
+"We use the ``${overlays}`` variable for overlays describing expansion "
+"boards that can not be detected during run time. To prevent applying "
+"overlays listed in the ``${overlays}`` variable during boot, the "
+"``${no_overlays}`` variable can be set to `1` in the bootloader "
+"environment."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:393
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:413
+msgid ""
+"The first part of the string MX93_PAD_UART1_RXD__LPUART1_RX names the pad"
+" (in this example UART1_RXD). The second part of the string (LPUART1_RX) "
+"is the desired muxing option for this pad. The pad setting value (hex "
+"value on the right) defines different modes of the pad, for example, if "
+"internal pull resistors are activated or not. In this case, the internal "
+"pull up is activated."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:400
+msgid ""
+"The device tree representation for UART1 pinmuxing: :imx-dt:`imx93"
+"-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n267`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:408
+msgid ""
+"|sbc|-|soc| provides two ethernet interfaces. A 100 megabit Ethernet is "
+"provided by our module and board."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:415
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx93-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n216`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:418
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt:`imx93"
+"-phycore-som.dtsi?h=v6.1.36_2.1.0-phy1#n195`"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:4
+msgid ""
+"The |sbc| doesn't have a set of pins especially dedicated for user I/Os "
+"since all GPIOs are used by kernel device drivers or used for a specific "
+"purpose. The processor has organized its GPIOs into five banks of 32 "
+"GPIOs each (GPIO1 – GPIO4) GPIOs. gpiochip0, gpiochip32, gpiochip64 and "
+"gpiochip96 are the sysfs representation of these internal |soc| GPIO "
+"banks GPIO1 – GPIO4."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:10
+msgid ""
+"The GPIOs are identified as GPIO<X>_<Y> (e.g. GPIO4_07). <X> identifies "
+"the GPIO bank and counts from 1 to 4, while <Y> stands for the GPIO "
+"within the bank. <Y> is being counted from 0 to 31 (32 GPIOs on each "
+"bank)."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:37
+msgid ""
+"Order of GPIOchips in ``i.MX 93 Application Processor Reference Manual`` "
+"and in Linux kernel differ!"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:41
+msgid "GPIOchip address"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:41
+msgid "Linux"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:41
+msgid "Reference Manual"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:43
+msgid "0x43810080"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:43
+msgid "gpiochip0"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:43
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:47
+msgid "gpiochip2"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:45
+msgid "0x43820080"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:45
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:49
+msgid "gpiochip1"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:45
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:49
+msgid "gpiochip3"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:47
+msgid "0x43830080"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:47
+msgid "gpiochip4"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:49
+msgid "0x47400080"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:59
+msgid "Read the value of a GPIO (e.g GPIO 3 from chip0):"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:65
+msgid "Set the value of GPIO 3 on chip0 to 0 and exit tool:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:116
+msgid ""
+"Support to access GPIOs via sysfs is not enabled by default any more. It "
+"is only possible with manually enabling CONFIG_GPIO_SYSFS in the kernel "
+"configuration. To make CONFIG_GPIO_SYSFS visible in menuconfig the option"
+" CONFIG_EXPERT has to be enabled first."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/gpios.rsti:121
+msgid ""
+"You can also add this option for example to the imx9_phytec_distro.config"
+" config fragment in the linux kernel sources under arch/arm64/configs ::"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/leds.rsti:22
+msgid ""
+"Here the LEDs ``green:heartbeat`` is on the |som|. If you are using "
+"phyBOARD-Segin there is also ``yellow`` LED which is populated on the "
+"PEB-EVAL-01."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:429
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx93-phyboard-segin-peb-"
+"eval-01.dtso?h=v6.1.36_2.1.0-phy1#n33`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:434
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx93"
+"-phycore-som.dtsi?h=v6.1.36_2.1.0-phy1#n88`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:437
+msgid ""
+"General I²C2 bus configuration (e.g. |dt-carrierboard|.dts) :imx-"
+"dt:`imx93-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n155`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:444
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:487
+msgid ""
+"There are two different I2C EEPROM flashes populated on |som| SoM and on "
+"the |sbc|. For now only the one on the |som| is enabled, and it is used "
+"for board detection."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:4
+msgid "The I2C EEPROM on the |som| SoM has its memory divided into two parts."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:6
+msgid "normal area (size: 4096 bytes, bus: I2C-2, addr: 0x50)"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:7
+msgid "ID page (size: 32 bytes, bus: I2C-2, addr: 0x58)"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:9
+msgid "It is possible to read and write from the device populated:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:22
+msgid ""
+"To fill the whole EEPROM (ID page) with zeros we first need to disable "
+"the EEPROM write protection, use:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:29
+msgid "Then the EEPROM can be written to:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:37
+msgid ""
+"The first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50) are"
+" reserved and should not be overwritten! (See below)"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:43
+msgid ""
+"PHYTEC uses first 256 bytes in EEPROM normal area to store information "
+"about the SoM. This includes PCB revision and mounting options."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:51
+msgid ""
+"If the first 265 bytes of the normal area are deleted, the bootloader "
+"will fall back to the |som| Kit RAM setup, which is |kit-ram-size| RAM."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:56
+msgid ""
+"Data in the first 265 bytes of the normal EEPROM area (bus: I2C-2 addr: "
+"0x50) shouldn't be erased or corrupted! This might influence the behavior"
+" of the bootloader. The board might not boot correctly anymore."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/eeprom.rsti:63
+msgid ""
+"The hardware introspection data is pre-written on the EEPROM data spaces."
+" If you have accidentally deleted or overwritten the HW data, you could "
+"contact our support!"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:450
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC "
+"git: :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.36_2.1.0-phy1#n173`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:455
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.36_2.1.0-phy1#n173`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:461
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:505
+msgid ""
+"The USB controller of the |soc| SoC provides a low-cost connectivity "
+"solution for numerous consumer portable devices by providing a mechanism "
+"for data transfer between USB devices with a line/bus speed of up to 480 "
+"Mbps (HighSpeed 'HS'). The USB subsystem has two independent USB "
+"controller cores. Both cores are capable of acting as a USB peripheral "
+"device or a USB host, but on the |sbc| one of them is used as a host-only"
+" port (USB-A connector)."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:470
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:514
+msgid ""
+"The OTG port provides an additional pin for over-current protection, "
+"which is not used on the |sbc|. Since it's not used, the driver part is "
+"also disabled from within the device tree. In case this pin is used, "
+"activate this over-current in the device tree and set the correct "
+"polarity (active high/low) according to the device specification. For the"
+" correct setup, please refer to the Kernel documentation under "
+"Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:478
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.36_2.1.0-phy1#n190`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:484
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:544
+msgid ""
+"The |sbc| has one flexCAN interface supporting CAN FD. They are supported"
+" by the Linux standard CAN framework which builds upon the Linux network "
+"layer. Using this framework, the CAN interfaces behave like an ordinary "
+"Linux network device, with some additional features special to CAN. More "
+"information can be found in the Linux Kernel documentation: "
+"https://www.kernel.org/doc/html/latest/networking/can.html"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/canfd.rsti:7
+msgid ""
+"to see the state of the interfaces. The CAN interface should show up as "
+"can0."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:493
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :imx-dt:`imx93"
+"-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n147`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:499
+msgid ""
+"On |sbc| the TI TLV320AIC3007 audio codec is used. It uses I2S for data "
+"transmission and I2C for codec control. The audio signals available are:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:502
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:564
+msgid "Stereo LINE IN,"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:503
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:565
+msgid "Stereo LINE OUT,"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:504
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:566
+msgid "Output where D-Class 1W speaker can be connected"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:513
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:575
+msgid ""
+"If Speaker volume it too low you can increase its volume with (values "
+"0-3):"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:521
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:583
+msgid ""
+"Speaker output is only mono so when stereo track is played only left "
+"channel will be played by speaker."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:527
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:589
+msgid ""
+"``arecord`` is a command-line tool for capturing audio streams which use "
+"Line In as the default input source."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:540
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.36_2.1.0-phy1#n62`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/display.rsti:4
+msgid ""
+"The **phyBOARD-Segin** i.MX 93 supports PEB-AV-02 with 7'' "
+"``edt,etm0700g0edh6`` parallel display with capacitive touchscreen. "
+"Overlay for said display is enabled in ``BOOT/bootenv.txt`` by default!"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/display.rsti:8
+msgid ""
+"The **phyBOARD-Nash** i.MX 93 needs additional adapter to support 10'' "
+"``edt,etml1010g3dra`` LVDS display with capacitive touchscreen. The PEB-"
+"AV-10 (1531.1 revision) can be bought separately to the Kit. Overlay for "
+"said display is enabled in ``BOOT/bootenv.txt`` by default!"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.0.rst:551
+msgid ""
+"The device tree of PEB-AV-02 can be found here: :imx-dt:`imx93-phyboard-"
+"segin-peb-av-02.dtso?h=v6.1.36_2.1.0-phy1`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:7
+msgid ""
+"The CPU in the |soc| SoC is able to scale the clock frequency and the "
+"voltage. This is used to save power when the full performance of the CPU "
+"is not needed. Unlike i.MX8 M family the i.MX 93 doesn't support "
+"*Dynamic* Voltage and Frequency Scaling (DVFS), but has the support of "
+"basic **Voltage and Frequency Scaling (VFS)**. The board can be put into "
+"these modes:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:14
+msgid "nominal (ND),"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:15
+msgid "overdrive (OD),"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:16
+msgid "Low Drive (LD) and"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:17
+msgid "Low Drive (LD) with Software Fast Frequency Change (SWFFC)."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:20
+msgid "Mode"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:20
+msgid "CPU freq"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:20
+msgid "DDR data rate"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:20
+msgid "VDD_SOC"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:22
+msgid "OverDrive (OD)"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:22
+msgid "1.7 GHz"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:22
+msgid "3733 MT/s"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:22
+msgid "900mV"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:23
+msgid "NominalDrive (ND)"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:23
+msgid "1.4 GHz"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:23
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:24
+msgid "1866 MT/s"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:23
+msgid "850mV"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:24
+msgid "LowDrive (LD)"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:24
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:25
+msgid "900 MHz"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:24
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:25
+msgid "800mV"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:25
+msgid "LowDrive (LD) with SWFFC"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:25
+msgid "625 MT/s"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:28
+msgid ""
+"The |soc| BSP supports the VFS feature. The Linux kernel provides a LPM "
+"driver that allows setting VDD_SOC, CPU freq and DDR speed."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:31
+msgid "To put the device in **OverDrive (OD)** mode type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:37
+msgid "To put the device in **NominalDrive (ND)** mode type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:43
+msgid "To put the device in **LowDrive (LD)** mode type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:49
+msgid ""
+"To put the device in **LowDrive (LD)** mode with the lowest DDR speed "
+"with SWFFC type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:56
+msgid "To check the current CPU frequency type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:62
+msgid "To check the current mode and DDR frequency type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:68
+msgid "To check the current VDD_SOC type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:74
+msgid ""
+"For more detailed information about the LPM driver and modes, refer to "
+"the NXPs documentation: "
+"https://docs.nxp.com/bundle/AN13917/page/topics/low_power_mode_use_cases.html"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:81
+msgid ""
+"The |soc| SoC can have multiple processor cores on the die. The |soc|, "
+"for example, has 2 ARM Cores which can be turned on and off individually "
+"at runtime."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:99
+msgid ""
+"Here the system has two processor cores. By default, all available cores "
+"in the system are enabled to get maximum performance."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:147
+msgid "Device can be put into suspend and waken-up with PEB-EVAL-01 S2 button"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/pm.rsti:149
+msgid "To wake up with RTC alarm check: `RTC Wakealarm`_"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:44
+msgid ""
+"There are two trip points registered by the imx_thermal kernel driver. "
+"These differ depending on the CPU variant. A distinction is made between "
+"Commercial, Industrial and Extended Industrial."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:49
+msgid "Extended Industrial"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:51
+msgid "115°C"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:52
+msgid "120°C"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:57
+msgid ""
+"The kernel thermal management uses these trip points to trigger events "
+"and change the cooling behavior. The following thermal policies (also "
+"named thermal governors) are available in the kernel: Step Wise and Power"
+" Allocator. The default policy used in the BSP is step_wise."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/tm.rsti:64
+msgid ""
+"If the value of the SoC temperature in the sysfs file temp reaches "
+"*trip_point_1*, the board immediately shuts down to avoid any heat "
+"damage. If this doesn't meet you expectations, an external supervisor "
+"circuit that starts the module again with X_ONOFF signal when the "
+"temperature drops below a selected trip point can be implemented"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/bbnsm-power-key.rsti:2
+msgid "bbnsm Power Key"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/bbnsm-power-key.rsti:4
+msgid ""
+"The X_ONOFF pin connected to the ON/OFF button can be pressed long (for 5"
+" seconds) to trigger Power OFF without SW intervention or used to wake up"
+" the system out of suspend. With the *bbnsm_pwrkey* driver, the KEY_POWER"
+" event is also reported to userspace when the button is pressed. On "
+"default, systemd is configured to ignore such events. The function of "
+"Power OFF without SW intervention are not configured. Triggering a power "
+"off with systemd when pushing the ON/OFF button can be configured under "
+"``/etc/systemd/logind.conf`` and set using:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:2
+msgid "PXP"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:4
+msgid ""
+"The |soc| SoC contains an PiXel Pipeline (PXP). The PXP combines the "
+"following into a single processing engine:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:7
+msgid "Scaling"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:8
+msgid "Color Space Conversion (CSC)"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:9
+msgid "Secondary Color Space Conversion (CSC2)"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:10
+msgid "Rotation"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/pxp.rsti:12
+msgid ""
+"and thus minimizes the memory footprint required for the display "
+"pipeline. How to use the PXP with Gstreamer and Wayland check the `How to"
+" Use PXP in GStreamer and Wayland` (AN13829) Application note from NXP."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:4
+msgid ""
+"The |soc| provides one-time programmable fuses to store information such "
+"as the MAC address, boot configuration, and other permanent settings "
+"(\"On-Chip OTP Controller (OCOTP_CTRL)\" in the |soc| Reference Manual). "
+"The following list is an abstract from the |soc| Reference Manual and "
+"includes some useful registers in the OCOTP_CTRL (at base address "
+"0x47510000):"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:11
+msgid "Memory offset at 0x47510000"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:14
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:86
+msgid "BOOT_CFG0"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:14
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:15
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:16
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:17
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:18
+msgid "3"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:14
+msgid "0    0x60"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:14
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:15
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:16
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:17
+msgid "boot fuse settings"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:15
+msgid "BOOT_CFG1"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:15
+msgid "1    0x64"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:16
+msgid "BOOT_CFG2"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:16
+msgid "2    0x68"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:17
+msgid "BOOT_CFG3"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:17
+msgid "3    0x6c"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:18
+msgid "MAC1_ADDR"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:18
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:20
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:24
+msgid "39"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:18
+msgid "0x4ec"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:20
+msgid "MAC1/2_ADDR"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:38
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:20
+msgid "4"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:20
+msgid "0x4f0"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:24
+msgid "MAC2_ADDR"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:36
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:24
+msgid "5"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:24
+msgid "0x4f4"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:35
+msgid "MAC1_ADDR:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:53
+msgid "Burning MAC addresses"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:55
+msgid "Let's say we want to burn the following MAC addresses:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:58
+msgid "MAC1"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:58
+msgid "12:34:56:78:90:Aa"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:60
+msgid "MAC2"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:60
+msgid "Bb:Cc:Dd:Ee:Ff:D0"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:63
+msgid "We would execute this in u-boot:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:72
+msgid "Burning Boot Fuses"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:75
+msgid ""
+"Fuses can only be written once! You can brick your board easily by "
+"burning the wrong boot configuration. It cannot be reversed!"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:78
+msgid ""
+"Which fuse bank/word should be used to program the BOOT_CFGX can be "
+"checked in *i.MX 93 Applications Processor Reference Manual* attached "
+"spreadsheet named **i.MX93_Fusemap.xlsx**."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:82
+msgid ""
+"These values should be written to the BOOT_CFG0, which can be "
+"read/written from fuses on Bank 3, Word 0."
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:86
+msgid "Boot Device"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:88
+msgid "0x20020002"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:89
+msgid "0x20000103"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:92
+msgid "To set internal fuses to boot from eMMC one can program them with:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:98
+msgid "In this example we:"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:100
+msgid "set the Boot_Mode to 0b0010 (eMMC) with BOOT_CFG0[3:0],"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:101
+msgid "set the eMMC Bus width to 0b01 (8 bit) with BOOT_CFG0[18:17]"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:102
+msgid "set the BT_FUSE_SEL (Boot fuses already programmed) bit with BOOT_CFG0[29]"
+msgstr ""
+
+#: ../../source/bsp/imx9/peripherals/ocotp-ctrl.rsti:104
+msgid ""
+"Make sure you set the right bits by reading the **Boot Fusemap** chapter "
+"in *i.MX 93 Applications Processor Reference Manual*."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:4
+msgid ""
+"In addition to the Cortex-A55 cores, there is a Cortex-|mcore| as MCU "
+"integrated into the |soc| SoC. Our Yocto-Linux-BSP runs on the A55-Cores "
+"and the |mcore| can be used as a secondary core for additional tasks "
+"using bare-metal firmware. Both cores have access to the same peripherals"
+" and thus peripheral usage needs to be limited either in the |mcore|'s "
+"firmware or the devicetree for the Linux operating system."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:12
+msgid "Our Yocto-BSP contains pre-built firmware examples for |mcore| from NXP."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:14
+msgid ""
+"This section describes how to run pre-built |mcore| firmware examples on "
+"|sbc|."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:19
+msgid ""
+"There are two ways to run the |mcore| firmware examples, from U-Boot "
+"bootloader and from Remoteproc subsystem within a running Linux."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:26
+msgid ""
+"On |sbc| an external \"USB TTL to serial adapter\" is required. Adapter's"
+" I/O pins should be able to operate at 3.3V voltage levels."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:29
+msgid ""
+"Connect external \"USB TTL to serial adapter\" signals to the |ref-m"
+"-core-connections| connector on the board according to the following "
+"table:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:34
+msgid "USB-TTL adapter pins"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:34
+msgid "X16 signal"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:462
+#: ../../source/bsp/imx9/mcu.rsti:34
+msgid "X16 pin"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:36
+msgid "RXD"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:36
+msgid "X_UART2_TX"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:37
+msgid "TXD"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:37
+msgid "X_UART2_RX"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:37
+msgid "8"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:38
+msgid "GND"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:44
+msgid ""
+"To load firmware examples using the U-Boot bootloader, the ``bootaux`` "
+"command can be used:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:49
+msgid ""
+"List available |mcore| firmware examples on the first partition of SD "
+"Card:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:57
+msgid ""
+"Available firmware examples start with ``imx93-11x11-evk_m33_TCM_*`` and "
+"end with ``*.bin``. Examples come from NXP's Yocto layer meta-imx and are"
+" selected based on compatibility with |sbc| hardware."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:61
+msgid "Load desired firmware example:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:76
+msgid ""
+"Remoteproc is a module that allows you to control the |mcore| from Linux "
+"during runtime. Firmware examples for |mcore| can be loaded and the "
+"execution started or stopped within Linux. To use Remoteproc a devicetree"
+" overlay needs to be set:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:81
+msgid ""
+"Edit the ``bootenv.txt`` file located in the ``/boot`` directory on the "
+"target by adding |dtbo-rpmsg|:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:93
+msgid ""
+"Firmware examples ``*.elf`` files for the |mcore| can be found under "
+"``/lib/firmware``. List available firmware examples:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:100
+msgid "To load the firmware, type:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:115
+msgid ""
+"The samples found in ``/lib/firmware`` on the target come from NXP's "
+"Yocto layer meta-imx and are selected based on compatibility with |sbc| "
+"hardware."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:119
+msgid ""
+"Some firmware examples from NXP require additional Linux kernel modules "
+"to be loaded."
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:122
+msgid ""
+"For example, when loading "
+"``imx93-11x11-evk_m33_TCM_rpmsg_lite_str_echo_rtos.elf`` firmware, one "
+"requires corresponding ``imx_rpmsg_tty`` module to be loaded:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:129
+msgid ""
+"This exposes an RPMsg endpoint as a virtual TTY at ``/dev/ttyRPMSG30``. "
+"Now it is possible to send messages from A55 Core to |mcore| by typing:"
+msgstr ""
+
+#: ../../source/bsp/imx9/mcu.rsti:136
+msgid "Observing |mcore| debug UART should result in the following output:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:126
+msgid "2024/05/07"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:147
+msgid ""
+"**Console examples in this BSP manual only focus on phyBOARD-Segin i.MX "
+"93. Similar commands can also be executed for/on phyBOARD-Nash i.MX 93**"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:169
+msgid ""
+"Connect the targets debug console with your host. Use |ref-"
+"debugusbconnector|."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:171
+msgid ""
+"Open serial/usb port with 115200 baud and 8N1 (you should see "
+"u-boot/linux start on the console"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:195
+msgid "**imx93-phyboard-*.dtb**: Kernel device tree file"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:200
+msgid ""
+"**phytec-qt6demo-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build "
+"was processed for ``phytec-qt6demo-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:202
+msgid ""
+"**phytec-headless-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build "
+"was processed for ``phytec-headless-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:208
+msgid ""
+"**phytec-qt6demo-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build "
+"was processed for ``phytec-qt6demo-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:210
+msgid ""
+"**phytec-headless-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build "
+"was processed for ``phytec-headless-image``"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:227
+msgid "Hardware revision baseboard:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:229
+msgid "phyBOARD-Segin-i.MX 93: 1472.5"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:230
+msgid "phyBOARD-Nash-i.MX 93: 1616.0"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:380
+msgid "Available overlays for phyboard-nash-imx93-1.conf are:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:420
+msgid ""
+"The device tree representation for UART1 pinmuxing: :imx-dt:`imx93"
+"-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n262`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:428
+msgid "|sbc| provides two ethernet interfaces."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:430
+msgid "On **phyBOARD-Segin** we have:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:432
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:437
+msgid "a 100 megabit Ethernet provided by |som|"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:433
+msgid "and 100 megabit Ethernet provided by phyBOARD."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:435
+msgid "On **phyBOARD-Nash** we have:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:438
+msgid "and 1 gigabit Ethernet provided by phyBOARD."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:444
+msgid ""
+"DT configuration for the MMC (SD card slot) interface can be found here: "
+":imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n216` or here: "
+":imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n201`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:448
+msgid ""
+"DT configuration for the eMMC interface can be found here: :imx-dt:`imx93"
+"-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n194` or here:"
+msgstr ""
+
+#: ../../source/bsp/peripherals/adc.rsti:2
+msgid "ADC"
+msgstr ""
+
+#: ../../source/bsp/peripherals/adc.rsti:4
+msgid ""
+"The PHYTEC |soc| include general purpose Analog-to-Digital Converters "
+"(ADC) which can be used for interfacing analog sensors."
+msgstr ""
+
+#: ../../source/bsp/peripherals/adc.rsti:7
+msgid "Reading the ADC values can be done through sysfs:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:459
+msgid "On phyBOARD-Nash the ADC lines are accessible on X16 expansion connector:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:462
+msgid "ADC input"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:464
+msgid "ADC_IN0"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:464
+msgid "47"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:465
+msgid "ADC_IN2"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:465
+msgid "49"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:470
+msgid ""
+"Device tree configuration for the User I/O configuration can be found "
+"here: :imx-dt:`imx93-phyboard-segin-peb-"
+"eval-01.dtso?h=v6.1.55_2.2.0-phy3#n33`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:475
+msgid ""
+"General I²C1 bus configuration (e.g. |dt-som|.dtsi): :imx-dt:`imx93"
+"-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n88`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:478
+msgid ""
+"General I²C2 bus configuration for |dt-carrierboard|.dts: :imx-dt:`imx93"
+"-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n155` or for imx93-phyboard-"
+"nash.dts: :imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n113`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:493
+msgid ""
+"DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC "
+"git: :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n172`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:498
+msgid ""
+"DT representation for I²C RTCs: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.55_2.2.0-phy3#n173` or :imx-dt:`imx93-phyboard-"
+"nash.dts?h=v6.1.55_2.2.0-phy3#n122`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:522
+msgid ""
+"DT representation for USB Host: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.55_2.2.0-phy3#n190` or :imx-dt:`imx93-phyboard-"
+"nash.dts?h=v6.1.55_2.2.0-phy3#n180`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:529
+msgid "The **phyBOARD-Nash** i.MX 93 SoC provides one RS232/RS485 serial port."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:532
+msgid ""
+"RS232 with HW flow control and RS485 are not working due to HW bug on the"
+" phyBOARD-Nash PCB revision 1616.0"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:538
+msgid ""
+"The device tree representation for RS232 and RS485: :imx-dt:`imx93"
+"-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n173`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:553
+msgid ""
+"Device Tree CAN configuration of |dt-carrierboard|.dts: :imx-dt:`imx93"
+"-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n147` or :imx-dt:`imx93"
+"-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n105`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:558
+msgid "Audio on phyBOARD-Segin"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:560
+msgid ""
+"On phyBOARD-Segin i.MX 93 the TI TLV320AIC3007 audio codec is used. It "
+"uses I2S for data transmission and I2C for codec control. The audio "
+"signals available are:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:602
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`imx93-phyboard-"
+"segin.dts?h=v6.1.55_2.2.0-phy3#n62`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:606
+msgid "Audio on phyBOARD-Nash"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:610
+msgid ""
+"Due to HW bug Audio is broken on phyBOARD-Nash i.MX 93 PCB revision: "
+"1616.0"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:612
+msgid ""
+"To use audio with phyBOARD-Nash an additional adapter for the Audio/Video"
+" connector is needed. The PEB-AV-10 (1531.1 revision) can be bought "
+"separately to the Kit. PEB-AV-10 is populated with a TI TLV320AIC3007 "
+"audio codec. Audio support is done via the I2S interface and controlled "
+"via I2C."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:623
+msgid ""
+"Device Tree Audio configuration: :imx-dt:`imx93-phyboard-nash-peb-"
+"av-010.dtso?h=v6.1.55_2.2.0-phy3#n57`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:634
+msgid ""
+"The device tree of PEB-AV-02 can be found here: :imx-dt:`imx93-phyboard-"
+"segin-peb-av-02.dtso?h=v6.1.55_2.2.0-phy3`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:637
+msgid ""
+"The device tree of PEB-AV-10 can be found here: :imx-dt:`imx93-phyboard-"
+"nash-peb-av-010.dtso?h=v6.1.55_2.2.0-phy3`"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:2
+msgid "TPM"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:4
+msgid ""
+"The **phyBOARD-Nash** i.MX 93 is equipped with a Trusted Platform Module "
+"(TPM) that provides hardware-based security functions."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:7
+msgid "Here are some useful examples to work with the TPM"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:9
+msgid "Generate 4-byte random value with TPM2 tools:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:15
+msgid "Generate 4-byte random value with OpenSSL tools:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:21
+msgid "Generate RSA private key and validate its contents:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:42
+msgid ""
+"Do NOT share your private RSA keys if you are going to use these keys for"
+" any security purposes."
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/peripherals/tpm.rsti:45
+msgid "Generate RSA public key and validate its contents:"
+msgstr ""
+
+#: ../../source/bsp/imx9/imx93/pd24.1.1.rst:654
+msgid ""
+"Device tree TPM configuration can be found here: :imx-dt:`imx93-phyboard-"
+"nash.dts?h=v6.1.55_2.2.0-phy3#n151`"
+msgstr ""
+
+#~ msgid ""
+#~ "For dual display in dual view mode"
+#~ " at HDMI and LVDS0 (PEB-AV-10), "
+#~ "both modes have to be set to "
+#~ "current:"
+#~ msgstr ""
+

--- a/source/locale/zh_CN/LC_MESSAGES/contributing_links.po
+++ b/source/locale/zh_CN/LC_MESSAGES/contributing_links.po
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, PHYTEC Messtechnik GmbH
+# This file is distributed under the same license as the PHYTEC BSP
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PHYTEC BSP Documentation imx8mp-pd22.1.2-5-ge2f699d\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-03 18:21+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../source/contributing_links.rst:3
+msgid "Contribute"
+msgstr ""
+
+#: ../../source/contributing_links.rst:5
+msgid ""
+"Phytec's Yocto BSPs are released under open source licenses and we "
+"welcome contributions to our Yocto BSPs and this documentation. Please "
+"check the Git repositories for the individual projects and layers for "
+"contribution guidelines."
+msgstr ""
+
+#: ../../source/contributing_links.rst:10
+msgid ""
+"If you have a **question related to our Yocto BSPs** or notice **issues "
+"with this documentation**, we encourage you to open an Issue or Pull-"
+"Request on the Github repository `doc-bsp-yocto "
+"<https://github.com/phytec/doc-bsp-yocto>`__. Have a look at the "
+"`Contributing guide <https://github.com/phytec/doc-bsp-"
+"yocto/blob/main/CONTRIBUTING.rst>`__ for more information."
+msgstr ""
+

--- a/source/locale/zh_CN/LC_MESSAGES/contributing_links.po
+++ b/source/locale/zh_CN/LC_MESSAGES/contributing_links.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #: ../../source/contributing_links.rst:3
 msgid "Contribute"
-msgstr ""
+msgstr "贡献"
 
 #: ../../source/contributing_links.rst:5
 msgid ""
@@ -31,6 +31,8 @@ msgid ""
 "check the Git repositories for the individual projects and layers for "
 "contribution guidelines."
 msgstr ""
+"Phytec 的 Yocto BSP 以开源许可证发布，我们欢迎对我们的 Yocto BSP 和本文档的"
+"贡献。请查看各个项目和层的 Git 仓库以获取贡献指南。"
 
 #: ../../source/contributing_links.rst:10
 msgid ""
@@ -41,4 +43,9 @@ msgid ""
 "`Contributing guide <https://github.com/phytec/doc-bsp-"
 "yocto/blob/main/CONTRIBUTING.rst>`__ for more information."
 msgstr ""
+"如果您对我们的 Yocto BSP 有**问题**或注意到本文档的**问题**，我们鼓励您在"
+"Github 仓库 `doc-bsp-yocto <https://github.com/phytec/doc-bsp-yocto>`__ 上"
+"打开一个 Issue 或 Pull Request。查阅`贡献指南 "
+"<https://github.com/phytec/doc-bsp-yocto/blob/main/CONTRIBUTING.rst>`__"
+"以获取更多信息。"
 

--- a/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, PHYTEC Messtechnik GmbH
+# This file is distributed under the same license as the PHYTEC BSP
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PHYTEC BSP Documentation imx8mp-pd22.1.2-5-ge2f699d\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-03 18:21+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../source/index.rst:6
+msgid "Contents"
+msgstr ""
+
+#: ../../source/index.rst:14
+msgid "Contribute"
+msgstr ""
+
+#: ../../source/index.rst:2
+msgid "Welcome to the PHYTEC BSP Documentation"
+msgstr ""
+
+#: ../../source/index.rst:4
+msgid "Welcome to the Documentation for our Yocto BSPs."
+msgstr ""
+

--- a/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -22,17 +22,17 @@ msgstr ""
 
 #: ../../source/index.rst:6
 msgid "Contents"
-msgstr ""
+msgstr "目录"
 
 #: ../../source/index.rst:14
 msgid "Contribute"
-msgstr ""
+msgstr "贡献"
 
 #: ../../source/index.rst:2
 msgid "Welcome to the PHYTEC BSP Documentation"
-msgstr ""
+msgstr "欢迎阅读 PHYTEC BSP 文档"
 
 #: ../../source/index.rst:4
 msgid "Welcome to the Documentation for our Yocto BSPs."
-msgstr ""
+msgstr "欢迎阅读我们的 Yocto BSP 文档。"
 

--- a/source/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/source/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, PHYTEC Messtechnik GmbH
+# This file is distributed under the same license as the PHYTEC BSP
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PHYTEC BSP Documentation imx8mp-pd22.1.2-5-ge2f699d\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-03 19:16+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../source/sphinx/templates/versions.html:9
+msgid "Languages"
+msgstr ""
+
+#~ msgid "Versions"
+#~ msgstr ""
+

--- a/source/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/source/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -22,8 +22,8 @@ msgstr ""
 
 #: ../../source/sphinx/templates/versions.html:9
 msgid "Languages"
-msgstr ""
+msgstr "语言"
 
 #~ msgid "Versions"
-#~ msgstr ""
+#~ msgstr "版本"
 

--- a/source/locale/zh_CN/LC_MESSAGES/yocto.po
+++ b/source/locale/zh_CN/LC_MESSAGES/yocto.po
@@ -1,0 +1,4263 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2024, PHYTEC Messtechnik GmbH
+# This file is distributed under the same license as the PHYTEC BSP
+# Documentation package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PHYTEC BSP Documentation imx8mp-pd22.1.2-5-ge2f699d\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-03 18:21+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../source/yocto/kirkstone.rst:9 ../../source/yocto/kirkstone.rst:17
+#: ../../source/yocto/mickledore.rst:9 ../../source/yocto/mickledore.rst:17
+#: ../../source/yocto/scarthgap.rst:9 ../../source/yocto/scarthgap.rst:17
+msgid "|yocto-ref-manual|"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:11 ../../source/yocto/mickledore.rst:11
+#: ../../source/yocto/scarthgap.rst:11
+msgid "Document Title"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:11 ../../source/yocto/mickledore.rst:11
+#: ../../source/yocto/scarthgap.rst:11
+msgid "|yocto-ref-manual| |yocto-codename|"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:13 ../../source/yocto/mickledore.rst:13
+#: ../../source/yocto/scarthgap.rst:13
+msgid "Document Type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:13 ../../source/yocto/mickledore.rst:13
+#: ../../source/yocto/scarthgap.rst:13
+msgid "Yocto Manual"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:15 ../../source/yocto/mickledore.rst:15
+#: ../../source/yocto/scarthgap.rst:15
+msgid "Release Date"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:15 ../../source/yocto/mickledore.rst:15
+#: ../../source/yocto/scarthgap.rst:15
+msgid "XXXX/XX/XX"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:17 ../../source/yocto/mickledore.rst:17
+#: ../../source/yocto/scarthgap.rst:17
+msgid "Is Branch of"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:21 ../../source/yocto/mickledore.rst:21
+#: ../../source/yocto/scarthgap.rst:21
+msgid "Compatible BSPs"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:21 ../../source/yocto/mickledore.rst:21
+#: ../../source/yocto/scarthgap.rst:21
+msgid "BSP Release Type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:21 ../../source/yocto/mickledore.rst:21
+#: ../../source/yocto/scarthgap.rst:21
+msgid "BSP Release Date"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:21 ../../source/yocto/mickledore.rst:21
+#: ../../source/yocto/scarthgap.rst:21
+msgid "BSP Status"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:23
+msgid "BSP-Yocto-Ampliphy-i.MX6-PD22.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:23 ../../source/yocto/kirkstone.rst:27
+#: ../../source/yocto/kirkstone.rst:31 ../../source/yocto/kirkstone.rst:33
+#: ../../source/yocto/kirkstone.rst:35 ../../source/yocto/kirkstone.rst:37
+#: ../../source/yocto/kirkstone.rst:39 ../../source/yocto/kirkstone.rst:41
+#: ../../source/yocto/kirkstone.rst:43 ../../source/yocto/mickledore.rst:23
+#: ../../source/yocto/scarthgap.rst:23
+msgid "Major"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:23
+msgid "14.12.2022"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:23 ../../source/yocto/kirkstone.rst:25
+#: ../../source/yocto/kirkstone.rst:27 ../../source/yocto/kirkstone.rst:29
+#: ../../source/yocto/kirkstone.rst:31 ../../source/yocto/kirkstone.rst:33
+#: ../../source/yocto/kirkstone.rst:35 ../../source/yocto/kirkstone.rst:37
+#: ../../source/yocto/kirkstone.rst:39 ../../source/yocto/kirkstone.rst:41
+#: ../../source/yocto/kirkstone.rst:43 ../../source/yocto/mickledore.rst:23
+#: ../../source/yocto/mickledore.rst:25 ../../source/yocto/scarthgap.rst:23
+#: ../../source/yocto/scarthgap.rst:25
+msgid "released"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:25
+msgid "BSP-Yocto-Ampliphy-i.MX6-PD22.1.1"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:25 ../../source/yocto/kirkstone.rst:29
+#: ../../source/yocto/mickledore.rst:25 ../../source/yocto/scarthgap.rst:25
+msgid "Minor"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:25
+msgid "20.06.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:27
+msgid "BSP-Yocto-Ampliphy-i.MX6UL-PD22.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:27
+msgid "11.08.2022"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:29
+msgid "BSP-Yocto-Ampliphy-i.MX6UL-PD22.1.1"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:29
+msgid "23.05.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:31
+msgid "BSP-Yocto-Ampliphy-AM335x-PD23.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:31
+msgid "25.04.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:33
+msgid "BSP-Yocto-NXP-i.MX8MM-PD23.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:33 ../../source/yocto/kirkstone.rst:35
+msgid "12.12.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:35
+msgid "BSP-Yocto-NXP-i.MX8MP-PD23.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:37
+msgid "BSP-Yocto-Ampliphy-AM62x-PD23.2.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:37 ../../source/yocto/kirkstone.rst:39
+#: ../../source/yocto/kirkstone.rst:41
+msgid "28.09.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:39
+msgid "BSP-Yocto-Ampliphy-AM62Ax-PD23.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:41
+msgid "BSP-Yocto-Ampliphy-AM64x-PD23.2.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:43
+msgid "BSP-Yocto-NXP-i.MX7-PD23.1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:43
+msgid "15.12.2023"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:47 ../../source/yocto/mickledore.rst:29
+#: ../../source/yocto/scarthgap.rst:29
+msgid "This manual applies to all |yocto-codename| based PHYTEC releases."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:50 ../../source/yocto/mickledore.rst:32
+#: ../../source/yocto/scarthgap.rst:32
+msgid "The Yocto Project"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:53 ../../source/yocto/mickledore.rst:35
+#: ../../source/yocto/scarthgap.rst:35
+msgid "PHYTEC Documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:55 ../../source/yocto/mickledore.rst:37
+#: ../../source/yocto/scarthgap.rst:37
+msgid ""
+"PHYTEC will provide a variety of hardware and software documentation for "
+"all of our products. This includes any or all of the following:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:58 ../../source/yocto/mickledore.rst:40
+#: ../../source/yocto/scarthgap.rst:40
+msgid ""
+"**QS Guide**: A short guide on how to set up and boot a phyCORE board "
+"along with brief information on building a BSP, the device tree, and "
+"accessing peripherals."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:61 ../../source/yocto/mickledore.rst:43
+#: ../../source/yocto/scarthgap.rst:43
+msgid ""
+"**Hardware Manual**: A detailed description of the System on Module and "
+"accompanying carrier board."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:63 ../../source/yocto/mickledore.rst:45
+#: ../../source/yocto/scarthgap.rst:45
+msgid ""
+"**Yocto Guide**: A comprehensive guide for the Yocto version the phyCORE "
+"uses. This guide contains an overview of Yocto; introducing, installing, "
+"and customizing the PHYTEC BSP; how to work with programs like Poky and "
+"Bitbake; and much more."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:67 ../../source/yocto/mickledore.rst:49
+#: ../../source/yocto/scarthgap.rst:49
+msgid ""
+"**BSP Manual**: A manual specific to the BSP version of the phyCORE. "
+"Information such as how to build the BSP, booting, updating software, "
+"device tree, and accessing peripherals can be found here."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:70 ../../source/yocto/mickledore.rst:52
+#: ../../source/yocto/scarthgap.rst:52
+msgid ""
+"**Development Environment Guide**: This guide shows how to work with the "
+"Virtual Machine (VM) Host PHYTEC has developed and prepared to run "
+"various Development Environments. There are detailed step-by-step "
+"instructions for Eclipse and Qt Creator, which are included in the VM. "
+"There are instructions for running demo projects for these programs on a "
+"phyCORE product as well. Information on how to build a Linux host PC "
+"yourself is also a part of this guide."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:77 ../../source/yocto/mickledore.rst:59
+#: ../../source/yocto/scarthgap.rst:59
+msgid ""
+"**Pin Muxing Table**: phyCORE SOMs have an accompanying pin table (in "
+"Excel format). This table will show the complete default signal path, "
+"from processor to carrier board. The default device tree muxing option "
+"will also be included. This gives a developer all the information needed "
+"in one location to make muxing changes and design options when developing"
+" a specialized carrier board or adapting a PHYTEC phyCORE SOM to an "
+"application."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:84 ../../source/yocto/mickledore.rst:66
+#: ../../source/yocto/scarthgap.rst:66
+msgid ""
+"On top of these standard manuals and guides, PHYTEC will also provide "
+"Product Change Notifications, Application Notes, and Technical Notes. "
+"These will be done on a case-by-case basis. Most of the documentation can"
+" be found in the applicable download page of our products."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:90 ../../source/yocto/mickledore.rst:72
+#: ../../source/yocto/scarthgap.rst:72
+msgid "Yocto Introduction"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:92 ../../source/yocto/mickledore.rst:74
+#: ../../source/yocto/scarthgap.rst:74
+msgid ""
+"Yocto is the smallest SI metric system prefix. Like milli equates to ``m "
+"= 10^-3``, and so is yocto ``y = 10^-24``. Yocto is also a project "
+"working group of the `Linux Foundation "
+"<https://www.linuxfoundation.org/>`_ and therefore backed up by several "
+"major companies in the field. On the `Yocto Project website "
+"<https://www.yoctoproject.org/>`_ you can read the official introduction:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:98 ../../source/yocto/mickledore.rst:80
+#: ../../source/yocto/scarthgap.rst:80
+msgid ""
+"The Yocto Project is an open-source collaboration project that provides "
+"templates, tools, and methods to help you create custom Linux-based "
+"systems for embedded products regardless of the hardware architecture. It"
+" was founded in 2010 as a collaboration among many hardware "
+"manufacturers, open-source operating systems vendors, and electronics "
+"companies to bring some order to the chaos of embedded Linux development."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:105 ../../source/yocto/mickledore.rst:87
+#: ../../source/yocto/scarthgap.rst:87
+msgid ""
+"As said, the project wants to provide toolsets for embedded developers. "
+"It builds on top of the long-lasting `OpenEmbedded "
+"<https://www.openembedded.org/wiki/Main_Page>`_ project. It is not a "
+"Linux distribution. But it contains the tools to create a Linux "
+"distribution specially fitted to the product requirements. The most "
+"important step in bringing order to the set of tools is to define a "
+"common versioning scheme and a reference system. All subprojects have "
+"then to comply with the reference system and have to comply with the "
+"versioning scheme."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:114 ../../source/yocto/mickledore.rst:96
+#: ../../source/yocto/scarthgap.rst:96
+msgid ""
+"The release process is similar to the `Linux kernel "
+"<https://kernel.org/>`_. Yocto increases its version number every six "
+"months and gives the release a codename. The release list can be found "
+"here: https://wiki.yoctoproject.org/wiki/Releases"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:120 ../../source/yocto/mickledore.rst:102
+#: ../../source/yocto/scarthgap.rst:102
+msgid "Core Components"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:122 ../../source/yocto/mickledore.rst:104
+#: ../../source/yocto/scarthgap.rst:104
+msgid "The most important tools or subprojects of the *Yocto* Project are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:124 ../../source/yocto/mickledore.rst:106
+#: ../../source/yocto/scarthgap.rst:106
+msgid "Bitbake: build engine, a task scheduler like make, interprets metadata"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:125 ../../source/yocto/mickledore.rst:107
+#: ../../source/yocto/scarthgap.rst:107
+msgid ""
+"OpenEmbedded-Core, a set of base layers, containing metadata of software,"
+" no sources"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:127 ../../source/yocto/mickledore.rst:109
+#: ../../source/yocto/scarthgap.rst:109
+msgid "Yocto kernel"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:129 ../../source/yocto/mickledore.rst:111
+#: ../../source/yocto/scarthgap.rst:111
+msgid "Optimized for embedded devices"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:130 ../../source/yocto/mickledore.rst:112
+#: ../../source/yocto/scarthgap.rst:112
+msgid "Includes many subprojects: rt-kernel, vendor patches"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:131 ../../source/yocto/mickledore.rst:113
+#: ../../source/yocto/scarthgap.rst:113
+msgid "The infrastructure provided by Wind River"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:132 ../../source/yocto/mickledore.rst:114
+#: ../../source/yocto/scarthgap.rst:114
+msgid ""
+"Alternative: classic kernel build → we use it to integrate our kernel "
+"into *Yocto*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:135 ../../source/yocto/mickledore.rst:117
+#: ../../source/yocto/scarthgap.rst:117
+msgid "*Yocto* Reference BSP: *beagleboneblack*, *minnow max*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:136 ../../source/yocto/mickledore.rst:118
+#: ../../source/yocto/scarthgap.rst:118
+msgid ""
+"*Poky*, the reference system, a collection of projects and tools, used to"
+" bootstrap a new distribution based on *Yocto*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:140 ../../source/yocto/mickledore.rst:122
+#: ../../source/yocto/scarthgap.rst:122
+msgid "Vocabulary"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:143 ../../source/yocto/mickledore.rst:125
+#: ../../source/yocto/scarthgap.rst:125
+msgid "Recipes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:145 ../../source/yocto/mickledore.rst:127
+#: ../../source/yocto/scarthgap.rst:127
+msgid ""
+"Recipes contain information about the software project (author, homepage,"
+" and license). A recipe is versioned, defines dependencies, contains the "
+"URL of the source code, and describes how to fetch, configure, and "
+"compile the sources. It describes how to package the software, e.g. into "
+"different .deb packages, which then contain the installation path. "
+"Recipes are basically written in *Bitbake's* own programming language, "
+"which has a simple syntax. However, a recipe can contain *Python* as well"
+" as a bash code."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:154 ../../source/yocto/mickledore.rst:136
+#: ../../source/yocto/scarthgap.rst:136
+msgid "Classes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:156 ../../source/yocto/mickledore.rst:138
+#: ../../source/yocto/scarthgap.rst:138
+msgid "Classes combine functionality used inside recipes into reusable blocks."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:159 ../../source/yocto/mickledore.rst:141
+#: ../../source/yocto/scarthgap.rst:141
+msgid "Layers"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:161 ../../source/yocto/mickledore.rst:143
+#: ../../source/yocto/scarthgap.rst:143
+msgid ""
+"A layer is a collection of recipes, classes, and configuration metadata. "
+"A layer can depend on other layers and can be included or excluded one by"
+" one. It encapsulates a specific functionality and fulfills a specific "
+"purpose. Each layer falls into a specific category:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:166 ../../source/yocto/mickledore.rst:148
+#: ../../source/yocto/scarthgap.rst:148
+msgid "Base"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:167 ../../source/yocto/mickledore.rst:149
+#: ../../source/yocto/scarthgap.rst:149
+msgid "Machine (BSP)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:168 ../../source/yocto/mickledore.rst:150
+#: ../../source/yocto/scarthgap.rst:150
+msgid "Software"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:169 ../../source/yocto/mickledore.rst:151
+#: ../../source/yocto/scarthgap.rst:151
+msgid "Distribution"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:170 ../../source/yocto/mickledore.rst:152
+#: ../../source/yocto/scarthgap.rst:152
+msgid "Miscellaneous"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:172 ../../source/yocto/mickledore.rst:154
+#: ../../source/yocto/scarthgap.rst:154
+msgid ""
+"*Yocto's* versioning scheme is reflected in every layer as version "
+"branches. For each *Yocto* version, every layer has a named branch in its"
+" *Git* repository. You can add one or many layers of each category in "
+"your build."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:176
+msgid ""
+"A collection of OpenEmbedded layers can be found here. The search "
+"function is very helpful to see if a software package can be retrieved "
+"and integrated easily: "
+"https://layers.openembedded.org/layerindex/branch/kirkstone/layers/"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:181 ../../source/yocto/mickledore.rst:163
+#: ../../source/yocto/scarthgap.rst:163
+msgid "Machine"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:183 ../../source/yocto/mickledore.rst:165
+#: ../../source/yocto/scarthgap.rst:165
+msgid ""
+"Machines are configuration variables that describe the aspects of the "
+"target hardware."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:187 ../../source/yocto/mickledore.rst:169
+#: ../../source/yocto/scarthgap.rst:169
+msgid "Distribution (Distro)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:189 ../../source/yocto/mickledore.rst:171
+#: ../../source/yocto/scarthgap.rst:171
+msgid ""
+"Distribution describes the software configuration and comes with a set of"
+" software features."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:193 ../../source/yocto/kirkstone.rst:299
+#: ../../source/yocto/mickledore.rst:175 ../../source/yocto/mickledore.rst:281
+#: ../../source/yocto/scarthgap.rst:175 ../../source/yocto/scarthgap.rst:281
+msgid "Poky"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:195 ../../source/yocto/mickledore.rst:177
+#: ../../source/yocto/scarthgap.rst:177
+msgid ""
+"*Poky* is the reference system to define *Yocto* Project compatibility. "
+"It combines several subprojects into releases:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:198 ../../source/yocto/mickledore.rst:180
+#: ../../source/yocto/scarthgap.rst:180
+msgid "*Bitbake*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:199 ../../source/yocto/mickledore.rst:181
+#: ../../source/yocto/scarthgap.rst:181
+msgid "*Toaster*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:200 ../../source/yocto/mickledore.rst:182
+#: ../../source/yocto/scarthgap.rst:182
+msgid "OpenEmbedded Core"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:201 ../../source/yocto/mickledore.rst:183
+#: ../../source/yocto/scarthgap.rst:183
+msgid "*Yocto* Documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:202 ../../source/yocto/mickledore.rst:184
+#: ../../source/yocto/scarthgap.rst:184
+msgid "*Yocto* Reference BSP"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:205 ../../source/yocto/mickledore.rst:187
+#: ../../source/yocto/scarthgap.rst:187
+msgid "Bitbake"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:207
+msgid ""
+"*Bitbake* is the task scheduler. It is written in *Python* and interprets"
+" recipes that contain code in *Bitbake's* own programming language, "
+"*Python*, and bash code. The official documentation can be found here: "
+"https://docs.yoctoproject.org/bitbake/2.0/index.html"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:213 ../../source/yocto/mickledore.rst:195
+#: ../../source/yocto/scarthgap.rst:195
+msgid "Toaster"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:215
+msgid ""
+"*Toaster* is a web frontend for *Bitbake* to start and investigate "
+"builds. It provides information about the build history and statistics on"
+" created images. There are several use cases where the installation and "
+"maintenance of a *Toaster* instance are beneficial. PHYTEC did not add or"
+" remove any features to the upstream *Toaster*, provided by *Poky*. The "
+"best source for more information is the official documentation: "
+"https://docs.yoctoproject.org/4.0.6/toaster-manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:224 ../../source/yocto/mickledore.rst:206
+#: ../../source/yocto/scarthgap.rst:206
+msgid "Official Documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:226
+msgid ""
+"For more general questions about *Bitbake* and *Poky* consult the mega-"
+"manual: https://docs.yoctoproject.org/4.0.6/singleindex.html"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:230 ../../source/yocto/mickledore.rst:212
+#: ../../source/yocto/scarthgap.rst:212
+msgid "Compatible Linux Distributions"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:232
+msgid ""
+"To build *Yocto* you need a compatible *Linux* host development machine. "
+"The list of supported distributions can be found in the reference manual:"
+" https://docs.yoctoproject.org/4.0.6/ref-manual/system-requirements.html"
+"#supported-linux-distributions"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:237 ../../source/yocto/mickledore.rst:219
+#: ../../source/yocto/scarthgap.rst:219
+msgid "PHYTEC BSP Introduction"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:240 ../../source/yocto/mickledore.rst:222
+#: ../../source/yocto/scarthgap.rst:222
+msgid "BSP Structure"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:242 ../../source/yocto/mickledore.rst:224
+#: ../../source/yocto/scarthgap.rst:224
+msgid ""
+"The BSP consists roughly of three parts. BSP management, BSP metadata, "
+"and BSP content. The management consists of *Repo* and phyLinux while the"
+" metadata depends on the SOC, which describes how to build the software. "
+"The content comprises PHYTEC's *Git* repositories and external sources."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:248 ../../source/yocto/mickledore.rst:230
+#: ../../source/yocto/scarthgap.rst:230
+msgid "BSP Management"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:250 ../../source/yocto/mickledore.rst:232
+#: ../../source/yocto/scarthgap.rst:232
+msgid ""
+"*Yocto* is an umbrella project. Naturally, this will force the user to "
+"base their work on several external repositories. They need to be managed"
+" in a deterministic way. We use manifest files, which contain an XML data"
+" structure, to describe all git repositories with pinned-down versions. "
+"The *Repo* tool and our phyLinux wrapper script are used to manage the "
+"manifests and set up the BSP, as described in the manifest file."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:258 ../../source/yocto/mickledore.rst:240
+#: ../../source/yocto/scarthgap.rst:240
+msgid "phyLinux"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:260 ../../source/yocto/mickledore.rst:242
+#: ../../source/yocto/scarthgap.rst:242
+msgid ""
+"phyLinux is a wrapper for *Repo* to handle downloading and setting up the"
+" BSP with an \"out of the box\" experience."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:264 ../../source/yocto/mickledore.rst:246
+#: ../../source/yocto/scarthgap.rst:246
+msgid "Repo"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:266 ../../source/yocto/mickledore.rst:248
+#: ../../source/yocto/scarthgap.rst:248
+msgid ""
+"*Repo* is a wrapper around the *Repo* toolset. The phyLinux script will "
+"install the wrapper in a global path. This is only a wrapper, though. "
+"Whenever you run ``repo init -u <url>``, you first download the *Repo* "
+"tools from *Googles* Git server in a specific version to the "
+"``.repo/repo`` directory. The next time you run *Repo*, all the commands "
+"will be available. Be aware that the *Repo* version in different build "
+"directories can differ over the years if you do not run *Repo sync*. Also"
+" if you store information for your archives, you need to include the "
+"complete ``.repo`` folder."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:275 ../../source/yocto/mickledore.rst:257
+#: ../../source/yocto/scarthgap.rst:257
+msgid ""
+"*Repo* expects a *Git* repository which will be parsed from the command "
+"line. In the PHYTEC BSP, it is called phy²octo. In this repository, all "
+"information about a software BSP release is stored in the form of a "
+"*Repo* XML manifest. This data structure defines URLs of *Git* servers "
+"(called \"remotes\") and *Git* repositories and their states (called "
+"\"projects\"). The *Git* repositories can be seen in different states. "
+"The revision field can be a branch, tag, or commit id of a repository. "
+"This means the state of the software is not necessarily unique and can "
+"change over time. That is the reason we use only tags or commit ids for "
+"our releases. The state of the working directory is then unique and does "
+"not change."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:286 ../../source/yocto/mickledore.rst:268
+#: ../../source/yocto/scarthgap.rst:268
+msgid ""
+"The manifests for the releases have the same name as the release itself. "
+"It is a unique identifier for the complete BSP. The releases are sorted "
+"by the SoC platform. The selected SoC will define the branch of the "
+"phy²octo *Git* repository which will be used for the manifest selection."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:292 ../../source/yocto/mickledore.rst:274
+#: ../../source/yocto/scarthgap.rst:274
+msgid "BSP Metadata"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:294 ../../source/yocto/mickledore.rst:276
+#: ../../source/yocto/scarthgap.rst:276
+msgid ""
+"We include several third-party layers in our BSP to get a complete "
+"*Linux* distribution up and running without the need to integrate "
+"external projects. All used repositories are described in the following "
+"section."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:301 ../../source/yocto/mickledore.rst:283
+#: ../../source/yocto/scarthgap.rst:283
+msgid ""
+"The PHYTEC BSP is built on top of *Poky*. It comes with a specific "
+"version, defined in the *Repo* manifest. *Poky* comes with a specific "
+"version of *Bitbake*. The OpenEmbedded-core layer \"meta\" is used as a "
+"base for our *Linux* system."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:307 ../../source/yocto/mickledore.rst:289
+#: ../../source/yocto/scarthgap.rst:289
+msgid "meta-openembedded"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:309 ../../source/yocto/mickledore.rst:291
+#: ../../source/yocto/scarthgap.rst:291
+msgid ""
+"OpenEmbedded is a collection of different layers containing the meta "
+"description for many open-source software projects. We ship all "
+"OpenEmbedded layers with our BSP, but not all of them are activated. Our "
+"example images pull several software packages generated from OpenEmbedded"
+" recipes."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:315 ../../source/yocto/mickledore.rst:297
+#: ../../source/yocto/scarthgap.rst:297
+msgid "meta-qt6"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:317 ../../source/yocto/mickledore.rst:299
+#: ../../source/yocto/scarthgap.rst:299
+msgid ""
+"This layer provides an integration of *Qt6* in the *Poky*-based root "
+"filesystem and is integrated into our BSP."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:321 ../../source/yocto/mickledore.rst:303
+#: ../../source/yocto/scarthgap.rst:303
+msgid "meta-nodejs"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:323 ../../source/yocto/mickledore.rst:305
+#: ../../source/yocto/scarthgap.rst:305
+msgid "This is an application layer to add recent Node.js versions."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:326 ../../source/yocto/mickledore.rst:308
+#: ../../source/yocto/scarthgap.rst:308
+msgid "meta-gstreamer1.0"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:328 ../../source/yocto/mickledore.rst:310
+#: ../../source/yocto/scarthgap.rst:310
+msgid "This is an application layer to add recent GStreamer versions."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:331 ../../source/yocto/mickledore.rst:313
+#: ../../source/yocto/scarthgap.rst:313
+msgid "meta-rauc"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:333 ../../source/yocto/mickledore.rst:315
+#: ../../source/yocto/scarthgap.rst:315
+msgid ""
+"This layer contains the tools required to build an updated infrastructure"
+" with `RAUC <https://rauc.readthedocs.io/en/latest/index.html>`_. A "
+"comparison with other update systems can be found here: `Yocto update "
+"tools <https://wiki.yoctoproject.org/wiki/System_Update>`_."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:339 ../../source/yocto/mickledore.rst:321
+#: ../../source/yocto/scarthgap.rst:321
+msgid "meta-phytec"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:341
+msgid ""
+"This layer contains all machines and common features for all our BSPs. It"
+" is PHYTEC's `Yocto Board Support Package "
+"<https://docs.yoctoproject.org/4.0.6/bsp-guide/index.html>`_ for all "
+"supported hardware (since *fido*) and is designed to be standalone with "
+"*Poky*. Only these two parts are required if you want to integrate the "
+"PHYTEC's hardware into your existing *Yocto* workflow. The features are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:348 ../../source/yocto/mickledore.rst:330
+#: ../../source/yocto/scarthgap.rst:330
+msgid "Bootloaders in ``recipes-bsp/barebox/`` and ``recipes-bsp/u-boot/``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:349 ../../source/yocto/mickledore.rst:331
+#: ../../source/yocto/scarthgap.rst:331
+msgid ""
+"Kernels in ``recipes-kernel/linux/`` and ``dynamic-layers/fsl-bsp-release"
+"/recipes-kernel/linux/``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:351 ../../source/yocto/mickledore.rst:333
+#: ../../source/yocto/scarthgap.rst:333
+msgid "Many machines in ``conf/machine/``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:352 ../../source/yocto/mickledore.rst:334
+#: ../../source/yocto/scarthgap.rst:334
+msgid ""
+"Proprietary *OpenGL ES/EGL* user space libraries for AM335x and i.MX 6 "
+"platforms"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:354 ../../source/yocto/mickledore.rst:336
+#: ../../source/yocto/scarthgap.rst:336
+msgid "Proprietary *OpenCL* libraries for i.MX 6 platforms"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:357 ../../source/yocto/mickledore.rst:339
+#: ../../source/yocto/scarthgap.rst:339
+msgid "meta-ampliphy"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:359 ../../source/yocto/mickledore.rst:341
+#: ../../source/yocto/scarthgap.rst:341
+msgid ""
+"This is our example distribution and BSP layer. It extends the basic "
+"configuration of *Poky* with software projects described by all the other"
+" BSP components. It provides a base for your specific development "
+"scenarios. The current features are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:364
+msgid ""
+"`systemd <https://www.freedesktop.org/wiki/Software/systemd//>`_ init "
+"system"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:365 ../../source/yocto/mickledore.rst:347
+#: ../../source/yocto/scarthgap.rst:347
+msgid "Images: ``phytec-headless-image`` for non-graphics applications"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:366 ../../source/yocto/mickledore.rst:348
+#: ../../source/yocto/scarthgap.rst:348
+msgid ""
+"Camera integration with OpenCV and GStreamer examples for the i.MX 6 "
+"platform bundled in a ``phytec-vision-image``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:368 ../../source/yocto/mickledore.rst:350
+#: ../../source/yocto/scarthgap.rst:350
+msgid ""
+"RAUC integration: we set up basic support for an A/B system image update,"
+" which is possible locally and over-the-air"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:372 ../../source/yocto/mickledore.rst:354
+#: ../../source/yocto/scarthgap.rst:354
+msgid "meta-qt6-phytec"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:374 ../../source/yocto/mickledore.rst:356
+#: ../../source/yocto/scarthgap.rst:356
+msgid ""
+"This is our layer for Qt6 board integration and examples. The features "
+"are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:376 ../../source/yocto/mickledore.rst:358
+#: ../../source/yocto/scarthgap.rst:358
+msgid ""
+"`Qt6 with eglfs backend <https://doc.qt.io/qt-5/embedded-linux.html>`_ "
+"for PHYTEC's AM335x, i.MX 6 and RK3288 platforms"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:378 ../../source/yocto/mickledore.rst:360
+#: ../../source/yocto/scarthgap.rst:360
+msgid "Images: ``phytec-qt6demo-image`` for *Qt6* and video applications"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:379 ../../source/yocto/mickledore.rst:361
+#: ../../source/yocto/scarthgap.rst:361
+msgid ""
+"A *Qt6* demo application demonstrating how to create a *Qt6* project "
+"using *QML* widgets and a *Bitbake* recipe for the *Yocto* and *systemd* "
+"integration. It can be found in ``sources/meta-qt6-phytec/recipes-"
+"qt/examples/phytec-qtdemo_git.bb``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:385 ../../source/yocto/mickledore.rst:367
+#: ../../source/yocto/scarthgap.rst:367
+msgid "meta-virtualization"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:387 ../../source/yocto/mickledore.rst:369
+#: ../../source/yocto/scarthgap.rst:369
+msgid ""
+"This layer provides support for building Xen, KVM, Libvirt, and "
+"associated packages necessary for constructing OE-based virtualized "
+"solutions."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:391 ../../source/yocto/mickledore.rst:373
+#: ../../source/yocto/scarthgap.rst:373
+msgid "meta-security"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:393 ../../source/yocto/mickledore.rst:375
+#: ../../source/yocto/scarthgap.rst:375
+msgid ""
+"This layer provides security tools, hardening tools for Linux kernels, "
+"and libraries for implementing security mechanisms."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:397 ../../source/yocto/mickledore.rst:379
+#: ../../source/yocto/scarthgap.rst:379
+msgid "meta-selinux"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:399 ../../source/yocto/mickledore.rst:381
+#: ../../source/yocto/scarthgap.rst:381
+msgid ""
+"This layer's purpose is to enable SE Linux support. The majority of this "
+"layer's work is accomplished in *bbappend* files, used to enable SE Linux"
+" support in existing recipes."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:404 ../../source/yocto/mickledore.rst:386
+#: ../../source/yocto/scarthgap.rst:386
+msgid "meta-browser"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:406 ../../source/yocto/mickledore.rst:388
+#: ../../source/yocto/scarthgap.rst:388
+msgid ""
+"This is an application layer to add recent web browsers (Chromium, "
+"Firefox, etc.)."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:410 ../../source/yocto/mickledore.rst:392
+#: ../../source/yocto/scarthgap.rst:392
+msgid "meta-rust"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:412 ../../source/yocto/mickledore.rst:394
+#: ../../source/yocto/scarthgap.rst:394
+msgid "Includes the Rust compiler and the Cargo package manager for Rust."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:415 ../../source/yocto/mickledore.rst:397
+#: ../../source/yocto/scarthgap.rst:397
+msgid "meta-timesys"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:417 ../../source/yocto/mickledore.rst:399
+#: ../../source/yocto/scarthgap.rst:399
+msgid ""
+"Timesys layer for Vigiles Yocto CVE monitoring, security notifications, "
+"and image manifest generation."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:421 ../../source/yocto/mickledore.rst:403
+#: ../../source/yocto/scarthgap.rst:403
+msgid "meta-freescale"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:423 ../../source/yocto/mickledore.rst:405
+#: ../../source/yocto/scarthgap.rst:405
+msgid ""
+"This layer provides support for the i.MX, Layerscape, and QorIQ product "
+"lines."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:427 ../../source/yocto/mickledore.rst:409
+#: ../../source/yocto/scarthgap.rst:409
+msgid "meta-freescale-3rdparty"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:429 ../../source/yocto/mickledore.rst:411
+#: ../../source/yocto/scarthgap.rst:411
+msgid "Provides support for boards from various vendors."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:432 ../../source/yocto/mickledore.rst:414
+#: ../../source/yocto/scarthgap.rst:414
+msgid "meta-freescale-distro"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:434 ../../source/yocto/mickledore.rst:416
+#: ../../source/yocto/scarthgap.rst:416
+msgid ""
+"This layer provides support for Freescale's Demonstration images for use "
+"with OpenEmbedded and/or Yocto Freescale's BSP layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:438 ../../source/yocto/mickledore.rst:420
+#: ../../source/yocto/scarthgap.rst:420
+msgid "base (fsl-community-bsp-base)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:440 ../../source/yocto/mickledore.rst:422
+#: ../../source/yocto/scarthgap.rst:422
+msgid "This layer provides BSP base files of NXP."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:443 ../../source/yocto/mickledore.rst:425
+#: ../../source/yocto/scarthgap.rst:425
+msgid "meta-fsl-bsp-release"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:445 ../../source/yocto/mickledore.rst:427
+#: ../../source/yocto/scarthgap.rst:427
+msgid "This is the i.MX Yocto Project Release Layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:448 ../../source/yocto/mickledore.rst:430
+#: ../../source/yocto/scarthgap.rst:430
+msgid "BSP Content"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:450
+msgid ""
+"The BSP content gets pulled from different online sources when you first "
+"start using *Bitbake*. All files will be downloaded and cloned in a local"
+" directory configured as ``DL_DIR`` in *Yocto*. If you backup your BSP "
+"with the complete content, those sources have to be backed up, too. How "
+"you can do this will be explained in the chapter :ref:`kirkstone_gen-"
+"source-mirrors`."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:457 ../../source/yocto/mickledore.rst:439
+#: ../../source/yocto/scarthgap.rst:439
+msgid "Build Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:459 ../../source/yocto/mickledore.rst:441
+#: ../../source/yocto/scarthgap.rst:441
+msgid ""
+"The BSP initializes a build folder that will contain all files you create"
+" by running *Bitbake* commands. It contains a ``conf`` folder that "
+"handles build input variables."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:463 ../../source/yocto/mickledore.rst:445
+#: ../../source/yocto/scarthgap.rst:445
+msgid "``bblayers.conf`` defines activated meta-layers,"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:464 ../../source/yocto/mickledore.rst:446
+#: ../../source/yocto/scarthgap.rst:446
+msgid "``local.conf`` defines build input variables specific to your build"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:465 ../../source/yocto/mickledore.rst:447
+#: ../../source/yocto/scarthgap.rst:447
+msgid ""
+"``site.conf`` defines build input variables specific to the development "
+"host"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:467 ../../source/yocto/mickledore.rst:449
+#: ../../source/yocto/scarthgap.rst:449
+msgid ""
+"The two topmost build input variables are ``DISTRO`` and ``MACHINE``. "
+"They are preconfigured ``local.conf`` when you check out the BSP using "
+"phyLinux."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:470 ../../source/yocto/mickledore.rst:452
+#: ../../source/yocto/scarthgap.rst:452
+msgid ""
+"We use \"*Ampliphy*\" as ``DISTRO`` with our BSP. This distribution will "
+"be preselected and give you a starting point for implementing your own "
+"configuration."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:474 ../../source/yocto/mickledore.rst:456
+#: ../../source/yocto/scarthgap.rst:456
+msgid ""
+"A ``MACHINE`` defines a binary image that supports specific hardware "
+"combinations of module and baseboard. Check the ``machine.conf`` file or "
+"our webpage for a description of the hardware."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:479 ../../source/yocto/mickledore.rst:461
+#: ../../source/yocto/scarthgap.rst:461
+msgid "Pre-built Images"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:481 ../../source/yocto/mickledore.rst:463
+#: ../../source/yocto/scarthgap.rst:463
+msgid ""
+"For each BSP we provide pre-built target images that can be downloaded "
+"from the PHYTEC FTP server: https://download.phytec.de/Software/Linux/"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:484 ../../source/yocto/mickledore.rst:466
+#: ../../source/yocto/scarthgap.rst:466
+msgid ""
+"These images are also used for the BSP tests, which are flashed to the "
+"boards during production. You can use the provided ``.wic`` images to "
+"create a bootable SD card at any time. Identify your hardware and flash "
+"the downloaded image file to an empty SD card using ``dd``. Please see "
+"section Images for information about the correct usage of the command."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:491 ../../source/yocto/mickledore.rst:473
+#: ../../source/yocto/scarthgap.rst:473
+msgid "BSP Workspace Installation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:494 ../../source/yocto/mickledore.rst:476
+#: ../../source/yocto/scarthgap.rst:476
+msgid "Setting Up the Host"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:496 ../../source/yocto/mickledore.rst:478
+#: ../../source/yocto/scarthgap.rst:478
+msgid ""
+"You can set up the host or use one of our build-container to run a Yocto "
+"build. You need to have a running *Linux* distribution. It should be "
+"running on a powerful machine since a lot of compiling will need to be "
+"done."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:500 ../../source/yocto/mickledore.rst:482
+#: ../../source/yocto/scarthgap.rst:482
+msgid ""
+"If you want to use a build-container, you only need to install following "
+"packages on your host"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:507
+msgid ""
+"Continue with the next step :ref:`kirkstone_git-config` after that. The "
+"documentation for using build-container can be found in this manual after"
+" :ref:`kirkstone_phylinux-advanced-usage` of phyLinux."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:511
+msgid ""
+"Else *Yocto* needs a handful of additional packages on your host. For "
+"*Ubuntu 20.04* you need"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:522
+msgid ""
+"For other distributions you can find information in the *Yocto* Quick "
+"Build: https://docs.yoctoproject.org/4.0.6/brief-"
+"yoctoprojectqs/index.html"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:528 ../../source/yocto/mickledore.rst:510
+#: ../../source/yocto/scarthgap.rst:510
+msgid "Git Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:530 ../../source/yocto/mickledore.rst:512
+#: ../../source/yocto/scarthgap.rst:512
+msgid ""
+"The BSP heavily utilizes *Git*. *Git* needs some information from you as "
+"a user to identify who made changes. Create a ``~/.gitconfig`` with the "
+"following content, if you do not have one"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:555 ../../source/yocto/mickledore.rst:537
+#: ../../source/yocto/scarthgap.rst:537
+msgid ""
+"You should set ``name`` and ``email`` in your *Git* configuration, "
+"otherwise, *Bitbake* will complain during the first build. You can use "
+"the two commands to set them directly without editing ``~/.gitconfig`` "
+"manually"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:565 ../../source/yocto/mickledore.rst:547
+#: ../../source/yocto/scarthgap.rst:547
+msgid "site.conf Setup"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:567 ../../source/yocto/mickledore.rst:549
+#: ../../source/yocto/scarthgap.rst:549
+msgid ""
+"Before starting the *Yocto* build, it is advisable to configure the "
+"development setup. Two things are most important: the download directory "
+"and the cache directory. PHYTEC strongly recommends configuring the setup"
+" as it will reduce the compile time of consequent builds."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:572 ../../source/yocto/mickledore.rst:554
+#: ../../source/yocto/scarthgap.rst:554
+msgid ""
+"A download directory is a place where *Yocto* stores all sources fetched "
+"from the internet. It can contain tar.gz, *Git* mirror, etc. It is very "
+"useful to set this to a common shared location on the machine. Create "
+"this directory with 777 access rights. To share this directory with "
+"different users, all files need to have group write access. This will "
+"most probably be in conflict with default *umask* settings. One possible "
+"solution would be to use ACLs for this directory"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:585 ../../source/yocto/mickledore.rst:567
+#: ../../source/yocto/scarthgap.rst:567
+msgid ""
+"If you have already created a download directory and want to fix the "
+"permissions afterward, you can do so with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:594 ../../source/yocto/mickledore.rst:576
+#: ../../source/yocto/scarthgap.rst:576
+msgid ""
+"The cache directory stores all stages of the build process. *Poky* has "
+"quite an involved caching infrastructure. It is advisable to create a "
+"shared directory, as all builds can access this cache directory, called "
+"the shared state cache."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:598
+msgid ""
+"Create the two directories on a drive where you have approximately 50 GB "
+"of space and assign the two variables in your ``build/conf/local.conf``"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:606 ../../source/yocto/mickledore.rst:586
+#: ../../source/yocto/scarthgap.rst:586
+msgid ""
+"If you want to know more about configuring your build, see the documented"
+" example settings"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:615 ../../source/yocto/mickledore.rst:595
+#: ../../source/yocto/scarthgap.rst:595
+msgid "phyLinux Documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:617 ../../source/yocto/mickledore.rst:597
+#: ../../source/yocto/scarthgap.rst:597
+msgid ""
+"The phyLinux script is a basic management tool for PHYTEC *Yocto* BSP "
+"releases written in *Python*. It is mainly a helper to get started with "
+"the BSP structure. You can get all the BSP sources without the need of "
+"interacting with *Repo* or *Git*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:622 ../../source/yocto/mickledore.rst:602
+#: ../../source/yocto/scarthgap.rst:602
+msgid ""
+"The phyLinux script has only one real dependency. It requires the *wget* "
+"tool installed on your host. It will also install the `Repo tool "
+"<https://source.android.com/docs/setup/download>`_ in a global path "
+"(/usr/local/bin) on your host PC. You can install it in a different "
+"location manually. *Repo* will be automatically detected by phyLinux if "
+"it is found in the PATH. The *Repo* tool will be used to manage the "
+"different *Git* repositories of the *Yocto* BSP."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:631 ../../source/yocto/mickledore.rst:611
+#: ../../source/yocto/scarthgap.rst:611
+msgid "Get phyLinux"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:633 ../../source/yocto/mickledore.rst:613
+#: ../../source/yocto/scarthgap.rst:613
+msgid ""
+"The phyLinux script can be found on the PHYTEC download server: "
+"https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:637 ../../source/yocto/mickledore.rst:617
+#: ../../source/yocto/scarthgap.rst:617
+msgid "Basic Usage"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:639 ../../source/yocto/mickledore.rst:619
+#: ../../source/yocto/scarthgap.rst:619
+msgid "For the basic usage of phyLinux, type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:645 ../../source/yocto/mickledore.rst:625
+#: ../../source/yocto/scarthgap.rst:625
+msgid "which will result in"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:667 ../../source/yocto/mickledore.rst:647
+#: ../../source/yocto/scarthgap.rst:647
+msgid "Initialization"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:669 ../../source/yocto/mickledore.rst:649
+#: ../../source/yocto/scarthgap.rst:649
+msgid "Create a fresh project folder"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:675 ../../source/yocto/mickledore.rst:655
+#: ../../source/yocto/scarthgap.rst:655
+msgid ""
+"Calling phyLinux will use the default Python version. Starting with "
+"Ubuntu 20.04 it will be Python3. If you want to initiate a BSP, which is "
+"not compatible with Python3, you need to set Python2 as default "
+"(temporarily) before running phyLinux"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:684 ../../source/yocto/mickledore.rst:664
+#: ../../source/yocto/scarthgap.rst:664
+msgid "Now run phyLinux from the new folder"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:690 ../../source/yocto/mickledore.rst:670
+#: ../../source/yocto/scarthgap.rst:670
+msgid ""
+"A clean folder is important because phyLinux will clean its working "
+"directory. Calling phyLinux from a directory that isn't empty will result"
+" in the following **warning**::"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:702 ../../source/yocto/mickledore.rst:682
+#: ../../source/yocto/scarthgap.rst:682
+msgid ""
+"On the first initialization, the phyLinux script will ask you to install "
+"the *Repo* tool in your */usr/local/bin* directory. During the execution "
+"of the *init* command, you need to choose your processor platform (SoC), "
+"PHYTEC's BSP release number, and the hardware you are working on"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:817 ../../source/yocto/mickledore.rst:765
+#: ../../source/yocto/scarthgap.rst:775
+msgid ""
+"If you cannot identify your board with the information given in the "
+"selector, have a look at the invoice for the product. After the "
+"configuration is done, you can always run"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:834 ../../source/yocto/mickledore.rst:783
+#: ../../source/yocto/scarthgap.rst:792
+msgid ""
+"to see which SoC and Release are selected in the current workspace. If "
+"you do not want to use the selector, phyLinux also supports command-line "
+"arguments for several settings"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:842 ../../source/yocto/mickledore.rst:791
+#: ../../source/yocto/scarthgap.rst:800
+msgid "or view the help command for more information"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:861 ../../source/yocto/mickledore.rst:810
+#: ../../source/yocto/scarthgap.rst:819
+msgid ""
+"After the execution of the *init* command, phyLinux will print a few "
+"important notes as well as information for the next steps in the build "
+"process."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:867 ../../source/yocto/mickledore.rst:816
+#: ../../source/yocto/scarthgap.rst:825
+msgid "Advanced Usage"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:869 ../../source/yocto/mickledore.rst:818
+#: ../../source/yocto/scarthgap.rst:827
+msgid ""
+"phyLinux can be used to transport software states over any medium. The "
+"state of the software is uniquely identified by *manifest.xml*. You can "
+"create a manifest, send it to another place and recover the software "
+"state with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:877 ../../source/yocto/mickledore.rst:826
+#: ../../source/yocto/scarthgap.rst:835
+msgid ""
+"You can also create a *Git* repository containing your software states. "
+"The *Git* repository needs to have branches other than master, as we "
+"reserved the master branch for different usage. Use phyLinux to check out"
+" the states"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:886 ../../source/yocto/mickledore.rst:835
+#: ../../source/yocto/scarthgap.rst:844
+msgid "Using build-container"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:889 ../../source/yocto/mickledore.rst:838
+#: ../../source/yocto/scarthgap.rst:847
+msgid ""
+"Currently, it is not possible to run the phyLinux script inside of a "
+"container. After a complete init with the phyLinux script on your host "
+"machine, you can use a container for the build. If you do not have "
+"phyLinux script running on your machine, please see phyLinux "
+"Documentation."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:893 ../../source/yocto/mickledore.rst:842
+#: ../../source/yocto/scarthgap.rst:851
+msgid ""
+"There are various possibilities to run a build-container. Commonly used "
+"is docker and podman, though we prefer podman as it does not need root "
+"privileges to run."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:898 ../../source/yocto/mickledore.rst:847
+#: ../../source/yocto/scarthgap.rst:856
+msgid "Installation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:900 ../../source/yocto/mickledore.rst:849
+#: ../../source/yocto/scarthgap.rst:858
+msgid ""
+"How to install podman: https://podman.io How to install docker: "
+"https://docs.docker.com/engine/install/"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:904 ../../source/yocto/mickledore.rst:853
+#: ../../source/yocto/scarthgap.rst:862
+msgid "Available container"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:906 ../../source/yocto/mickledore.rst:855
+#: ../../source/yocto/scarthgap.rst:864
+msgid ""
+"Right now we provide 4 different container based on Ubuntu LTS versions: "
+"https://hub.docker.com/u/phybuilder"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:909 ../../source/yocto/mickledore.rst:858
+#: ../../source/yocto/scarthgap.rst:867
+msgid "yocto-ubuntu-16.04"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:910 ../../source/yocto/mickledore.rst:859
+#: ../../source/yocto/scarthgap.rst:868
+msgid "yocto-ubuntu-18.04"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:911 ../../source/yocto/mickledore.rst:860
+#: ../../source/yocto/scarthgap.rst:869
+msgid "yocto-ubuntu-20.04"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:912 ../../source/yocto/mickledore.rst:861
+#: ../../source/yocto/scarthgap.rst:870
+msgid "yocto-ubuntu-22.04"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:914 ../../source/yocto/mickledore.rst:863
+#: ../../source/yocto/scarthgap.rst:872
+msgid ""
+"These containers can be run with podman or docker. With Yocto Project "
+"branch |yocto-codename| the container \"yocto-ubuntu-20.04\" is "
+"preferred."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:917 ../../source/yocto/mickledore.rst:866
+#: ../../source/yocto/scarthgap.rst:875
+msgid "Download/Pull container"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:927 ../../source/yocto/mickledore.rst:876
+#: ../../source/yocto/scarthgap.rst:885
+msgid ""
+"By adding a tag at the end separated by a colon, you can also pull or run"
+" a special tagged container."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:929 ../../source/yocto/mickledore.rst:878
+#: ../../source/yocto/scarthgap.rst:887
+msgid "podman pull docker.io/phybuilder/yocto-ubuntu-20.04:phy2"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:931 ../../source/yocto/mickledore.rst:880
+#: ../../source/yocto/scarthgap.rst:889
+msgid "You can find all available tags in our duckerhub space:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:933 ../../source/yocto/mickledore.rst:882
+#: ../../source/yocto/scarthgap.rst:891
+msgid "https://hub.docker.com/r/phybuilder/yocto-ubuntu-16.04/tags"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:934 ../../source/yocto/mickledore.rst:883
+#: ../../source/yocto/scarthgap.rst:892
+msgid "https://hub.docker.com/r/phybuilder/yocto-ubuntu-18.04/tags"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:935 ../../source/yocto/mickledore.rst:884
+#: ../../source/yocto/scarthgap.rst:893
+msgid "https://hub.docker.com/r/phybuilder/yocto-ubuntu-20.04/tags"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:936 ../../source/yocto/mickledore.rst:885
+#: ../../source/yocto/scarthgap.rst:894
+msgid "https://hub.docker.com/r/phybuilder/yocto-ubuntu-22.04/tags"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:938 ../../source/yocto/mickledore.rst:887
+#: ../../source/yocto/scarthgap.rst:896
+msgid ""
+"If you try to run a container, which is not pulled/downloaded, it will be"
+" pulled/downloaded automatically."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:940 ../../source/yocto/mickledore.rst:889
+#: ../../source/yocto/scarthgap.rst:898
+msgid "You can have a look at all downloaded/pulled container with:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:958 ../../source/yocto/mickledore.rst:907
+#: ../../source/yocto/scarthgap.rst:916
+msgid "Run container"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:960 ../../source/yocto/mickledore.rst:909
+#: ../../source/yocto/scarthgap.rst:918
+msgid ""
+"To run and use container for a Yocto build, first enter to your folder, "
+"where you run phyLinux init before. Then start the container"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:968 ../../source/yocto/mickledore.rst:917
+#: ../../source/yocto/scarthgap.rst:926
+msgid ""
+"To run and use a container with docker, it is not that simple like with "
+"podman. Therefore the container-user has to be defined and configured. "
+"Furthermore forwarding of credentials is not given per default and has to"
+" be configured as well."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:972 ../../source/yocto/mickledore.rst:921
+#: ../../source/yocto/scarthgap.rst:930
+msgid ""
+"Now your commandline should look something like that (where $USERNAME is "
+"the user, who called \"podman run\" and the char/number code diffs every "
+"time a container is started)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:981 ../../source/yocto/mickledore.rst:930
+#: ../../source/yocto/scarthgap.rst:939
+msgid ""
+"If the given username is \"root\" you will not be able to run bitbake at "
+"all. Please be sure, you run the container with your own user."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:984 ../../source/yocto/mickledore.rst:933
+#: ../../source/yocto/scarthgap.rst:942
+msgid ""
+"Now you are ready to go on and starting the build. To stop/close the "
+"container, just call"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:992 ../../source/yocto/mickledore.rst:941
+#: ../../source/yocto/scarthgap.rst:950
+msgid "Working with Poky and Bitbake"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:995 ../../source/yocto/mickledore.rst:944
+#: ../../source/yocto/scarthgap.rst:953
+msgid "Start the Build"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:997 ../../source/yocto/mickledore.rst:946
+#: ../../source/yocto/scarthgap.rst:955
+msgid ""
+"After you download all the metadata with phyLinux init, you have to set "
+"up the shell environment variables. This needs to be done every time you "
+"open a new shell for starting builds. We use the shell script provided by"
+" *Poky* in its default configuration. From the root of your project "
+"directory type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1006 ../../source/yocto/mickledore.rst:955
+#: ../../source/yocto/scarthgap.rst:964
+msgid "The abbreviation for the source command is a single dot"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1012 ../../source/yocto/mickledore.rst:961
+#: ../../source/yocto/scarthgap.rst:970
+msgid ""
+"The current working directory of the shell should change to *build/*. "
+"Before building for the first time, you should take a look at the main "
+"configuration file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1020 ../../source/yocto/mickledore.rst:969
+#: ../../source/yocto/scarthgap.rst:978
+msgid ""
+"Your local modifications for the current build are stored here. Depending"
+" on the SoC, you might need to accept license agreements. For example, to"
+" build the image for Freescale/NXP processors you need to accept the GPU "
+"and VPU binary license agreements. You have to uncomment the "
+"corresponding line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1030 ../../source/yocto/mickledore.rst:979
+#: ../../source/yocto/scarthgap.rst:988
+msgid ""
+"Now you are ready to build your first image. We suggest starting with our"
+" smaller non-graphical image *phytec-headless-image* to see if everything"
+" is working correctly"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1038 ../../source/yocto/mickledore.rst:987
+#: ../../source/yocto/scarthgap.rst:996
+msgid ""
+"The first compile process takes about 40 minutes on a modern Intel Core "
+"i7. All subsequent builds will use the filled caches and should take "
+"about 3 minutes."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1042 ../../source/yocto/mickledore.rst:991
+#: ../../source/yocto/scarthgap.rst:1000
+msgid "Images images"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1044 ../../source/yocto/mickledore.rst:993
+#: ../../source/yocto/scarthgap.rst:1002
+msgid "If everything worked, the images can be found under"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1050 ../../source/yocto/mickledore.rst:999
+#: ../../source/yocto/scarthgap.rst:1008
+msgid ""
+"The easiest way to test your image is to configure your board for SD card"
+" boot and to flash the build image to the SD card"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1057 ../../source/yocto/mickledore.rst:1006
+#: ../../source/yocto/scarthgap.rst:1015
+msgid ""
+"Here <your_device> could be \"sde\", for example, depending on your "
+"system. Be very careful when selecting the right drive! Selecting the "
+"wrong drive can erase your hard drive! The parameter conv=fsync forces a "
+"data buffer to write to the device before dd returns."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1062 ../../source/yocto/mickledore.rst:1011
+#: ../../source/yocto/scarthgap.rst:1020
+msgid ""
+"After booting you can log in using a serial cable or over *ssh*. There is"
+" no root password. That is because of the debug settings in "
+"*conf/local.conf*. If you uncomment the line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1070 ../../source/yocto/mickledore.rst:1019
+#: ../../source/yocto/scarthgap.rst:1028
+msgid ""
+"the debug settings, like setting an empty root password, will not be "
+"applied."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1073 ../../source/yocto/mickledore.rst:1022
+#: ../../source/yocto/scarthgap.rst:1031
+msgid "Accessing the Development States between Releases"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1075 ../../source/yocto/mickledore.rst:1024
+msgid ""
+"Special release manifests exist to give you access to the current "
+"development states of the *Yocto* BSP. They will not be displayed in the "
+"phyLinux selection menu but need to be selected manually. This can be "
+"done using the following command line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1084 ../../source/yocto/mickledore.rst:1033
+msgid ""
+"This will initialize a BSP that will track the latest development state. "
+"From now on running"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1091 ../../source/yocto/mickledore.rst:1040
+msgid "this folder will pull all the latest changes from our Git repositories."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1094 ../../source/yocto/mickledore.rst:1043
+#: ../../source/yocto/scarthgap.rst:1044
+msgid "Inspect your Build Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1096 ../../source/yocto/mickledore.rst:1045
+#: ../../source/yocto/scarthgap.rst:1046
+msgid ""
+"*Poky* includes several tools to inspect your build layout. You can "
+"inspect the commands of the layer tool"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1103 ../../source/yocto/mickledore.rst:1052
+#: ../../source/yocto/scarthgap.rst:1053
+msgid ""
+"It can, for example, be used to view in which layer a specific recipe "
+"gets modified"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1110 ../../source/yocto/mickledore.rst:1059
+#: ../../source/yocto/scarthgap.rst:1060
+msgid ""
+"Before running a build you can also launch *Toaster* to be able to "
+"inspect the build details with the Toaster web GUI"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1117 ../../source/yocto/mickledore.rst:1066
+#: ../../source/yocto/scarthgap.rst:1067
+msgid "Maybe you need to install some requirements, first"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1124
+msgid ""
+"You can then point your browser to *http://0.0.0.0:8000/* and continue "
+"working with *Bitbake*. All build activity can be monitored and analyzed "
+"from this web server. If you want to learn more about *Toaster*, look at "
+"https://docs.yoctoproject.org/4.0.6/toaster-manual/index.html. To shut "
+"down the *Toaster* web GUI again, execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1135 ../../source/yocto/mickledore.rst:1084
+#: ../../source/yocto/scarthgap.rst:1085
+msgid "BSP Features of meta-phytec and meta-ampliphy"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1138 ../../source/yocto/mickledore.rst:1087
+#: ../../source/yocto/scarthgap.rst:1088
+msgid "*Buildinfo*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1140 ../../source/yocto/mickledore.rst:1089
+#: ../../source/yocto/scarthgap.rst:1090
+msgid ""
+"The *buildinfo* task is a feature in our recipes that prints instructions"
+" to fetch the source code from the public repositories. So you do not "
+"have to look into the recipes yourself. To see the instructions, e.g. for"
+" the *barebox* package, execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1149 ../../source/yocto/mickledore.rst:1098
+#: ../../source/yocto/scarthgap.rst:1099
+msgid "in your shell. This will print something like"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1194 ../../source/yocto/mickledore.rst:1143
+#: ../../source/yocto/scarthgap.rst:1144
+msgid "As you can see, everything is explained in the output."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1198 ../../source/yocto/mickledore.rst:1147
+#: ../../source/yocto/scarthgap.rst:1148
+msgid ""
+"Using *externalsrc* breaks a lot of *Yocto's* internal dependency "
+"mechanisms. It is not guaranteed that any changes to the source directory"
+" are automatically picked up by the build process and incorporated into "
+"the root filesystem or SD card image. You have to always use *--force*. "
+"E.g. to compile *barebox* and redeploy it to *deploy/images/<machine>* "
+"execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1210 ../../source/yocto/mickledore.rst:1159
+#: ../../source/yocto/scarthgap.rst:1160
+msgid ""
+"To update the SD card image with a new kernel or image first force the "
+"compilation of it and then force a rebuild of the root filesystem. Use"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1217 ../../source/yocto/mickledore.rst:1166
+#: ../../source/yocto/scarthgap.rst:1167
+msgid ""
+"Note that the build system is not modifying the external source "
+"directory. If you want to apply all patches the *Yocto* recipe is "
+"carrying to the external source directory, run the line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1226 ../../source/yocto/mickledore.rst:1175
+#: ../../source/yocto/scarthgap.rst:1176
+msgid "BSP Customization"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1228 ../../source/yocto/mickledore.rst:1177
+#: ../../source/yocto/scarthgap.rst:1178
+msgid ""
+"To get you started with the BSP, we have summarized some basic tasks from"
+" the *Yocto* official documentation. It describes how to add additional "
+"software to the image, change the kernel and bootloader configuration, "
+"and integrate patches for the kernel and bootloader."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1233 ../../source/yocto/mickledore.rst:1182
+#: ../../source/yocto/scarthgap.rst:1183
+msgid ""
+"Minor modifications, such as adding software, are done in the file "
+"*build/conf/local.conf*. There you can overwrite global configuration "
+"variables and make small modifications to recipes."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1237 ../../source/yocto/mickledore.rst:1186
+#: ../../source/yocto/scarthgap.rst:1187
+msgid "There are 2 ways to make major changes:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1239 ../../source/yocto/mickledore.rst:1188
+#: ../../source/yocto/scarthgap.rst:1189
+msgid "Either create your own layer and use *bbappend* files."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1240 ../../source/yocto/mickledore.rst:1189
+#: ../../source/yocto/scarthgap.rst:1190
+msgid "Add everything to PHYTEC's Distro layer *meta-ampliphy*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1242 ../../source/yocto/mickledore.rst:1191
+#: ../../source/yocto/scarthgap.rst:1192
+msgid "Creating your own layer is described in the section Create your own Layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1245 ../../source/yocto/mickledore.rst:1194
+#: ../../source/yocto/scarthgap.rst:1195
+msgid "Disable Qt Demo"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1247 ../../source/yocto/mickledore.rst:1196
+#: ../../source/yocto/scarthgap.rst:1197
+msgid ""
+"By default, the BSP image *phytec-qt6demo-image* starts a Qt6 Demo "
+"application on the attached display or monitor. If you want to stop the "
+"demo and use the *Linux* framebuffer console behind it, connect to the "
+"target via serial cable or *ssh* and execute the shell command"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1256 ../../source/yocto/mickledore.rst:1205
+#: ../../source/yocto/scarthgap.rst:1206
+msgid ""
+"This command stops the demo temporarily. To start it again, reboot the "
+"board or execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1263 ../../source/yocto/mickledore.rst:1212
+#: ../../source/yocto/scarthgap.rst:1213
+msgid "You can disable the service permanently, so it does not start on boot"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1271 ../../source/yocto/mickledore.rst:1220
+#: ../../source/yocto/scarthgap.rst:1221
+msgid ""
+"The last command only disables the service. It does not *stop* "
+"immediately. To see the current status execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1278 ../../source/yocto/mickledore.rst:1227
+#: ../../source/yocto/scarthgap.rst:1228
+msgid ""
+"If you want to disable the service by default, edit the file "
+"*build/conf/local.conf* and add the following line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1286 ../../source/yocto/mickledore.rst:1235
+#: ../../source/yocto/scarthgap.rst:1236
+msgid "After that, rebuild the image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1293 ../../source/yocto/mickledore.rst:1242
+#: ../../source/yocto/scarthgap.rst:1243
+msgid "Framebuffer Console"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1295 ../../source/yocto/mickledore.rst:1244
+#: ../../source/yocto/scarthgap.rst:1245
+msgid ""
+"On boards with a display interface, the framebuffer console is enabled "
+"per default. You can attach a USB keyboard and log in. To change the "
+"keyboard layout from the English default to German, type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1303 ../../source/yocto/mickledore.rst:1252
+#: ../../source/yocto/scarthgap.rst:1253
+msgid "To detach the framebuffer console, run"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1309 ../../source/yocto/mickledore.rst:1258
+#: ../../source/yocto/scarthgap.rst:1259
+msgid ""
+"To completely deactivate the framebuffer console, disable the following "
+"kernel configuration option"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1316 ../../source/yocto/mickledore.rst:1265
+#: ../../source/yocto/scarthgap.rst:1266
+msgid ""
+"More information can be found at: "
+"https://www.kernel.org/doc/Documentation/fb/fbcon.txt"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1320 ../../source/yocto/mickledore.rst:1269
+#: ../../source/yocto/scarthgap.rst:1270
+msgid "Tools Provided in the Prebuild Image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1323 ../../source/yocto/mickledore.rst:1272
+#: ../../source/yocto/scarthgap.rst:1273
+msgid "RAM Benchmark"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1325 ../../source/yocto/mickledore.rst:1274
+#: ../../source/yocto/scarthgap.rst:1275
+msgid ""
+"Performing RAM and cache performance tests can best be done by using "
+"*pmbw* (Parallel Memory Bandwidth Benchmark/Measurement Tool). *Pmbw* "
+"runs several assembly routines which all use different access patterns to"
+" the caches and RAM of the SoC. Before running the test, make sure that "
+"you have about 2 MiB of space left on the device for the log files. We "
+"also lower the level of the benchmark to ask the kernel more aggressively"
+" for resources. The benchmark test will take several hours."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1333 ../../source/yocto/mickledore.rst:1282
+#: ../../source/yocto/scarthgap.rst:1283
+msgid "To start the test type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1339 ../../source/yocto/mickledore.rst:1288
+#: ../../source/yocto/scarthgap.rst:1289
+msgid ""
+"Upon completion of the test run, the log file can be converted to a "
+"*gnuplot* script with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1346 ../../source/yocto/mickledore.rst:1295
+#: ../../source/yocto/scarthgap.rst:1296
+msgid ""
+"Now you can transfer the file to the host machine and install any version"
+" of *gnuplot*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1353 ../../source/yocto/mickledore.rst:1302
+#: ../../source/yocto/scarthgap.rst:1303
+msgid ""
+"The generated *plots-<machine>.pdf* file contains all plots. To render "
+"single plots as *png* files for any web output you can use *Ghostscript*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1362 ../../source/yocto/mickledore.rst:1311
+#: ../../source/yocto/scarthgap.rst:1312
+msgid "Add Additional Software for the BSP Image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1364
+msgid ""
+"To add additional software to the image, look at the OpenEmbedded layer "
+"index: "
+"https://layers.openembedded.org/layerindex/branch/kirkstone/layers/"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1367 ../../source/yocto/mickledore.rst:1316
+#: ../../source/yocto/scarthgap.rst:1317
+msgid ""
+"First, select the *Yocto* version of the BSP you have from the drop-down "
+"list in the top left corner and click **Recipes**. Now you can search for"
+" a software project name and find which layer it is in. In some cases, "
+"the program is in *meta-openembedded*, *openembedded-core*, or *Poky* "
+"which means that the recipe is already in your build tree. This section "
+"describes how to add additional software when this is the case. If the "
+"package is in another layer, see the next section."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1375 ../../source/yocto/mickledore.rst:1324
+#: ../../source/yocto/scarthgap.rst:1325
+msgid "You can also search the list of available recipes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1382 ../../source/yocto/mickledore.rst:1331
+#: ../../source/yocto/scarthgap.rst:1332
+msgid ""
+"When the recipe for the program is already in the *Yocto* build, you can "
+"simply add it by appending a configuration option to your file "
+"*build/conf/local.conf*. The general syntax to add additional software to"
+" an image is"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1391 ../../source/yocto/mickledore.rst:1340
+#: ../../source/yocto/scarthgap.rst:1341
+msgid "For example, the line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1398 ../../source/yocto/mickledore.rst:1347
+#: ../../source/yocto/scarthgap.rst:1348
+msgid "installs some helper programs on the target image."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1402 ../../source/yocto/mickledore.rst:1351
+#: ../../source/yocto/scarthgap.rst:1352
+msgid "The leading whitespace is essential for the append command."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1404 ../../source/yocto/mickledore.rst:1353
+#: ../../source/yocto/scarthgap.rst:1354
+msgid ""
+"All configuration options in local.conf apply to all images. "
+"Consequently, the tools are now included in both images phytec-headless-"
+"image and phytec-qt6demo-image."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1409 ../../source/yocto/mickledore.rst:1358
+#: ../../source/yocto/scarthgap.rst:1359
+msgid "Notes about Packages and Recipes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1411 ../../source/yocto/mickledore.rst:1360
+#: ../../source/yocto/scarthgap.rst:1361
+msgid ""
+"You are adding packages to the IMAGE_INSTALL variable. Those are not "
+"necessarily equivalent to the recipes in your meta-layers. A recipe "
+"defines per default a package with the same name. But a recipe can set "
+"the PACKAGES variable to something different and is able to generate "
+"packages with arbitrary names. Whenever you look for software, you have "
+"to search for the package name and, strictly speaking, not for the "
+"recipe. In the worst case, you have to look at all PACKAGES variables. A "
+"tool such as *Toaster* can be helpful in some cases."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1419 ../../source/yocto/mickledore.rst:1368
+#: ../../source/yocto/scarthgap.rst:1369
+msgid ""
+"If you can not find your software in the layers provided in the folder "
+"*sources*, see the next section to include another layer into the *Yocto*"
+" build."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1423
+msgid ""
+"References: `Yocto 4.0.6 Documentation - Customizing Yocto builds "
+"<https://docs.yoctoproject.org/4.0.6/singleindex.html#user-"
+"configuration>`_"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1427 ../../source/yocto/mickledore.rst:1376
+#: ../../source/yocto/scarthgap.rst:1377
+msgid "Add an Additional Layer"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1429
+msgid ""
+"This is a step-by-step guide on how to add another layer to your *Yocto* "
+"build and install additional software from it. As an example, we include "
+"the network security scanner *nmap* in the layer *meta-security*. First, "
+"you must locate the layer on which the software is hosted. Check out the "
+"`OpenEmbedded MetaData Index "
+"<https://layers.openembedded.org/layerindex/branch/kirkstone/layers/>`_ "
+"and guess a little bit. The network scanner *nmap* is in the *meta-"
+"security* layer. See `meta-security on layers.openembedded.org "
+"<https://layers.openembedded.org/layerindex/branch/kirkstone/layer/meta-"
+"security/>`_. To integrate it into the *Yocto* build, you have to check "
+"out the repository and then switch to the correct stable branch. Since "
+"the BSP is based on the *Yocto* 'sumo' build, you should try to use the "
+"'sumo' branch in the layer, too."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1448 ../../source/yocto/mickledore.rst:1397
+msgid ""
+"All available remote branches will show up. Usually there should be "
+"'fido', 'jethro', 'krogoth', 'master', ..."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1455 ../../source/yocto/mickledore.rst:1404
+#: ../../source/yocto/scarthgap.rst:1405
+msgid ""
+"Now we add the directory of the layer to the file "
+"*build/conf/bblayers.conf* by appending the line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1463 ../../source/yocto/mickledore.rst:1412
+#: ../../source/yocto/scarthgap.rst:1413
+msgid ""
+"to the end of the file. After that, you can check if the layer is "
+"available in the build configuration by executing"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1470 ../../source/yocto/mickledore.rst:1419
+#: ../../source/yocto/scarthgap.rst:1420
+msgid "If there is an error like"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1476 ../../source/yocto/mickledore.rst:1425
+#: ../../source/yocto/scarthgap.rst:1426
+msgid ""
+"the layer that you want to add (here *meta-security*), depends on another"
+" layer, which you need to enable first. E.g. the dependency required here"
+" is a layer in *meta-openembedded* (in the PHYTEC BSP it is in the path "
+"*sources/meta-openembedded/meta-perl/*). To enable it, add the following "
+"line to *build/conf/bblayers.conf*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1487 ../../source/yocto/mickledore.rst:1436
+#: ../../source/yocto/scarthgap.rst:1437
+msgid ""
+"Now the command *bitbake-layers show-layers* should print a list of all "
+"layers enabled including *meta-security* and *meta-perl*. After the layer"
+" is included, you can install additional software from it as already "
+"described above. The easiest way is to add the following line (here is "
+"the package *nmap*)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1497 ../../source/yocto/mickledore.rst:1446
+#: ../../source/yocto/scarthgap.rst:1447
+msgid "to your *build/conf/local.conf*. Do not forget to rebuild the image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1504 ../../source/yocto/mickledore.rst:1453
+#: ../../source/yocto/scarthgap.rst:1454
+msgid "Create your own Layer create layer"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1506 ../../source/yocto/mickledore.rst:1455
+#: ../../source/yocto/scarthgap.rst:1456
+msgid ""
+"Creating your layer should be one of the first tasks when customizing the"
+" BSP. You have two basic options. You can either copy and rename our "
+"*meta-ampliphy*, or you can create a new layer that will contain your "
+"changes. The better option depends on your use case. *meta-ampliphy* is "
+"our example of how to create a custom *Linux* distribution that will be "
+"updated in the future. If you want to benefit from those changes and are,"
+" in general, satisfied with the userspace configuration, it could be the "
+"best solution to create your own layer on top of *Ampliphy*. If you need "
+"to rework a lot of information and only need the basic hardware support "
+"from PHYTEC, it would be better to copy *meta-ampliphy*, rename it, and "
+"adapt it to your needs. You can also have a look at the OpenEmbedded "
+"layer index to find different distribution layers. If you just need to "
+"add your own application to the image, create your own layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1519 ../../source/yocto/mickledore.rst:1468
+#: ../../source/yocto/scarthgap.rst:1469
+msgid ""
+"In the following chapter, we have an embedded project called \"racer\" "
+"which we will implement using our *Ampliphy Linux* distribution. First, "
+"we need to create a new layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1523 ../../source/yocto/mickledore.rst:1472
+#: ../../source/yocto/scarthgap.rst:1473
+msgid ""
+"*Yocto* provides a script for that. If you set up the BSP and the shell "
+"is ready, type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1530 ../../source/yocto/mickledore.rst:1479
+#: ../../source/yocto/scarthgap.rst:1480
+msgid "Default options are fine for now. Move the layer to the source directory"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1536 ../../source/yocto/mickledore.rst:1485
+#: ../../source/yocto/scarthgap.rst:1486
+msgid "Create a *Git* repository in this layer to track your changes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1543 ../../source/yocto/mickledore.rst:1492
+#: ../../source/yocto/scarthgap.rst:1493
+msgid "Now you can add the layer directly to your build/conf/bblayers.conf"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1549 ../../source/yocto/mickledore.rst:1498
+#: ../../source/yocto/scarthgap.rst:1499
+msgid "or with a script provided by *Yocto*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1556 ../../source/yocto/mickledore.rst:1505
+#: ../../source/yocto/scarthgap.rst:1506
+msgid "Kernel and Bootloader Recipe and Version"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1558 ../../source/yocto/mickledore.rst:1507
+#: ../../source/yocto/scarthgap.rst:1508
+msgid ""
+"First, you need to know which kernel and version are used for your target"
+" machine. PHYTEC provides multiple kernel recipes *linux-mainline*, "
+"*linux-ti* and *linux-imx*. The first one provides support for PHYTEC's "
+"i.MX 6 and AM335x modules and is based on the *Linux* kernel stable "
+"releases from `kernel.org <https://kernel.org/>`_. The *Git* repositories"
+" URLs are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1565 ../../source/yocto/mickledore.rst:1514
+#: ../../source/yocto/scarthgap.rst:1515
+msgid "*linux-mainline*: git://git.phytec.de/linux-mainline"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1566 ../../source/yocto/mickledore.rst:1515
+#: ../../source/yocto/scarthgap.rst:1516
+msgid "*linux-ti*: git://git.phytec.de/linux-ti"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1567 ../../source/yocto/mickledore.rst:1516
+#: ../../source/yocto/scarthgap.rst:1517
+msgid "*linux-imx:* git://git.phytec.de/linux-imx"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1568 ../../source/yocto/mickledore.rst:1517
+#: ../../source/yocto/scarthgap.rst:1518
+msgid "*barebox*: git://git.phytec.de/barebox"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1569 ../../source/yocto/mickledore.rst:1518
+#: ../../source/yocto/scarthgap.rst:1519
+msgid "*u-boot-imx*: git://git.phytec.de/u-boot-imx"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1571 ../../source/yocto/mickledore.rst:1520
+#: ../../source/yocto/scarthgap.rst:1521
+msgid "To find your kernel provider, execute the following command"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1577 ../../source/yocto/mickledore.rst:1526
+#: ../../source/yocto/scarthgap.rst:1527
+msgid ""
+"The command prints the value of the variable "
+"*PREFERRED_PROVIDER_virtual/kernel*. The variable is used in the internal"
+" *Yocto* build process to select the kernel recipe to use. The following "
+"lines are different outputs you might see"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1588 ../../source/yocto/mickledore.rst:1537
+#: ../../source/yocto/scarthgap.rst:1538
+msgid "To see which version is used, execute *bitbake -s*. For example"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1594 ../../source/yocto/mickledore.rst:1543
+#: ../../source/yocto/scarthgap.rst:1544
+msgid ""
+"The parameter *-s* prints the version of all recipes. The output contains"
+" the recipe name on the left and the version on the right"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1604 ../../source/yocto/mickledore.rst:1553
+#: ../../source/yocto/scarthgap.rst:1554
+msgid ""
+"As you can see, the recipe *linux-mainline* has version *5.15.102-phy1*. "
+"In the PHYTEC's *linux-mainline*  *Git* repository, you will find a "
+"corresponding tag *v5.15.102-phy1*. The version of the *barebox* recipe "
+"is 2022.02.0-phy1. On i.MX8M\\* modules the output will contain *linux-"
+"imx* and *u-boot-imx*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1610 ../../source/yocto/mickledore.rst:1559
+#: ../../source/yocto/scarthgap.rst:1560
+msgid "Kernel and Bootloader Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1612 ../../source/yocto/mickledore.rst:1561
+#: ../../source/yocto/scarthgap.rst:1562
+msgid ""
+"The bootloader used by PHYTEC, *barebox*, uses the same build system as "
+"the *Linux* kernel. Therefore, all commands in this section can be used "
+"to configure the kernel and bootloader. To configure the kernel or "
+"bootloader, execute one of the following commands"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1626 ../../source/yocto/mickledore.rst:1575
+#: ../../source/yocto/scarthgap.rst:1576
+msgid "After that, you can recompile and redeploy the kernel or bootloader"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1633 ../../source/yocto/mickledore.rst:1582
+#: ../../source/yocto/scarthgap.rst:1583
+msgid "Instead, you can also just rebuild the complete build output with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1639 ../../source/yocto/mickledore.rst:1588
+#: ../../source/yocto/scarthgap.rst:1589
+msgid ""
+"In the last command, you can replace the image name with the name of an "
+"image of your choice. The new images and binaries are in "
+"*build/deploy/images/<machine>/*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1645 ../../source/yocto/mickledore.rst:1594
+#: ../../source/yocto/scarthgap.rst:1595
+msgid ""
+"The build configuration is not permanent yet. Executing *bitbake "
+"virtual/kernel -c clean* will remove everything."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1648 ../../source/yocto/mickledore.rst:1597
+#: ../../source/yocto/scarthgap.rst:1598
+msgid ""
+"To make your changes permanent in the build system, you have to integrate"
+" your configuration modifications into a layer. For the configuration you"
+" have two options:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1652 ../../source/yocto/mickledore.rst:1601
+#: ../../source/yocto/scarthgap.rst:1602
+msgid ""
+"Include only a configuration fragment (a minimal *diff* between the old "
+"and new configuration)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1654 ../../source/yocto/mickledore.rst:1603
+#: ../../source/yocto/scarthgap.rst:1604
+msgid "Complete default configuration (*defconfig*) after your modifications."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1657 ../../source/yocto/mickledore.rst:1606
+#: ../../source/yocto/scarthgap.rst:1607
+msgid ""
+"Having a set of configuration fragments makes what was changed at which "
+"stage more transparent. You can turn on and off the changes, you can "
+"manage configurations for different situations and it helps when porting "
+"changes to new kernel versions. You can also group changes together to "
+"reflect specific use cases. A fully assembled kernel configuration will "
+"be deployed in the directory *build/deploy/images/<machine>*. If you do "
+"not have any of those requirements, it might be simpler to just manage a "
+"separate *defconfig* file."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1666 ../../source/yocto/mickledore.rst:1615
+#: ../../source/yocto/scarthgap.rst:1616
+msgid "Add a Configuration Fragment to a Recipe"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1668 ../../source/yocto/mickledore.rst:1617
+#: ../../source/yocto/scarthgap.rst:1618
+msgid ""
+"The following steps can be used for both kernel and bootloader. Just "
+"replace the recipe name *linux-mainline* in the commands with *linux-ti*,"
+" or *barebox* for the bootloader. If you did not already take care of "
+"this, start with a clean build. Otherwise, the diff of the configuration "
+"may be wrong"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1678 ../../source/yocto/mickledore.rst:1627
+#: ../../source/yocto/scarthgap.rst:1628
+msgid "Make your configuration changes in the menu and generate a config fragment"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1685 ../../source/yocto/mickledore.rst:1634
+#: ../../source/yocto/scarthgap.rst:1635
+msgid "which prints the path of the written file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1692 ../../source/yocto/mickledore.rst:1641
+#: ../../source/yocto/scarthgap.rst:1642
+msgid ""
+"All config changes are in the file *fragment.cfg* which should consist of"
+" only some lines. The following example shows how to create a *bbappend* "
+"file and how to add the necessary lines for the config fragment. You just"
+" have to adjust the directories and names for the specific recipe: "
+"*linux-mainline*, *linux-ti*, linux-imx, u-boot-imx, or *barebox*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1706 ../../source/yocto/mickledore.rst:1655
+#: ../../source/yocto/scarthgap.rst:1656
+msgid ""
+"Replace the string *layer* with your own layer created as shown above "
+"(e.g. *meta-racer*), or just use *meta-ampliphy*. To use *meta-ampliphy*,"
+" first, create the directory for the config fragment and give it a new "
+"name (here *enable-r8169.cfg*) and move the fragment to the layer."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1718 ../../source/yocto/mickledore.rst:1667
+#: ../../source/yocto/scarthgap.rst:1668
+msgid ""
+"Then open the *bbappend* file (in this case *sources/meta-ampliphy"
+"/recipes-kernel/linux/linux-mainline_%.bbappend* ) with your favorite "
+"editor and add the following lines"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1732 ../../source/yocto/mickledore.rst:1681
+#: ../../source/yocto/scarthgap.rst:1682
+msgid ""
+"Do not forget to use the correct *bbappend* filenames: *linux-"
+"ti_%.bbappend* for the linux-ti recipe and *barebox_%.bbappend* for the "
+"bootloader in the folder *recipes-bsp/barebox/* !"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1736 ../../source/yocto/mickledore.rst:1685
+#: ../../source/yocto/scarthgap.rst:1686
+msgid ""
+"After saving the *bbappend* file, you have to rebuild the image. *Yocto* "
+"should pick up the recipe changes automatically and generate a new image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1744 ../../source/yocto/mickledore.rst:1693
+#: ../../source/yocto/scarthgap.rst:1694
+msgid "Add a Complete Default Configuration (*defconfig*) to a Recipe"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1746 ../../source/yocto/mickledore.rst:1695
+#: ../../source/yocto/scarthgap.rst:1696
+msgid ""
+"This approach is similar to the one above, but instead of adding a "
+"fragment, a *defconfig* is used. First, create the necessary folders in "
+"the layer you want to use, either your own layer or *meta-ampliphy*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1755 ../../source/yocto/mickledore.rst:1704
+#: ../../source/yocto/scarthgap.rst:1705
+msgid ""
+"Then you have to create a suitable *defconfig* file. Make your "
+"configuration changes using *menuconfig* and then save the *defconfig* "
+"file to the layer"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1763 ../../source/yocto/mickledore.rst:1712
+#: ../../source/yocto/scarthgap.rst:1713
+msgid "This will print the path to the generated file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1769 ../../source/yocto/mickledore.rst:1718
+#: ../../source/yocto/scarthgap.rst:1719
+msgid ""
+"Then, as above, copy the generated file to your layer, rename it to "
+"*defconfig*, and add the following lines to the *bbappend* file (here "
+"*sources/meta-ampliphy/recipes-kernel/linux/linux-mainline_%.bbappend*)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1783 ../../source/yocto/mickledore.rst:1732
+#: ../../source/yocto/scarthgap.rst:1733
+msgid ""
+"Do not forget to use the correct bbappend filenames: *linux-"
+"ti_%.bbappend* for the linux-ti recipe and *barebox_%.bbappend* for the "
+"bootloader in the folder *recipes-bsp/barebox/* !"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1787 ../../source/yocto/mickledore.rst:1736
+#: ../../source/yocto/scarthgap.rst:1737
+msgid "After that, rebuild your image as the changes are picked up automatically"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1794 ../../source/yocto/mickledore.rst:1743
+#: ../../source/yocto/scarthgap.rst:1744
+msgid "Patch the Kernel or Bootloader with *devtool*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1796 ../../source/yocto/mickledore.rst:1745
+#: ../../source/yocto/scarthgap.rst:1746
+msgid ""
+"*Apart from using the standard versions of kernel and bootloader which "
+"are provided in the recipes, you can modify the source code or use our "
+"own repositories to build your customized kernel.*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1801 ../../source/yocto/kirkstone.rst:1858
+#: ../../source/yocto/kirkstone.rst:2001 ../../source/yocto/mickledore.rst:1750
+#: ../../source/yocto/mickledore.rst:1807
+#: ../../source/yocto/mickledore.rst:1950 ../../source/yocto/scarthgap.rst:1751
+#: ../../source/yocto/scarthgap.rst:1808 ../../source/yocto/scarthgap.rst:1951
+msgid "PRO"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1801 ../../source/yocto/kirkstone.rst:1858
+#: ../../source/yocto/kirkstone.rst:2001 ../../source/yocto/mickledore.rst:1750
+#: ../../source/yocto/mickledore.rst:1807
+#: ../../source/yocto/mickledore.rst:1950 ../../source/yocto/scarthgap.rst:1751
+#: ../../source/yocto/scarthgap.rst:1808 ../../source/yocto/scarthgap.rst:1951
+msgid "CON"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1803 ../../source/yocto/mickledore.rst:1752
+#: ../../source/yocto/scarthgap.rst:1753
+msgid "Standard workflow of the official *Yocto* documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1803 ../../source/yocto/mickledore.rst:1752
+#: ../../source/yocto/scarthgap.rst:1753
+msgid "Uses additional hard drive space as the sources get duplicated"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1806 ../../source/yocto/kirkstone.rst:1864
+#: ../../source/yocto/mickledore.rst:1755
+#: ../../source/yocto/mickledore.rst:1813 ../../source/yocto/scarthgap.rst:1756
+#: ../../source/yocto/scarthgap.rst:1814
+msgid "Toolchain does not have to recompile everything"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1806 ../../source/yocto/mickledore.rst:1755
+#: ../../source/yocto/scarthgap.rst:1756
+msgid "No optimal cache usage, build overhead"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1810 ../../source/yocto/mickledore.rst:1759
+#: ../../source/yocto/scarthgap.rst:1760
+msgid ""
+"*Devtool* is a set of helper scripts to enhance the user workflow of "
+"*Yocto*. It was integrated with version 1.8. It is available as soon as "
+"you set up your shell environment. *Devtool* can be used to:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1814 ../../source/yocto/mickledore.rst:1763
+#: ../../source/yocto/scarthgap.rst:1764
+msgid "modify existing sources"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1815 ../../source/yocto/mickledore.rst:1764
+#: ../../source/yocto/scarthgap.rst:1765
+msgid "integrate software projects into your build setup"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1816 ../../source/yocto/mickledore.rst:1765
+#: ../../source/yocto/scarthgap.rst:1766
+msgid "build software and deploy software modifications to your target"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1818 ../../source/yocto/mickledore.rst:1767
+#: ../../source/yocto/scarthgap.rst:1768
+msgid ""
+"Here we will use *devtool* to patch the kernel. We use *linux-mainline* "
+"as an example for the AM335x Kernel. The first command we use is *devtool"
+" modify - x <recipe> <directory>*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1826 ../../source/yocto/mickledore.rst:1775
+#: ../../source/yocto/scarthgap.rst:1776
+msgid ""
+"*Devtool* will create a layer in *build/workspace* where you can see all "
+"modifications done by *devtool* . It will extract the sources "
+"corresponding to the recipe to the specified directory. A *bbappend* will"
+" be created in the workspace directing the SRC_URI to this directory. "
+"Building an image with *Bitbake* will now use the sources in this "
+"directory. Now you can modify lines in the kernel"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1839
+msgid ""
+"Your changes will now be recompiled and added to the image. If you want "
+"to store your changes permanently, it is advisable to create a patch from"
+" the changes, then store and backup only the patch. You can go into the "
+"*linux-mainline* directory and create a patch using *Git*. How to create "
+"a patch is described in :ref:`kirkstone_temporary-method` and is the same"
+" for all methods."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1845 ../../source/yocto/mickledore.rst:1794
+#: ../../source/yocto/scarthgap.rst:1795
+msgid "If you want to learn more about *devtool*, visit:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1847
+msgid ""
+"`Yocto 4.0.6 - Devtool <https://docs.yoctoproject.org/4.0.6/sdk-"
+"manual/extensible.html#using-devtool-in-your-sdk-workflow>`_ or `Devtool "
+"Quick Reference <https://docs.yoctoproject.org/4.0.6/ref-manual/devtool-"
+"reference.html>`_"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1855 ../../source/yocto/mickledore.rst:1804
+#: ../../source/yocto/scarthgap.rst:1805
+msgid "Patch the Kernel or Bootloader using the \"Temporary Method\""
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1860 ../../source/yocto/mickledore.rst:1809
+#: ../../source/yocto/scarthgap.rst:1810
+msgid "No overhead, no extra configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1860 ../../source/yocto/mickledore.rst:1809
+#: ../../source/yocto/scarthgap.rst:1810
+msgid "Changes are easily overwritten by *Yocto* (Everything is lost!!)."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1868 ../../source/yocto/mickledore.rst:1817
+#: ../../source/yocto/scarthgap.rst:1818
+msgid ""
+"It is possible to alter the source code before *Bitbake* configures and "
+"compiles the recipe. Use *Bitbake'* s *devshell* command to jump into the"
+" source directory of the recipe. Here is the *barebox* recipe"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1876 ../../source/yocto/mickledore.rst:1825
+#: ../../source/yocto/scarthgap.rst:1826
+msgid ""
+"After executing the command, a shell window opens. The current working "
+"directory of the shell will be changed to the source directory of the "
+"recipe inside the *tmp* folder. Here you can use your favorite editor, "
+"e.g. *vim*, *emacs*, or any other graphical editor, to alter the source "
+"code. When you are finished, exit the *devshell* by typing *exit* or "
+"hitting **CTRL-D**."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1882 ../../source/yocto/mickledore.rst:1831
+#: ../../source/yocto/scarthgap.rst:1832
+msgid "After leaving the *devshell* you can recompile the package"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1888 ../../source/yocto/mickledore.rst:1837
+#: ../../source/yocto/scarthgap.rst:1838
+msgid ""
+"The extra argument '--force' is important because *Yocto* does not "
+"recognize that the source code was changed."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1893 ../../source/yocto/mickledore.rst:1842
+#: ../../source/yocto/scarthgap.rst:1843
+msgid ""
+"You cannot execute the *bitbake* command in the *devshell* . You have to "
+"leave it first."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1896 ../../source/yocto/mickledore.rst:1845
+#: ../../source/yocto/scarthgap.rst:1846
+msgid ""
+"If the build fails, execute the devshell command again and fix it. If the"
+" build is successful, you can deploy the package and create a new SD card"
+" image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1906 ../../source/yocto/mickledore.rst:1855
+#: ../../source/yocto/scarthgap.rst:1856
+msgid ""
+"If you execute a clean e.g *bitbake barebox -c clean* , or if *Yocto* "
+"fetches the source code again, all your changes are lost!!!"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1909 ../../source/yocto/mickledore.rst:1858
+#: ../../source/yocto/scarthgap.rst:1859
+msgid ""
+"To avoid this, you can create a patch and add it to a *bbappend* file. It"
+" is the same workflow as described in the section about changing the "
+"configuration."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1913 ../../source/yocto/mickledore.rst:1862
+#: ../../source/yocto/scarthgap.rst:1863
+msgid ""
+"You have to create the patch in the *devshell* if you use the temporary "
+"method and in the subdirectory created by *devtool* if you used "
+"*devtool*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1926 ../../source/yocto/mickledore.rst:1875
+#: ../../source/yocto/scarthgap.rst:1876
+msgid ""
+"After you have created the patch, you must create a *bbappend* file for "
+"it. The locations for the three different recipes - *linux-mainline* , "
+"*linux-ti* , and *barebox* - are"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1938 ../../source/yocto/mickledore.rst:1887
+#: ../../source/yocto/scarthgap.rst:1888
+msgid ""
+"The following example is for the recipe *barebox*. You have to adjust the"
+" paths. First, create the folders and move the patch into them. Then "
+"create the *bbappend* file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1950 ../../source/yocto/mickledore.rst:1899
+#: ../../source/yocto/scarthgap.rst:1900
+msgid ""
+"Pay attention to your current work directory. You have to execute the "
+"commands in the BSP top-level directory. Not in the *build* directory!"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1953 ../../source/yocto/mickledore.rst:1902
+#: ../../source/yocto/scarthgap.rst:1903
+msgid ""
+"After that use your favorite editor to add the following snipped into the"
+" *bbappend* file (here *sources/meta-ampliphy/recipes-"
+"bsp/barebox/barebox_%.bbappend*)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1965 ../../source/yocto/mickledore.rst:1914
+#: ../../source/yocto/scarthgap.rst:1915
+msgid "Save the file and rebuild the *barebox* recipe with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1972 ../../source/yocto/mickledore.rst:1921
+#: ../../source/yocto/scarthgap.rst:1922
+msgid "If the build is successful, you can rebuild the final image with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1978 ../../source/yocto/mickledore.rst:1927
+#: ../../source/yocto/scarthgap.rst:1928
+msgid "**Further Resources:**"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1980 ../../source/yocto/mickledore.rst:1929
+#: ../../source/yocto/scarthgap.rst:1930
+msgid ""
+"The *Yocto* Project has some documentation for software developers. Check"
+" the 'Kernel Development Manual' for more information about how to "
+"configure the kernel. Please note that not all of the information from "
+"the *Yocto* manual can be applied to the PHYTEC BSP as we use the classic"
+" kernel approach of *Yocto* and most of the documentation assumes the "
+"*Yocto* kernel approach."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1986
+msgid ""
+"`Yocto - Kernel Development Manual <https://docs.yoctoproject.org/4.0.6"
+"/kernel-dev/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1988
+msgid ""
+"`Yocto - Development Manual <https://docs.yoctoproject.org/4.0.6/dev-"
+"manual/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1992 ../../source/yocto/mickledore.rst:1941
+#: ../../source/yocto/scarthgap.rst:1942
+msgid "Working with the Kernel and Bootloader using SRC_URI in *local.conf*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:1994 ../../source/yocto/mickledore.rst:1943
+#: ../../source/yocto/scarthgap.rst:1944
+msgid ""
+"*Here we present a third option to make kernel and bootloader changes. "
+"You have external checkouts of the linux-mainline, linux-ti, or barebox  "
+"Git repositories. You will overwrite the URL of the source code fetcher, "
+"the variable SRC_URI, to point to your local checkout instead of the "
+"remote repositories.*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2003 ../../source/yocto/mickledore.rst:1952
+#: ../../source/yocto/scarthgap.rst:1953
+msgid "All changes are saved with *Git*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2003 ../../source/yocto/mickledore.rst:1952
+#: ../../source/yocto/scarthgap.rst:1953
+msgid "Many working directories in *build/tmp-\\ glibc/work/<machine>/<package>/*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2007 ../../source/yocto/mickledore.rst:1956
+#: ../../source/yocto/scarthgap.rst:1957
+msgid "You have to commit every change before recompiling"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2010 ../../source/yocto/mickledore.rst:1959
+#: ../../source/yocto/scarthgap.rst:1960
+msgid ""
+"For each change, the toolchain compiles everything from scratch "
+"(avoidable with *ccache*)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2015 ../../source/yocto/mickledore.rst:1964
+#: ../../source/yocto/scarthgap.rst:1965
+msgid ""
+"First, you need a local clone of the *Git* repository *barebox* or "
+"kernel. If you do not have one, use the commands"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2026 ../../source/yocto/mickledore.rst:1975
+#: ../../source/yocto/scarthgap.rst:1976
+msgid "Add the following snippet to the file build/conf/local.conf"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2037 ../../source/yocto/mickledore.rst:1986
+#: ../../source/yocto/scarthgap.rst:1987
+msgid ""
+"You also have to set the correct BRANCH name in the file. Either you "
+"create your own branch in the *Git* repository, or you use the default "
+"(here \"v2015.02.0-phy\"). Now you should recompile *barebox* from your "
+"own source"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2046 ../../source/yocto/mickledore.rst:1995
+#: ../../source/yocto/scarthgap.rst:1996
+msgid "The build should be successful because the source was not changed yet."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2048 ../../source/yocto/mickledore.rst:1997
+#: ../../source/yocto/scarthgap.rst:1998
+msgid ""
+"You can alter the source in *~/git/barebox* or the default *defconfig* "
+"(e.g. *~/git/barebox/arch/arm/configs/imx_v7_defconfig*). After you are "
+"satisfied with your changes, you have to make a dummy commit for *Yocto*."
+" If you do not, *Yocto* will not notice that the source code was modified"
+" in your repository folder (e.g. ~/git/barebox/)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2060 ../../source/yocto/mickledore.rst:2009
+#: ../../source/yocto/scarthgap.rst:2010
+msgid ""
+"Try to compile your new changes. *Yocto* will automatically notice that "
+"the source code was changed and fetches and configures everything from "
+"scratch."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2067 ../../source/yocto/mickledore.rst:2016
+#: ../../source/yocto/scarthgap.rst:2017
+msgid ""
+"If the build fails, go back to the source directory, fix the problem, and"
+" recommit your changes. If the build was successful, you can deploy "
+"*barebox* and even create a new SD card image."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2076 ../../source/yocto/mickledore.rst:2025
+#: ../../source/yocto/scarthgap.rst:2026
+msgid ""
+"If you want to make additional changes, just make another commit in the "
+"repository and rebuild *barebox* again."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2080 ../../source/yocto/mickledore.rst:2029
+#: ../../source/yocto/scarthgap.rst:2030
+msgid "Add Existing Software with \"Sustainable Method\""
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2082 ../../source/yocto/mickledore.rst:2031
+#: ../../source/yocto/scarthgap.rst:2032
+msgid ""
+"Now that you have created your own layer, you have a second option to add"
+" existing software to existing image definitions. Our standard image is "
+"defined in meta-ampliphy"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2090 ../../source/yocto/mickledore.rst:2039
+#: ../../source/yocto/scarthgap.rst:2040
+msgid ""
+"In your layer, you can now modify the recipe with a *bbappend* without "
+"modifying any BSP code"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2097 ../../source/yocto/mickledore.rst:2046
+#: ../../source/yocto/scarthgap.rst:2047
+msgid ""
+"The append will be parsed together with the base recipe. As a result, you"
+" can easily overwrite all variables set in the base recipe, which is not "
+"always what you want. If we want to include additional software, we need "
+"to append it to the IMAGE_INSTALL variable"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2107 ../../source/yocto/mickledore.rst:2056
+#: ../../source/yocto/scarthgap.rst:2057
+msgid "Add Linux Firmware Files to the Root Filesystem"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2109 ../../source/yocto/mickledore.rst:2058
+#: ../../source/yocto/scarthgap.rst:2059
+msgid ""
+"It is a common task to add an extra firmware file to your root filesystem"
+" into */lib/firmware/*. For example, WiFi adapters or PCIe Ethernet cards"
+" might need proprietary firmware. As a solution, we use a *bbappend* in "
+"our layer. To create the necessary folders, *bbappend* and copy the "
+"firmware file type"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2121 ../../source/yocto/mickledore.rst:2070
+#: ../../source/yocto/scarthgap.rst:2071
+msgid ""
+"Then add the following content to the *bbappend* file and replace every "
+"occurrence of *example-firmware.bin* with your firmware file name."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2139 ../../source/yocto/mickledore.rst:2088
+#: ../../source/yocto/scarthgap.rst:2089
+msgid "Now try to build the linux-firmware recipe"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2146 ../../source/yocto/mickledore.rst:2095
+#: ../../source/yocto/scarthgap.rst:2096
+msgid ""
+"This should generate a new package *deploy/ipk/all/linux-firmware-"
+"example*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2148 ../../source/yocto/mickledore.rst:2097
+#: ../../source/yocto/scarthgap.rst:2098
+msgid ""
+"As the final step, you have to install the firmware package to your "
+"image. You can do that in your *local.conf* or image recipe via"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2158 ../../source/yocto/mickledore.rst:2107
+#: ../../source/yocto/scarthgap.rst:2108
+msgid ""
+"Ensure that you have adapted the package name *linux-firmware-example* "
+"with the name you assigned in *linux-firmware_%.bbappend*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2162 ../../source/yocto/mickledore.rst:2111
+#: ../../source/yocto/scarthgap.rst:2112
+msgid "Change the *u-boot* Environment via *bbappend* Files"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2164 ../../source/yocto/mickledore.rst:2113
+#: ../../source/yocto/scarthgap.rst:2114
+msgid ""
+"All i.MX8M\\* products use the u-boot bootloader. The u-boot environment "
+"can be modified using the Temporary Method. In the *u-boot-imx* sources "
+"modify the header file corresponding to the processor located in "
+"*include/configs/phycore_imx8m\\**. New environment variables should be "
+"added at the end of *CONFIG_EXTRA_ENV_SETTINGS*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2177 ../../source/yocto/mickledore.rst:2126
+#: ../../source/yocto/scarthgap.rst:2127
+msgid ""
+"Commit the changes and and create the file *u-boot-imx_%.bbappend* in "
+"your layer at *<layer>/recipes-bsp/u-boot/u-boot-imx_%.bbappend*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2189 ../../source/yocto/mickledore.rst:2138
+#: ../../source/yocto/scarthgap.rst:2139
+msgid "Change the *barebox* Environment via *bbappend* Files"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2191 ../../source/yocto/mickledore.rst:2140
+#: ../../source/yocto/scarthgap.rst:2141
+msgid ""
+"Since *BSP-Yocto-AM335x-16.2.0* and *BSP-Yocto-i.MX6-PD16.1.0*, the "
+"*barebox* environment handling in *meta-phytec* has changed. Now it is "
+"possible to add, change, and remove files in the *barebox* environment "
+"via the *Python* bitbake task *do_env*. There are two *Python* functions "
+"to change the environment. Their signatures are:"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2197 ../../source/yocto/mickledore.rst:2146
+#: ../../source/yocto/scarthgap.rst:2147
+msgid ""
+"*env_add(d, *\\ **filename as string**\\ *, *\\ **file content as "
+"string**\\ *)*: to add a new file or overwrite an existing file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2199 ../../source/yocto/mickledore.rst:2148
+#: ../../source/yocto/scarthgap.rst:2149
+msgid "*env_rm(d, *\\ **filename as string**\\ *)*: to remove a file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2201 ../../source/yocto/mickledore.rst:2150
+#: ../../source/yocto/scarthgap.rst:2151
+msgid ""
+"The first example of a *bbappend* file in the custom layer *meta-racer* "
+"shows how to add a new non-volatile variable *linux.bootargs.fb* in the "
+"*barebox* environment folder */env/nv/*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2212 ../../source/yocto/mickledore.rst:2161
+#: ../../source/yocto/scarthgap.rst:2162
+msgid ""
+"The next example shows how to replace the network configuration file "
+"*/env/network/eth0*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2234 ../../source/yocto/mickledore.rst:2183
+#: ../../source/yocto/scarthgap.rst:2184
+msgid ""
+"In the above example, the *Python* multiline string syntax **\"\"\" text "
+"\"\"\"** is used to avoid adding multiple newline characters *\\\\n* into"
+" the recipe *Python* code. The *Python* function *env_add* can add and "
+"overwrite environment files."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2238 ../../source/yocto/mickledore.rst:2187
+#: ../../source/yocto/scarthgap.rst:2188
+msgid ""
+"The next example shows how to remove an already added environment file, "
+"for example *,* */env/boot/mmc*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2249 ../../source/yocto/mickledore.rst:2198
+#: ../../source/yocto/scarthgap.rst:2199
+msgid "Debugging the Environment"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2251 ../../source/yocto/mickledore.rst:2200
+#: ../../source/yocto/scarthgap.rst:2201
+msgid ""
+"If you want to see all environment files that are added in the build "
+"process, you can enable a debug flag in the *local.conf*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2259 ../../source/yocto/mickledore.rst:2208
+#: ../../source/yocto/scarthgap.rst:2209
+msgid ""
+"After that, you have to rebuild the *barebox* recipe to see the debugging"
+" output"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2267 ../../source/yocto/mickledore.rst:2216
+#: ../../source/yocto/scarthgap.rst:2217
+msgid "The output of the last command looks like this"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2278 ../../source/yocto/mickledore.rst:2227
+#: ../../source/yocto/scarthgap.rst:2228
+msgid "Changing the Environment (depending on Machines)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2280 ../../source/yocto/mickledore.rst:2229
+#: ../../source/yocto/scarthgap.rst:2230
+msgid ""
+"If you need to apply some *barebox* environment modifications only to a "
+"single or only a few machines, you can use *Bitbake'* s machine overwrite"
+" syntax. For the machine overwrite syntax, you append a machine name or "
+"SoC name (such as *mx6* , *ti33x,* or *rk3288* ) with an underscore to a "
+"variable or task"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2290 ../../source/yocto/mickledore.rst:2239
+#: ../../source/yocto/scarthgap.rst:2240
+msgid ""
+"The next example adds the environment variables only if the MACHINE is "
+"set to *phyboard-mira-imx6-4*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2300
+msgid ""
+"*Bitbake's* override syntax for variables is explained in more detail at:"
+" https://docs.yoctoproject.org/bitbake/2.0/bitbake-user-manual/bitbake-"
+"user-manual-metadata.html#conditional-metadata"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2304 ../../source/yocto/mickledore.rst:2253
+#: ../../source/yocto/scarthgap.rst:2254
+msgid "Upgrading the *barebox* Environment from Previous BSP Releases"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2306 ../../source/yocto/mickledore.rst:2255
+#: ../../source/yocto/scarthgap.rst:2256
+msgid ""
+"Prior to BSP version *BSP-Yocto-AM335x-16.2.0* and *BSP-"
+"Yocto-i.MX6-PD16.1.0* , *barebox* environment changes via *bbappend* file"
+" were done differently. For example, the directory structure in your meta"
+" layer (here *meta-skeleton* ) may have looked like this"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2324 ../../source/yocto/mickledore.rst:2273
+#: ../../source/yocto/scarthgap.rst:2274
+msgid "and the file *barebox_%.bbappend* contained"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2331 ../../source/yocto/mickledore.rst:2280
+#: ../../source/yocto/scarthgap.rst:2281
+msgid ""
+"In this example, all environment changes from the directory *boardenv* in"
+" the layer *meta-phytec* are ignored and the file *nv/linux.bootargs.cma*"
+" is added. For the new handling of the *barebox* environment, you use the"
+" *Python* functions *env_add* and *env_rm* in the *Python* task *do_env*."
+" Now the above example translates to a single *Python* function in the "
+"file *barebox_%.bbappend* that looks like"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2352 ../../source/yocto/mickledore.rst:2301
+#: ../../source/yocto/scarthgap.rst:2302
+msgid "Changing the Network Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2354 ../../source/yocto/mickledore.rst:2303
+#: ../../source/yocto/scarthgap.rst:2304
+msgid ""
+"To tweak IP addresses, routes, and gateways at runtime you can use the "
+"tools *ifconfig* and *ip* . Some examples"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2365 ../../source/yocto/mickledore.rst:2314
+#: ../../source/yocto/scarthgap.rst:2315
+msgid ""
+"The network configuration is managed by *systemd-networkd* . To query the"
+" current status use"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2373 ../../source/yocto/mickledore.rst:2322
+#: ../../source/yocto/scarthgap.rst:2323
+msgid ""
+"The network daemon reads its configuration from the directories "
+"*/etc/systemd/network/* , */run/systemd/network/* , and "
+"*/lib/systemd/network/* (from higher to lower priority). A sample "
+"configuration in */lib/systemd/network/10-eth0.network* looks like this"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2388 ../../source/yocto/mickledore.rst:2337
+#: ../../source/yocto/scarthgap.rst:2338
+msgid ""
+"These files *\\*.network* replace */etc/network/interfaces* from other "
+"distributions. You can either edit the file *10-eth0.network* in-place or"
+" copy it to */etc/systemd/network/* and make your changes there. After "
+"changing a file you must restart the daemon to apply your changes"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2397 ../../source/yocto/mickledore.rst:2346
+#: ../../source/yocto/scarthgap.rst:2347
+msgid "To see the syslog message of the network daemon, use"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2403 ../../source/yocto/mickledore.rst:2352
+#: ../../source/yocto/scarthgap.rst:2353
+msgid ""
+"To modify the network configuration at build time, look at the recipe "
+"*sources/meta-ampliphy/recipes-core/systemd/systemd-machine-units.bb* and"
+" the interface files in the folder *meta-ampliphy/recipes-core/systemd"
+"/systemd-machine-units/* where the static IP address configuration for "
+"*eth0* (and optionally *eth1*) is done."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2409 ../../source/yocto/mickledore.rst:2358
+#: ../../source/yocto/scarthgap.rst:2359
+msgid ""
+"For more information, see https://wiki.archlinux.org/title/Systemd-"
+"networkd and "
+"https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2413 ../../source/yocto/mickledore.rst:2362
+#: ../../source/yocto/scarthgap.rst:2363
+msgid "Changing the Wireless Network Configuration"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2416 ../../source/yocto/mickledore.rst:2365
+#: ../../source/yocto/scarthgap.rst:2366
+msgid "Connecting to a WLAN Network"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2418 ../../source/yocto/mickledore.rst:2367
+#: ../../source/yocto/scarthgap.rst:2368
+msgid "First set the correct regulatory domain for your country"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2425 ../../source/yocto/mickledore.rst:2374
+#: ../../source/yocto/scarthgap.rst:2375
+msgid "You will see"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2436 ../../source/yocto/mickledore.rst:2385
+#: ../../source/yocto/scarthgap.rst:2386
+msgid "Set up the wireless interface"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2443 ../../source/yocto/mickledore.rst:2392
+#: ../../source/yocto/scarthgap.rst:2393
+msgid "Now you can scan for available networks"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2449 ../../source/yocto/mickledore.rst:2398
+#: ../../source/yocto/scarthgap.rst:2399
+msgid ""
+"You can use a cross-platform supplicant with support for *WEP*, *WPA*, "
+"and *WPA2* called *wpa_supplicant* for an encrypted connection."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2452 ../../source/yocto/mickledore.rst:2401
+#: ../../source/yocto/scarthgap.rst:2402
+msgid ""
+"To do so, add the network credentials to the file "
+"*/etc/wpa_supplicant.conf*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2459 ../../source/yocto/mickledore.rst:2408
+#: ../../source/yocto/scarthgap.rst:2409
+msgid "Now a connection can be established"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2465 ../../source/yocto/mickledore.rst:2414
+#: ../../source/yocto/scarthgap.rst:2415
+msgid "This should result in the following output"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2471
+msgid ""
+"To finish the configuration you can configure DHCP to receive an IP "
+"address (supported by most WLAN access points). For other possible IP "
+"configurations, see the section :ref:`kirkstone_changing-net-config`."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2475 ../../source/yocto/mickledore.rst:2424
+#: ../../source/yocto/scarthgap.rst:2425
+msgid "First, create the directory"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2481 ../../source/yocto/mickledore.rst:2430
+#: ../../source/yocto/scarthgap.rst:2431
+msgid ""
+"Then add the following configuration snippet in "
+"*/etc/systemd/network/10-wlan0.network*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2493 ../../source/yocto/mickledore.rst:2442
+#: ../../source/yocto/scarthgap.rst:2443
+msgid "Now, restart the network daemon so that the configuration takes effect"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2500 ../../source/yocto/mickledore.rst:2449
+#: ../../source/yocto/scarthgap.rst:2450
+msgid "Creating a WLAN Access Point"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2502 ../../source/yocto/mickledore.rst:2451
+#: ../../source/yocto/scarthgap.rst:2452
+msgid ""
+"This section provides a basic access point (AP) configuration for a "
+"secured *WPA2* network."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2505 ../../source/yocto/mickledore.rst:2454
+#: ../../source/yocto/scarthgap.rst:2455
+msgid "Find the name of the WLAN interface with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2511 ../../source/yocto/mickledore.rst:2460
+#: ../../source/yocto/scarthgap.rst:2461
+msgid ""
+"Edit the configuration in */etc/hostapd.conf*. It is strongly dependent "
+"on the use case. The following shows an example"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2530 ../../source/yocto/mickledore.rst:2479
+#: ../../source/yocto/scarthgap.rst:2480
+msgid ""
+"Set up and start the DHCP server for the network interface *wlan0* via "
+"*systemd-networkd*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2538 ../../source/yocto/mickledore.rst:2487
+#: ../../source/yocto/scarthgap.rst:2488
+msgid "Insert the following text into the file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2554 ../../source/yocto/mickledore.rst:2503
+#: ../../source/yocto/scarthgap.rst:2504
+msgid "Start the userspace daemon *hostapd*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2561 ../../source/yocto/mickledore.rst:2510
+#: ../../source/yocto/scarthgap.rst:2511
+msgid ""
+"Now, you should see the WLAN network *Test-Wifi* on your terminal device "
+"(laptop, smartphone, etc.)."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2564 ../../source/yocto/mickledore.rst:2513
+#: ../../source/yocto/scarthgap.rst:2514
+msgid ""
+"If there are problems with the access point, you can either check the log"
+" messages with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2571 ../../source/yocto/mickledore.rst:2520
+#: ../../source/yocto/scarthgap.rst:2521
+msgid "or start the daemon in debugging mode from the command line"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2578 ../../source/yocto/mickledore.rst:2527
+#: ../../source/yocto/scarthgap.rst:2528
+msgid "You should see"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2586 ../../source/yocto/mickledore.rst:2535
+#: ../../source/yocto/scarthgap.rst:2536
+msgid ""
+"Further information about AP settings and the userspace daemon *hostapd* "
+"can be found at"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2595 ../../source/yocto/mickledore.rst:2544
+#: ../../source/yocto/scarthgap.rst:2545
+msgid "phyCORE-i.MX 6UL/ULL Bluetooth"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2597
+msgid ""
+"Special consideration must be paid when working with any Bluetooth on a "
+"phyCORE-i.MX 6UL/ULL. For further information, please check `L-844e.A5 "
+"i.MX 6UL/ULL BSP Manual - Bluetooth "
+"<https://www.phytec.de/cdocuments/?doc=xoJEEQ#BSPReferenceManualphyCOREi-"
+"MX6ULULLL844e-A5-Bluetooth>`_."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2603 ../../source/yocto/mickledore.rst:2552
+#: ../../source/yocto/scarthgap.rst:2553
+msgid "Add OpenCV Libraries and Examples"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2605 ../../source/yocto/mickledore.rst:2554
+#: ../../source/yocto/scarthgap.rst:2555
+msgid ""
+"*OpenCV* (Opensource Computer Vision https://opencv.org/) is an open-"
+"source library for computer vision applications."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2608 ../../source/yocto/mickledore.rst:2557
+#: ../../source/yocto/scarthgap.rst:2558
+msgid ""
+"To install the libraries and examples edit the file *conf/local.conf* in "
+"the *Yocto* build system and add"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2639 ../../source/yocto/mickledore.rst:2588
+#: ../../source/yocto/scarthgap.rst:2589
+msgid "Then rebuild your image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2647 ../../source/yocto/mickledore.rst:2596
+#: ../../source/yocto/scarthgap.rst:2597
+msgid ""
+"Most examples do not work out of the box, because they depend on the "
+"*GTK* graphics library. The BSP only supports *Qt6* ."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2651 ../../source/yocto/mickledore.rst:2600
+#: ../../source/yocto/scarthgap.rst:2601
+msgid "Add Minimal PHP web runtime with *lightpd*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2653 ../../source/yocto/mickledore.rst:2602
+#: ../../source/yocto/scarthgap.rst:2603
+msgid ""
+"This is one example of how to add a small runtime for PHP applications "
+"and a web server on your target. Lighttpd can be used together with the "
+"PHP command line tool over cgi. This solution weights only 5.5 MiB of "
+"disk storage. It is already preconfigured in meta-ampliphy. Just modify "
+"the build configuration to install it on the image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2665 ../../source/yocto/mickledore.rst:2614
+#: ../../source/yocto/scarthgap.rst:2615
+msgid ""
+"After booting the image, you should find the example web content in "
+"*/www/pages* . For testing php, you can delete the *index.html* and "
+"replace it with a *index.php* file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2680 ../../source/yocto/mickledore.rst:2629
+#: ../../source/yocto/scarthgap.rst:2630
+msgid ""
+"On your host, you can point your browser to the board's IP, (e.g. "
+"192.168.3.11) and the phpinfo should show up."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2684 ../../source/yocto/mickledore.rst:2633
+#: ../../source/yocto/scarthgap.rst:2634
+msgid "Common Tasks"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2687 ../../source/yocto/mickledore.rst:2636
+#: ../../source/yocto/scarthgap.rst:2637
+msgid "Debugging a User Space Application"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2689 ../../source/yocto/mickledore.rst:2638
+#: ../../source/yocto/scarthgap.rst:2639
+msgid ""
+"The phytec-qt6demo-image can be cross-debugged without any change. For "
+"cross-debugging, you just have to match the host sysroot with the image "
+"in use. So you need to create a toolchain for your image"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2697 ../../source/yocto/mickledore.rst:2646
+#: ../../source/yocto/scarthgap.rst:2647
+msgid ""
+"Additionally, if you want to have full debug and backtrace capabilities "
+"for all programs and libraries in the image, you could add"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2704 ../../source/yocto/mickledore.rst:2653
+#: ../../source/yocto/scarthgap.rst:2654
+msgid ""
+"to the ``conf/local.conf``. This is not necessary in all cases. The "
+"compiler options will then be switched from FULL_OPTIMIZATION to "
+"DEBUG_OPTIMIZATION. Look at the *Poky* source code for the default "
+"assignment of DEBUG_OPTIMIZATION."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2708 ../../source/yocto/mickledore.rst:2657
+#: ../../source/yocto/scarthgap.rst:2658
+msgid ""
+"To start a cross debug session, install the SDK as mentioned previously, "
+"source the SDK environment, and run *Qt Creator* in the same shell. If "
+"you do not use *Qt Creator*, you can directly call the arm-<..>-gdb "
+"debugger instead which should be in your path after sourcing the "
+"environment script."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2713 ../../source/yocto/mickledore.rst:2662
+#: ../../source/yocto/scarthgap.rst:2663
+msgid ""
+"If you work with *Qt Creator*, have a look at the appropriate "
+"documentation delivered with your product (either QuickStart or "
+"Application Guide) for information on how to set up the toolchain."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2717 ../../source/yocto/mickledore.rst:2666
+#: ../../source/yocto/scarthgap.rst:2667
+msgid ""
+"When starting the debugger with your userspace application you will get a"
+" SIGILL, an illegal instruction from the *libcrypto*. *Openssl* probes "
+"for the system capabilities by trapping illegal instructions, which will "
+"trigger *GDB*. You can ignore this and hit **Continue** (c command). You "
+"can permanently ignore this stop by adding"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2727 ../../source/yocto/mickledore.rst:2676
+#: ../../source/yocto/scarthgap.rst:2677
+msgid ""
+"to your *GDB* startup script or in the *Qt Creator GDB* configuration "
+"panel. Secondly, you might need to disable a security feature by adding"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2734 ../../source/yocto/mickledore.rst:2683
+#: ../../source/yocto/scarthgap.rst:2684
+msgid ""
+"to the same startup script, which will enable the automatic loading of "
+"libraries from any location."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2737 ../../source/yocto/mickledore.rst:2686
+#: ../../source/yocto/scarthgap.rst:2687
+msgid ""
+"If you need to have native debugging, you might want to install the debug"
+" symbols on the target. You can do this by adding the following line to "
+"your *conf/local.conf*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2745 ../../source/yocto/mickledore.rst:2694
+#: ../../source/yocto/scarthgap.rst:2695
+msgid ""
+"For cross-debugging, this is not required as the debug symbols will be "
+"loaded from the host side and the dbg-pkgs are included in the SDK of "
+"your image anyway."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2752 ../../source/yocto/mickledore.rst:2701
+#: ../../source/yocto/scarthgap.rst:2702
+msgid "Generating Source Mirrors, working Offline"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2754 ../../source/yocto/mickledore.rst:2703
+#: ../../source/yocto/scarthgap.rst:2704
+msgid ""
+"Modify your *site.conf* (or *local.conf* if you do not use a *site.conf* "
+") as follows"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2764 ../../source/yocto/mickledore.rst:2713
+#: ../../source/yocto/scarthgap.rst:2714
+msgid "Now run"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2770 ../../source/yocto/mickledore.rst:2719
+#: ../../source/yocto/scarthgap.rst:2720
+msgid ""
+"for all images and for all machines you want to provide sources for. This"
+" will create all the necessary *tar* archives. We can remove all SCM "
+"subfolders, as they are duplicated with the tarballs"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2779 ../../source/yocto/mickledore.rst:2728
+#: ../../source/yocto/scarthgap.rst:2729
+msgid ""
+"Please consider that we used a local source mirror for generating the "
+"dl_dir. Because of that, some archives will be linked locally."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2782 ../../source/yocto/mickledore.rst:2731
+#: ../../source/yocto/scarthgap.rst:2732
+msgid ""
+"First, we need to copy all files, resolving symbolic links into the new "
+"mirror directory"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2789 ../../source/yocto/mickledore.rst:2738
+#: ../../source/yocto/scarthgap.rst:2739
+msgid ""
+"Now we clean the */build* directory by deleting everything except "
+"*/build/conf/* but including */build/conf/sanity*. We change *site.conf* "
+"as follows"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2799 ../../source/yocto/mickledore.rst:2748
+#: ../../source/yocto/scarthgap.rst:2749
+msgid "The BSP directory can now be compressed with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2805 ../../source/yocto/mickledore.rst:2754
+#: ../../source/yocto/scarthgap.rst:2755
+msgid "where filename and folder should be the full BSP Name."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2808 ../../source/yocto/mickledore.rst:2757
+#: ../../source/yocto/scarthgap.rst:2758
+msgid "Compiling on the Target"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2810 ../../source/yocto/mickledore.rst:2759
+#: ../../source/yocto/scarthgap.rst:2760
+msgid "To your *local.conf* add"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2817 ../../source/yocto/mickledore.rst:2766
+#: ../../source/yocto/scarthgap.rst:2767
+msgid "Different Toolchains"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2819 ../../source/yocto/mickledore.rst:2768
+#: ../../source/yocto/scarthgap.rst:2769
+msgid ""
+"There are several ways to create a toolchain installer in *Poky*. One "
+"option is to run"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2826 ../../source/yocto/mickledore.rst:2775
+#: ../../source/yocto/scarthgap.rst:2776
+msgid ""
+"This will generate a toolchain installer in *build/deploy/sdk* which can "
+"be used for cross-compiling of target applications. However, the "
+"installer does not include libraries added to your image, so it is a bare"
+" *GCC* compiler only. This is suited for bootloader and kernel "
+"development."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2831 ../../source/yocto/mickledore.rst:2780
+#: ../../source/yocto/scarthgap.rst:2781
+msgid "Another you can run is"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2837 ../../source/yocto/mickledore.rst:2786
+#: ../../source/yocto/scarthgap.rst:2787
+msgid ""
+"This will generate a toolchain installer containing all necessary "
+"development packages of the software installed on the root filesystem of "
+"the target. This installer can be handed over to the user space "
+"application development team and includes all necessary parts to develop "
+"an application. If the image contains the *QT* libraries, all of those "
+"will be available in the installer too."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2843 ../../source/yocto/mickledore.rst:2792
+#: ../../source/yocto/scarthgap.rst:2793
+msgid ""
+"The third option is to create the ADT (Application Development Toolkit) "
+"installer. It will contain the cross-toolchain and some tools to aid the "
+"software developers, for example, an *Eclipse* plugin and a *QEMU* target"
+" simulator."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2852 ../../source/yocto/mickledore.rst:2801
+#: ../../source/yocto/scarthgap.rst:2802
+msgid "The ADT is untested for our BSP at the moment."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2855 ../../source/yocto/mickledore.rst:2804
+#: ../../source/yocto/scarthgap.rst:2805
+msgid "Using the SDK"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2857 ../../source/yocto/mickledore.rst:2806
+#: ../../source/yocto/scarthgap.rst:2807
+msgid "After generating the SDK with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2864 ../../source/yocto/mickledore.rst:2813
+#: ../../source/yocto/scarthgap.rst:2814
+msgid "run the generated binary with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2875 ../../source/yocto/mickledore.rst:2824
+#: ../../source/yocto/scarthgap.rst:2825
+msgid ""
+"You can activate the toolchain for your shell by sourcing the file "
+"*environment-setup* in the toolchain directory"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2882 ../../source/yocto/mickledore.rst:2831
+#: ../../source/yocto/scarthgap.rst:2841
+msgid ""
+"Then the necessary tools like the cross compiler and linker are in your "
+"PATH. To compile a simple *C* program, use"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2889 ../../source/yocto/mickledore.rst:2838
+#: ../../source/yocto/scarthgap.rst:2848
+msgid ""
+"The environment variable $CC contains the path to the ARM cross compiler "
+"and other compiler arguments needed like *-march* , *-sysroot* and "
+"*--mfloat-abi*."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2894 ../../source/yocto/mickledore.rst:2843
+#: ../../source/yocto/scarthgap.rst:2853
+msgid "You cannot compile programs only with the compiler name like"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2900 ../../source/yocto/mickledore.rst:2849
+#: ../../source/yocto/scarthgap.rst:2859
+msgid "It will fail in many cases. Always use *CC*, CFLAGS, LDFLAGS, and so on."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2902 ../../source/yocto/mickledore.rst:2851
+#: ../../source/yocto/scarthgap.rst:2861
+msgid ""
+"For convenience, the *environment-setup* exports other environment "
+"variables like CXX, LD, SDKTARGETSYSROOT."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2905 ../../source/yocto/mickledore.rst:2854
+#: ../../source/yocto/scarthgap.rst:2864
+msgid "A simple makefile compiling a *C* and *C++* program may look like this"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2924 ../../source/yocto/mickledore.rst:2873
+#: ../../source/yocto/scarthgap.rst:2883
+msgid ""
+"To compile for the target, just source the toolchain in your shell before"
+" executing make"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2933 ../../source/yocto/mickledore.rst:2882
+#: ../../source/yocto/scarthgap.rst:2892
+msgid ""
+"If you need to specify additionally included directories in the sysroot "
+"of the toolchain, you can use an '=' sign in the *-I* argument like"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2940 ../../source/yocto/mickledore.rst:2889
+#: ../../source/yocto/scarthgap.rst:2899
+msgid ""
+"*GCC* replaces it by the sysroot path (here "
+"*/opt/ampliphy/i.MX6-PD15.3-rc/sysroots/cortexa9hf-vfp-neon-phytec-linux-"
+"gnueabi/*). See the main page of *GCC* for more information."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2946 ../../source/yocto/mickledore.rst:2895
+#: ../../source/yocto/scarthgap.rst:2905
+msgid ""
+"The variables $CFLAGS and $CXXFLAGS contain the compiler debug flag '-g' "
+"by default. This includes debugging information in the binary and making "
+"it bigger. Those should be removed from the production image. If you "
+"create a *Bitbake* recipe, the default behavior is to turn on '-g' too. "
+"The debugging symbols are used in the SDK rootfs to be able to get "
+"debugging information when invoking *GDB* from the host. Before "
+"installing the package to the target rootfs, *Bitbake* will invoke "
+"*strip* on the program which removes the debugging symbols. By default, "
+"they are not found nor required on the target root filesystem"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2957 ../../source/yocto/mickledore.rst:2906
+#: ../../source/yocto/scarthgap.rst:2916
+msgid "Using the SDK with GNU Autotools"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2959 ../../source/yocto/mickledore.rst:2908
+#: ../../source/yocto/scarthgap.rst:2918
+msgid ""
+"*Yocto* SDK is a straightforward tool for a project that uses the *GNU "
+"Autotools*. The traditional compile steps for the host are usually"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2969 ../../source/yocto/mickledore.rst:2918
+#: ../../source/yocto/scarthgap.rst:2928
+msgid ""
+"The commands to compile for the target machine with the *Yocto* SDK are "
+"quite similar. The following commands assume that the SDK was unpacked to"
+" the directory */opt/phytec-ampliphy/i.MX6-PD15.3.0/* (adapt the path as "
+"needed)"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2981
+msgid ""
+"Refer to the official *Yocto* documentation for more information: "
+"https://docs.yoctoproject.org/4.0.6/singleindex.html#autotools-based-"
+"projects"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2985 ../../source/yocto/mickledore.rst:2934
+#: ../../source/yocto/scarthgap.rst:2944
+msgid "Working with Kernel Modules"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2987 ../../source/yocto/mickledore.rst:2936
+#: ../../source/yocto/scarthgap.rst:2946
+msgid ""
+"You will come to the point where you either need to set some options for "
+"a kernel module or you want to blacklist a module. Those things are "
+"handled by *udev* and go into *\\*.conf* files in"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:2995 ../../source/yocto/mickledore.rst:2944
+#: ../../source/yocto/scarthgap.rst:2954
+msgid ""
+"If you want to specify an option at build time, there are three relevant "
+"variables. If you just want to autoload a module that has no autoload "
+"capabilities, add it to"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3003 ../../source/yocto/mickledore.rst:2952
+#: ../../source/yocto/scarthgap.rst:2962
+msgid ""
+"either in the kernel recipe or in the global variable scope. If you need "
+"to specify options for a module, you can do so with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3012 ../../source/yocto/mickledore.rst:2961
+#: ../../source/yocto/scarthgap.rst:2971
+msgid ""
+"if you want to blacklist a module from autoloading, you can do it "
+"intuitively with"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3022 ../../source/yocto/mickledore.rst:2971
+#: ../../source/yocto/scarthgap.rst:2981
+msgid "Working with *udev*"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3024 ../../source/yocto/mickledore.rst:2973
+#: ../../source/yocto/scarthgap.rst:2983
+msgid ""
+"Udev (Linux dynamic device management) is a system daemon that handles "
+"dynamic device management in /dev. It is controlled by *udev* \\ rules "
+"that are located in */etc/udev/rules.d* (sysadmin configuration space) "
+"and\\  */lib/udev/rules.d/* (vendor-provided). Here is an example of an "
+"*udev* \\ rule file"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3036 ../../source/yocto/mickledore.rst:2985
+#: ../../source/yocto/scarthgap.rst:2995
+msgid ""
+"See https://www.freedesktop.org/software/systemd/man/latest/udev.html for"
+" more details about the syntax and usage. To get the list of attributes "
+"for a specific device that can be used in an *udev* rule you can use the "
+"*udevadm info* tool. It prints all existing attributes of the device node"
+" and its parents. The key-value pairs from the output can be copied and "
+"pasted into a rule file. Some examples"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3048 ../../source/yocto/mickledore.rst:2997
+#: ../../source/yocto/scarthgap.rst:3007
+msgid ""
+"After changing an *udev* rule, you have to notify the daemon. Otherwise, "
+"your changes are not reflected. Use the following command"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3055 ../../source/yocto/mickledore.rst:3004
+#: ../../source/yocto/scarthgap.rst:3014
+msgid ""
+"While developing *udev* rules you should monitor the events in order to "
+"see when devices are attached or unattached to the system. Use"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3062 ../../source/yocto/mickledore.rst:3011
+#: ../../source/yocto/scarthgap.rst:3021
+msgid ""
+"Furthermore, it is very useful to monitor the system log in another "
+"shell, especially if the rule executes external scripts. Execute"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3071
+msgid ""
+"You cannot start daemons or heavy scripts in a *RUN* attribute. See "
+"https://www.freedesktop.org/software/systemd/man/latest/udev.html ."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3074 ../../source/yocto/mickledore.rst:3023
+#: ../../source/yocto/scarthgap.rst:3033
+msgid ""
+"This can only be used for very short-running foreground tasks. Running an"
+" event process for a long period of time may block all further events for"
+" this or a dependent device. Starting daemons or other long-running "
+"processes is not appropriate for *udev*; the forked processes, detached "
+"or not, will be unconditionally killed after the event handling has "
+"finished. You can use the special attribute *ENV{SYSTEMD_WANTS"
+"}=\"service-name.service\"* and a *systemd*\\ service instead."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3082 ../../source/yocto/mickledore.rst:3031
+#: ../../source/yocto/scarthgap.rst:3041
+msgid ""
+"See https://unix.stackexchange.com/questions/63232/what-is-the-correct-"
+"way-to-write-a-udev-rule-to-stop-a-service-under-systemd."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3086 ../../source/yocto/mickledore.rst:3035
+#: ../../source/yocto/scarthgap.rst:3045
+msgid "Troubleshooting"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3089 ../../source/yocto/mickledore.rst:3038
+#: ../../source/yocto/scarthgap.rst:3048
+msgid "Setscene Task Warning"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3091 ../../source/yocto/mickledore.rst:3040
+#: ../../source/yocto/scarthgap.rst:3050
+msgid "This warning occurs when the Yocto cache is in a dirty state."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3097 ../../source/yocto/mickledore.rst:3046
+#: ../../source/yocto/scarthgap.rst:3056
+msgid ""
+"You should avoid canceling the build process or if you have to, press "
+"Ctrl-C once and wait until the build process has stopped. To remove all "
+"these warnings just clean the sstate cache and remove the build folders."
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3106 ../../source/yocto/mickledore.rst:3055
+#: ../../source/yocto/scarthgap.rst:3065
+msgid "Yocto Documentation"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3108
+msgid ""
+"The most important piece of documentation for a BSP user is probably the "
+"developer manual. https://docs.yoctoproject.org/4.0.6/dev-"
+"manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3112
+msgid ""
+"The chapter about common tasks is a good starting point. "
+"https://docs.yoctoproject.org/4.0.6/dev-manual/common-tasks.html#common-"
+"tasks"
+msgstr ""
+
+#: ../../source/yocto/kirkstone.rst:3115
+msgid ""
+"The complete documentation is available on one single HTML page, which is"
+" good for searching for a feature or a variable name. "
+"https://docs.yoctoproject.org/4.0.6/singleindex.html"
+msgstr ""
+
+#: ../../source/yocto/manual-index.rst:8 ../../source/yocto/manual-index.rst:18
+#: ../../source/yocto/manual-index.rst:28
+msgid "Table of Contents"
+msgstr ""
+
+#: ../../source/yocto/manual-index.rst:3
+msgid "Yocto Reference Manuals"
+msgstr ""
+
+#: ../../source/yocto/manual-index.rst:6
+msgid "Kirkstone"
+msgstr ""
+
+#: ../../source/yocto/manual-index.rst:16
+msgid "Mickledore"
+msgstr ""
+
+#: ../../source/yocto/manual-index.rst:26
+msgid "Scarthgap"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:23
+msgid "BSP-Yocto-NXP-i.MX93-PD24.1.0"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:23
+msgid "05.02.2024"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:25
+msgid "BSP-Yocto-NXP-i.MX93-PD24.1.1"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:25
+msgid "08.05.2024"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:158
+msgid ""
+"A collection of OpenEmbedded layers can be found here. The search "
+"function is very helpful to see if a software package can be retrieved "
+"and integrated easily: "
+"https://layers.openembedded.org/layerindex/branch/mickledore/layers/"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:189
+msgid ""
+"*Bitbake* is the task scheduler. It is written in *Python* and interprets"
+" recipes that contain code in *Bitbake's* own programming language, "
+"*Python*, and bash code. The official documentation can be found here: "
+"https://docs.yoctoproject.org/bitbake/2.4/index.html"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:197
+msgid ""
+"*Toaster* is a web frontend for *Bitbake* to start and investigate "
+"builds. It provides information about the build history and statistics on"
+" created images. There are several use cases where the installation and "
+"maintenance of a *Toaster* instance are beneficial. PHYTEC did not add or"
+" remove any features to the upstream *Toaster*, provided by *Poky*. The "
+"best source for more information is the official documentation: "
+"https://docs.yoctoproject.org/4.2.4/toaster-manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:208
+msgid ""
+"For more general questions about *Bitbake* and *Poky* consult the mega-"
+"manual: https://docs.yoctoproject.org/4.2.4/singleindex.html"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:214
+msgid ""
+"To build *Yocto* you need a compatible *Linux* host development machine. "
+"The list of supported distributions can be found in the reference manual:"
+" https://docs.yoctoproject.org/4.2.4/ref-manual/system-requirements.html"
+"#supported-linux-distributions"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:323
+msgid ""
+"This layer contains all machines and common features for all our BSPs. It"
+" is PHYTEC's `Yocto Board Support Package "
+"<https://docs.yoctoproject.org/4.2.4/bsp-guide/index.html>`_ for all "
+"supported hardware (since *fido*) and is designed to be standalone with "
+"*Poky*. Only these two parts are required if you want to integrate the "
+"PHYTEC's hardware into your existing *Yocto* workflow. The features are:"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:346 ../../source/yocto/scarthgap.rst:346
+msgid ""
+"`systemd <https://www.freedesktop.org/wiki/Software/systemd/>`_ init "
+"system"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:432
+msgid ""
+"The BSP content gets pulled from different online sources when you first "
+"start using *Bitbake*. All files will be downloaded and cloned in a local"
+" directory configured as ``DL_DIR`` in *Yocto*. If you backup your BSP "
+"with the complete content, those sources have to be backed up, too. How "
+"you can do this will be explained in the chapter :ref:`mickledore_gen-"
+"source-mirrors`."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:489
+msgid ""
+"Continue with the next step :ref:`mickledore_git-config` after that. The "
+"documentation for using build-container can be found in this manual after"
+" :ref:`mickledore_phylinux-advanced-usage` of phyLinux."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:493 ../../source/yocto/scarthgap.rst:493
+msgid ""
+"Else *Yocto* needs a handful of additional packages on your host. For "
+"*Ubuntu* you need"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:504
+msgid ""
+"For other distributions you can find information in the *Yocto* Quick "
+"Build: https://docs.yoctoproject.org/4.2.4/brief-"
+"yoctoprojectqs/index.html"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:580 ../../source/yocto/scarthgap.rst:580
+msgid ""
+"Create the two directories on a drive where you have approximately 50 GB "
+"of space and assign the two variables in your ``build/conf/local.conf``::"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1073
+msgid ""
+"You can then point your browser to *http://0.0.0.0:8000/* and continue "
+"working with *Bitbake*. All build activity can be monitored and analyzed "
+"from this web server. If you want to learn more about *Toaster*, look at "
+"https://docs.yoctoproject.org/4.2.4/toaster-manual/index.html. To shut "
+"down the *Toaster* web GUI again, execute"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1313
+msgid ""
+"To add additional software to the image, look at the OpenEmbedded layer "
+"index: "
+"https://layers.openembedded.org/layerindex/branch/mickledore/layers/"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1372
+msgid ""
+"References: `Yocto 4.2.4 Documentation - Customizing Yocto builds "
+"<https://docs.yoctoproject.org/4.2.4/singleindex.html#user-"
+"configuration>`_"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1378
+msgid ""
+"This is a step-by-step guide on how to add another layer to your *Yocto* "
+"build and install additional software from it. As an example, we include "
+"the network security scanner *nmap* in the layer *meta-security*. First, "
+"you must locate the layer on which the software is hosted. Check out the "
+"`OpenEmbedded MetaData Index "
+"<https://layers.openembedded.org/layerindex/branch/mickledore/layers/>`_ "
+"and guess a little bit. The network scanner *nmap* is in the *meta-"
+"security* layer. See `meta-security on layers.openembedded.org "
+"<https://layers.openembedded.org/layerindex/branch/mickledore/layer/meta-"
+"security/>`_. To integrate it into the *Yocto* build, you have to check "
+"out the repository and then switch to the correct stable branch. Since "
+"the BSP is based on the *Yocto* 'sumo' build, you should try to use the "
+"'sumo' branch in the layer, too."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1788
+msgid ""
+"Your changes will now be recompiled and added to the image. If you want "
+"to store your changes permanently, it is advisable to create a patch from"
+" the changes, then store and backup only the patch. You can go into the "
+"*linux-mainline* directory and create a patch using *Git*. How to create "
+"a patch is described in :ref:`mickledore_temporary-method` and is the "
+"same for all methods."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1796
+msgid ""
+"`Yocto 4.2.4 - Devtool <https://docs.yoctoproject.org/4.2.4/sdk-"
+"manual/extensible.html#using-devtool-in-your-sdk-workflow>`_ or `Devtool "
+"Quick Reference <https://docs.yoctoproject.org/4.2.4/ref-manual/devtool-"
+"reference.html>`_"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1935
+msgid ""
+"`Yocto - Kernel Development Manual <https://docs.yoctoproject.org/4.2.4"
+"/kernel-dev/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:1937
+msgid ""
+"`Yocto - Development Manual <https://docs.yoctoproject.org/4.2.4/dev-"
+"manual/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:2249 ../../source/yocto/scarthgap.rst:2250
+msgid ""
+"*Bitbake's* override syntax for variables is explained in more detail at:"
+" https://docs.yoctoproject.org/bitbake/2.4/bitbake-user-manual/bitbake-"
+"user-manual-metadata.html#conditional-metadata"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:2420
+msgid ""
+"To finish the configuration you can configure DHCP to receive an IP "
+"address (supported by most WLAN access points). For other possible IP "
+"configurations, see the section :ref:`mickledore_changing-net-config`."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:2546 ../../source/yocto/scarthgap.rst:2547
+msgid ""
+"Special consideration must be paid when working with any Bluetooth on a "
+"phyCORE-i.MX 6UL/ULL. For further information, please check `L-844e.A5 "
+"i.MX 6UL/ULL BSP Manual - Bluetooth "
+"<https://www.phytec.de/cdocuments/?doc=xoJEEQ#L844e-A5i-"
+"MX6ULULLBSPManual-Bluetooth>`_."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:2930
+msgid ""
+"Refer to the official *Yocto* documentation for more information: "
+"https://docs.yoctoproject.org/4.2.4/singleindex.html#autotools-based-"
+"projects"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:3020 ../../source/yocto/scarthgap.rst:3030
+msgid ""
+"You cannot start daemons or heavy scripts in a *RUN* attribute. See "
+"https://www.freedesktop.org/software/systemd/man/latest/udev.html#RUN%7Btype%7D"
+" ."
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:3057
+msgid ""
+"The most important piece of documentation for a BSP user is probably the "
+"developer manual. https://docs.yoctoproject.org/4.2.4/dev-"
+"manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:3061
+msgid ""
+"The chapter about common tasks is a good starting point. "
+"https://docs.yoctoproject.org/4.2.4/dev-manual/layers.html#understanding-"
+"and-creating-layers"
+msgstr ""
+
+#: ../../source/yocto/mickledore.rst:3064
+msgid ""
+"The complete documentation is available on one single HTML page, which is"
+" good for searching for a feature or a variable name. "
+"https://docs.yoctoproject.org/4.2.4/singleindex.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:23
+msgid "BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.0"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:23
+msgid "2024-04-02"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:25
+msgid "BSP-Yocto-Ampliphy-i.MX8MP-PD24.1.1"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:25
+msgid "2024-04-09"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:158
+msgid ""
+"A collection of OpenEmbedded layers can be found here. The search "
+"function is very helpful to see if a software package can be retrieved "
+"and integrated easily: "
+"https://layers.openembedded.org/layerindex/branch/scarthgap/layers/"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:189
+msgid ""
+"*Bitbake* is the task scheduler. It is written in *Python* and interprets"
+" recipes that contain code in *Bitbake's* own programming language, "
+"*Python*, and bash code. The official documentation can be found here: "
+"https://docs.yoctoproject.org/bitbake/2.8/index.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:197
+msgid ""
+"*Toaster* is a web frontend for *Bitbake* to start and investigate "
+"builds. It provides information about the build history and statistics on"
+" created images. There are several use cases where the installation and "
+"maintenance of a *Toaster* instance are beneficial. PHYTEC did not add or"
+" remove any features to the upstream *Toaster*, provided by *Poky*. The "
+"best source for more information is the official documentation: "
+"https://docs.yoctoproject.org/dev/toaster-manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:208
+msgid ""
+"For more general questions about *Bitbake* and *Poky* consult the mega-"
+"manual: https://docs.yoctoproject.org/dev/singleindex.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:214
+msgid ""
+"To build *Yocto* you need a compatible *Linux* host development machine. "
+"The list of supported distributions can be found in the reference manual:"
+" https://docs.yoctoproject.org/dev/ref-manual/system-requirements.html"
+"#supported-linux-distributions"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:323
+msgid ""
+"This layer contains all machines and common features for all our BSPs. It"
+" is PHYTEC's `Yocto Board Support Package "
+"<https://docs.yoctoproject.org/dev/bsp-guide/index.html>`_ for all "
+"supported hardware (since *fido*) and is designed to be standalone with "
+"*Poky*. Only these two parts are required if you want to integrate the "
+"PHYTEC's hardware into your existing *Yocto* workflow. The features are:"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:432
+msgid ""
+"The BSP content gets pulled from different online sources when you first "
+"start using *Bitbake*. All files will be downloaded and cloned in a local"
+" directory configured as ``DL_DIR`` in *Yocto*. If you backup your BSP "
+"with the complete content, those sources have to be backed up, too. How "
+"you can do this will be explained in the chapter :ref:`scarthgap_gen-"
+"source-mirrors`."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:489
+msgid ""
+"Continue with the next step :ref:`scarthgap_git-config` after that. The "
+"documentation for using build-container can be found in this manual after"
+" :ref:`scarthgap_phylinux-advanced-usage` of phyLinux."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:504
+msgid ""
+"For other distributions you can find information in the *Yocto* Quick "
+"Build: https://docs.yoctoproject.org/dev/brief-yoctoprojectqs/index.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1033
+msgid ""
+"Special release manifests exist to give you access to the current "
+"development states of the *Yocto* BSP. They will be displayed in the "
+"phyLinux selection menu with the ending *PDXX.X.y*"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1041
+msgid "This will initialize a BSP that will track the latest development state."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1074
+msgid ""
+"You can then point your browser to *http://0.0.0.0:8000/* and continue "
+"working with *Bitbake*. All build activity can be monitored and analyzed "
+"from this web server. If you want to learn more about *Toaster*, look at "
+"https://docs.yoctoproject.org/dev/toaster-manual/index.html. To shut down"
+" the *Toaster* web GUI again, execute"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1314
+msgid ""
+"To add additional software to the image, look at the OpenEmbedded layer "
+"index: "
+"https://layers.openembedded.org/layerindex/branch/scarthgap/layers/"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1373
+msgid ""
+"References: `Yocto dev Documentation - Customizing Yocto builds "
+"<https://docs.yoctoproject.org/dev/singleindex.html#user-configuration>`_"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1379
+msgid ""
+"This is a step-by-step guide on how to add another layer to your *Yocto* "
+"build and install additional software from it. As an example, we include "
+"the network security scanner *nmap* in the layer *meta-security*. First, "
+"you must locate the layer on which the software is hosted. Check out the "
+"`OpenEmbedded MetaData Index "
+"<https://layers.openembedded.org/layerindex/branch/scarthgap/layers/>`_ "
+"and guess a little bit. The network scanner *nmap* is in the *meta-"
+"security* layer. See `meta-security on layers.openembedded.org "
+"<https://layers.openembedded.org/layerindex/branch/scarthgap/layer/meta-"
+"security/>`_. To integrate it into the *Yocto* build, you have to check "
+"out the repository and then switch to the correct stable branch. Since "
+"the BSP is based on the *Yocto* |yocto-codename| build, you should try to"
+" use the |yocto-codename| branch in the layer, too."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1398
+msgid ""
+"All available remote branches will show up. Usually there should be "
+"'sumo', 'warrior', 'zeus', 'dunfell', 'hardnkott', 'kirkstone', "
+"'mickledore', 'master'..."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1789
+msgid ""
+"Your changes will now be recompiled and added to the image. If you want "
+"to store your changes permanently, it is advisable to create a patch from"
+" the changes, then store and backup only the patch. You can go into the "
+"*linux-mainline* directory and create a patch using *Git*. How to create "
+"a patch is described in :ref:`scarthgap_temporary-method` and is the same"
+" for all methods."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1797
+msgid ""
+"`Yocto dev - Devtool <https://docs.yoctoproject.org/dev/sdk-"
+"manual/extensible.html#using-devtool-in-your-sdk-workflow>`_ or `Devtool "
+"Quick Reference <https://docs.yoctoproject.org/dev/ref-manual/devtool-"
+"reference.html>`_"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1936
+msgid ""
+"`Yocto - Kernel Development Manual <https://docs.yoctoproject.org/dev"
+"/kernel-dev/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:1938
+msgid ""
+"`Yocto - Development Manual <https://docs.yoctoproject.org/dev/dev-"
+"manual/index.html>`_"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:2421
+msgid ""
+"To finish the configuration you can configure DHCP to receive an IP "
+"address (supported by most WLAN access points). For other possible IP "
+"configurations, see the section :ref:`scarthgap_changing-net-config`."
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:2834
+msgid ""
+"To be able to build a Qt6 application with the SDK and the Meson Build "
+"system, the following has to be done, *after* the SDK has been sourced:"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:2940
+msgid ""
+"Refer to the official *Yocto* documentation for more information: "
+"https://docs.yoctoproject.org/dev/singleindex.html#autotools-based-"
+"projects"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:3067
+msgid ""
+"The most important piece of documentation for a BSP user is probably the "
+"developer manual. https://docs.yoctoproject.org/dev/dev-manual/index.html"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:3071
+msgid ""
+"The chapter about common tasks is a good starting point. "
+"https://docs.yoctoproject.org/dev/dev-manual/layers.html#understanding-"
+"and-creating-layers"
+msgstr ""
+
+#: ../../source/yocto/scarthgap.rst:3074
+msgid ""
+"The complete documentation is available on one single HTML page, which is"
+" good for searching for a feature or a variable name. "
+"https://docs.yoctoproject.org/dev/singleindex.html"
+msgstr ""
+

--- a/source/sphinx/templates/versions.html
+++ b/source/sphinx/templates/versions.html
@@ -1,0 +1,16 @@
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    Languages
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {% if languages|length >= 1 %}
+    <dl>
+      <dt>{{ _('Languages') }}</dt>
+        {% for the_language, url in languages %}
+          <dd><a href="{{ url }}/index.html">{{ the_language }}</a></dd>
+        {% endfor %}
+    </dl>
+    {% endif %}
+  </div>
+</div>

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,12 @@ skipsdist = true
 deps =
     -r requirements/build.txt
 
+[testenv:py3-intl]
+commands =
+    sphinx-build -b gettext source build/locale
+    sphinx-intl update -p build/locale -l zh_CN
+    sphinx-build -E -W --keep-going -b html -D language=zh_CN source build/html/zh_CN -j auto
+
 [testenv:py3-html]
 commands =
     sphinx-build -E -W --keep-going -b html source build/html -j auto
@@ -16,8 +22,10 @@ allowlist_externals =
 commands =
     # Builds are not only handled by sphinx, so we need to clean the build dir.
     sh -c 'find build/latex -type f -delete 2>/dev/null || true'
-    sphinx-build -M latex source build -W --keep-going -j auto
-    sh -c 'make -C build/latex -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
+    sphinx-build -M latex -d build -D language=en source build/latex/en -W --keep-going -j auto
+    sphinx-build -M latex -d build -D language=zh_CN source build/latex/zh_CN -W --keep-going -j auto
+    sh -c 'make -C build/latex/en -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
+    sh -c 'make -C build/latex/zh_CN -j $(nproc) --keep-going LATEXMKOPTS="-silent"'
 
 [testenv:py3-linkcheck]
 commands =


### PR DESCRIPTION
This PR is a draft on how to add internationalization to the project. Pushing to test the GitHub actions compatibility and review. ~More information coming soon.~

### Overview
Spinx can automatically generate text files (*.pot, *.po) that contain translation references, called messages (more [details](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html)). Those messages are broken down in paragraphs. For simplified Chinese (zh_CN) the files are located at:

```
doc-bsp-yocto/source/locale/zh_CN/
└── LC_MESSAGES
    ├── bsp.po
    ├── contributing_links.po
    ├── index.po
    ├── sphinx.po
    └── yocto.po
```

The file bsp.po contains a list of messages (strings to be translated) found in all BSP manuals. This looks as follows:
  
```
#: ../../source/bsp/getting-started.rsti:27                                                           
#: ../../source/bsp/imx8/imx8mm/pd23.1.0.rst:185                                                      
#: ../../source/bsp/imx8/imx8mn/pd23.1.0.rst:176                                                      
#: ../../source/bsp/imx8/imx8mp/pd23.1.0.rst:194                                                      
#: ../../source/bsp/imx8/imx8mp/pd24.1.1.rst:189                                                      
msgid "Get either the partup package or the WIC image from the download server:"                      
msgstr "从下载服务器获取 partup 软件包或 WIC 镜像：" 
```

The string `"Get either [..]"` exists in 5 documents. Once a translation is provided, it can be used in all of those documents simultaneously. I added an example translation via ChatGPT. That means once all messages are translated in the *.po files, the whole documentation is available in both languages. `bsp.po` has 12k lines of code, of which most lines are references to files. There is an editor called `poedit`, that may help in filling the translations. If I load `bsp.po` in `poedit`, it shows 1576 translation messages.

The advantage of this method of summarizing all translation messages into only a few files is that we don't have to repeatedly go through individual documents to translate them.

### Keeping translations in Sync:
If a new Pull-Request changes the original documentation, Sphinx will automatically keep track of the messages in the `*.po `files. I will setup GitHub action later that automatically creates a new Pull-Request with the changes.

Example of changes in bsp.po on original content change:
```
-#: ../../source/bsp/imx8/development/netboot.rsti:11
-msgid "Copy the kernel fitimage to your tftp directory:"

+#: ../../source/bsp/imx8/imx8mp/head.rst:247
+msgid "Starting with this release, the boot behavior [..]"
```

### Representation on GitHub Pages:
The user can change the language of the documentation via a language switching menu at the bottom of the page. The menu uses hardcoded links to https://phytec.github.io/doc-bsp-yocto and https://phytec.github.io/doc-bsp-yocto/zh_CN, so it will currently not work with the preview.

**Working preview page:** https://phytec.github.io/doc-bsp-yocto/previews/215/zh_CN/index.html

![image](https://github.com/user-attachments/assets/a79e1882-e92d-4441-a286-1c0defe49d37)