### PR TITLE
Wip/bhahn/BSPIMX8M-3386 BSPIMX8M-3342

### DIFF
--- a/source/bsp/imx-common/peripherals/display.rsti
+++ b/source/bsp/imx-common/peripherals/display.rsti
@@ -6,6 +6,10 @@ with the Linux kernel sysfs interface. All available backlight devices in the
 system can be found in the folder /sys/class/backlight. Reading the appropriate
 files and writing to them allows you to control the backlight.
 
+.. note::
+   Some boards with multiple display connectors might have multiple backlight
+   controls in /sys/class/backlight. For example: backlight0 and backlight1
+
 *  To get, for example, the maximum brightness level (max_brightness) execute:
 
    .. code-block:: console

--- a/source/bsp/imx8/dt-overlays.rsti
+++ b/source/bsp/imx8/dt-overlays.rsti
@@ -22,7 +22,7 @@ You can read and write the file on booted target from linux:
    :substitutions:
 
    target:~$ cat /boot/bootenv.txt
-   overlays=|dt-carrierboard|-peb-eval-01.dtbo |dt-carrierboard|-peb-av-010.dtbo
+   overlays=|dt-carrierboard|-peb-eval-01.dtbo |dtbo-peb-av-10|
 
 Changes will take effect after the next reboot. If no ``bootenv.txt`` file is
 available the overlays variable can be set directly in the U-Boot environment.
@@ -30,9 +30,9 @@ available the overlays variable can be set directly in the U-Boot environment.
 .. code-block::
    :substitutions:
 
-   u-boot=> setenv overlays |dt-carrierboard|-peb-av-010.dtbo
+   u-boot=> setenv overlays |dtbo-peb-av-10|
    u-boot=> printenv overlays
-   overlays=|dt-carrierboard|-peb-av-010.dtbo
+   overlays=|dtbo-peb-av-10|
    u-boot=> boot
 
 If a user defined ``${overlays}`` variable should be directly loaded from U-Boot
@@ -43,7 +43,7 @@ variable needs to be set as a flag:
    :substitutions:
 
    u-boot=> setenv no_bootenv 1
-   u-boot=> setenv overlays |dt-carrierboard|-peb-av-010.dtbo
+   u-boot=> setenv overlays |dtbo-peb-av-10|
    u-boot=> boot
 
 More information about the external environment can be found in

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -60,6 +60,7 @@
 .. |dt-carrierboard| replace:: imx8mm-phyboard-polis-rdk
 .. |dt-som| replace:: imx8mm-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mm-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mm-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MM) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mm-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n59`

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -53,6 +53,7 @@
 .. |dt-carrierboard| replace:: imx8mm-phyboard-polis-rdk
 .. |dt-som| replace:: imx8mm-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mm-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mm-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MM) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mm-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n53`

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -58,6 +58,7 @@
 .. |dt-carrierboard| replace:: imx8mm-phyboard-polis-rdk
 .. |dt-som| replace:: imx8mm-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mm-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mm-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MM) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mm-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n59`

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -58,6 +58,7 @@
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mn-phyboard-polis
 .. |dt-som| replace:: imx8mn-phycore-som
+.. |dtbo-peb-av-10| replace:: imx8mn-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MN) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n50`

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -52,6 +52,7 @@
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mn-phyboard-polis
 .. |dt-som| replace:: imx8mn-phycore-som
+.. |dtbo-peb-av-10| replace:: imx8mn-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MN) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n47`

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -57,6 +57,7 @@
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mn-phyboard-polis
 .. |dt-som| replace:: imx8mn-phycore-som
+.. |dtbo-peb-av-10| replace:: imx8mn-phyboard-polis-peb-av-010.dtbo
 
 .. IMX8(MN) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n50`

--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -9,7 +9,7 @@ overlays for the different interfaces.
 Interface Expansion                devicetree overlay
 ========= ======================== ======================================
 HDMI      |sbc|                    no overlay needed (enabled by default)
-LVDS0     PEB-AV-10                imx8mp-phyboard-pollux-peb-av-010.dtbo
+LVDS0     PEB-AV-10                |dtbo-peb-av-10|
                                    (loaded by default)
 LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
 MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -60,6 +60,7 @@
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-10.dtbo
 
 .. IMX8(MP) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n50`
@@ -284,13 +285,14 @@ To revert to the old style of booting, you may do
 .. _imx8mp-head-device-tree:
 .. include:: /bsp/device-tree.rsti
 
-::
+.. code-block::
+   :substitutions:
 
    imx8mp-isi-csi1.dtbo
    imx8mp-isi-csi2.dtbo
    imx8mp-isp-csi1.dtbo
    imx8mp-isp-csi2.dtbo
-   imx8mp-phyboard-pollux-peb-av-010.dtbo
+   |dtbo-peb-av-10|
    imx8mp-phyboard-pollux-peb-av-012.dtbo
    imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
    imx8mp-phycore-no-eth.dtbo

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -52,6 +52,7 @@
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-010.dtbo
 
 .. IMX8(MP) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n41`

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -52,6 +52,7 @@
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-010.dtbo
 
 .. IMX8(MP) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n41`

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -58,6 +58,7 @@
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
 .. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-010.dtbo
 
 .. IMX8(MP) specific
 .. |dt-somnetwork| replace:: :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n50`

--- a/source/bsp/imx8/imx8mp/wireless-network.rsti
+++ b/source/bsp/imx8/imx8mp/wireless-network.rsti
@@ -19,7 +19,7 @@ PEB-WLBT-05.
 
    .. code-block::
 
-      overlays=imx8mp-phyboard-pollux-peb-av-010.dtbo imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+      overlays=imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
 
    The changes will be applied after a reboot:
 

--- a/source/bsp/imx8/mcu.rsti
+++ b/source/bsp/imx8/mcu.rsti
@@ -171,7 +171,7 @@ adding |dtbo-rpmsg|:
 .. code-block::
    :substitutions:
 
-   overlays=imx8mp-phyboard-xxxxx-peb-av-010.dtbo |dtbo-rpmsg|
+   overlays=|dtbo-rpmsg|
 
 Restart the target and execute in U-Boot::
 

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -97,32 +97,14 @@ The Bluetooth device needs to be set up manually:
 
    target:~$ hciconfig hci0 up
 
-   target:~$ hciconfig
+   target:~$ hciconfig -a
 
    hci0:   Type: Primary  Bus: UART
            BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
            UP RUNNING PSCAN
            RX bytes:1392 acl:0 sco:0 events:76 errors:0
            TX bytes:1198 acl:0 sco:0 commands:76 errors:0
-
-   target:~$ hciconfig -a
-
-   hci0:   Type: Primary  Bus: UART
-           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
-           UP RUNNING PSCAN
-           RX bytes:3179 acl:8 sco:0 events:104 errors:0
-           TX bytes:1599 acl:8 sco:0 commands:85 errors:0
-           Features: 0xbf 0xfe 0xcf 0xfe 0xdb 0xff 0x7b 0x87
-           Packet type: DM1 DM3 DM5 DH1 DH3 DH5 HV1 HV2 HV3
-           Link policy: RSWITCH SNIFF
-           Link mode: SLAVE ACCEPT
-           Name: 'phyboard-polaris-imx8m-2'
-           Class: 0x200000
-           Service Classes: Audio
-           Device Class: Miscellaneous,
-           HCI Version: 4.1 (0x7)  Revision: 0x60
-           LMP Version: 4.1 (0x7)  Subversion: 0x2209
-           Manufacturer: Broadcom Corporation (15)
+           ...
 
 Now you can scan your environment for visible Bluetooth devices. Bluetooth is
 not visible during a default startup.


### PR DESCRIPTION
- remove old outdated hci info
- peb-av-10 overlay got renamed for new imx8mp PD24.1.0 NXP BSP
- add note that some boards might have multiple backlight controls