### PR TITLE
bsp: imx8mp: display: Adjust HDMI weston mode

### DIFF
--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -44,10 +44,11 @@ Single Display
 In our BSP, the default Weston output is set to HDMI.
 
 .. code-block::
+   :substitutions:
 
    [output]
    name=HDMI-A-1
-   mode=current
+   mode=|weston-hdmi-mode|
 
    [output]
    name=LVDS-1
@@ -73,13 +74,14 @@ Dual Display
 ~~~~~~~~~~~~
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
-have to be set to current:
+have to be set to the:
 
 .. code-block::
+   :substitutions:
 
    [output]
    name=HDMI-A-1
-   mode=current
+   mode=|weston-hdmi-mode|
 
    [output]
    name=LVDS-1
@@ -89,6 +91,7 @@ For dual display at LVDS0 (PEB-AV-010) and MIPI (PEB-AV-012), both dtbos need to
 be loaded at the bootenv.txt and the weston.ini should look like this:
 
 .. code-block::
+   :substitutions:
 
    [output]
    name=HDMI-A-1
@@ -110,10 +113,11 @@ Three outputs: HDMI, LVDS-1 (PEB-AV-10), and LVDS-2 (PEB-AV-12). Remember to
 load both dtbos for LVDS interfaces.
 
 .. code-block::
+   :substitutions:
 
    [output]
    name=HDMI-A-1
-   mode=current
+   mode=|weston-hdmi-mode|
 
    [output]
    name=LVDS-1

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -111,6 +111,7 @@
 .. |ref-jp4| replace:: :ref:`JP4 <imx8mp-head-components>`
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mp-head-ubootexternalenv>`
+.. |weston-hdmi-mode| replace:: preferred
 
 
 .. M-Core specific

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -103,6 +103,7 @@
    Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
    to GPIO fan due to availability. The PWM fan will not be supported
    anymore and will not function with the new release.
+.. |weston-hdmi-mode| replace:: current
 
 .. |ref-serial| replace:: :ref:`X2 <imx8mp-pd23.1.0-components>`
 .. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd23.1.0-components>`


### PR DESCRIPTION
HDMI weston mode which should be used in weston.ini changed from "current" to "preferred".