### PR TITLE
bsp: imx8mp: head: Update linux recipe name

### DIFF
--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -29,7 +29,7 @@
 
 .. Linux Kernel
 .. |kernel-defconfig| replace:: imx8_phytec_defconfig
-.. |kernel-recipe-path| replace:: meta-phytec/recipes-kernel/linux/linux-imx-phytec_*.bb
+.. |kernel-recipe-path| replace:: meta-phytec/recipes-kernel/linux/linux-phytec-imx_*.bb
 .. |kernel-repo-name| replace:: linux-imx
 .. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
 .. |kernel-socname| replace:: imx8mp


### PR DESCRIPTION
To fit the PHYTEC repo naming scheme we updated the recipe name to linux-phytec-imx_*.bb. Update documentation, too.