### PR TITLE
bsp: imx-common: standalone_build_kernel: Fix indentation

### DIFF
--- a/source/bsp/imx-common/development/standalone_build_kernel.rsti
+++ b/source/bsp/imx-common/development/standalone_build_kernel.rsti
@@ -38,8 +38,8 @@ Build Kernel
 
 *  Install kernel modules to e.g. NFS directory:
 
-  .. code-block:: console
-     :substitutions:
+   .. code-block:: console
+      :substitutions:
 
       host:~/|kernel-repo-name|$ make INSTALL_MOD_PATH=/home/<user>/<rootfspath> modules_install
 


### PR DESCRIPTION
The code block wasn't correctly formatted. Fixes 9badff3380f40