### PR TITLE
Wip/andrej.picej@norik.com/bspimx8 m 3351

### DIFF
--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -77,6 +77,11 @@ imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 Dual Display
 ~~~~~~~~~~~~
 
+.. note::
+
+   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
+   together.
+
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
 have to be set to the:
 
@@ -106,11 +111,6 @@ be loaded at the bootenv.txt and the weston.ini should look like this:
    [output]
    name=LVDS-1
    mode=current
-
-.. note::
-
-   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
-   together.
 
 Triple Display
 ~~~~~~~~~~~~~~

--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -1,6 +1,8 @@
 Display
 -------
 
+.. supported-display-interfaces-marker-start
+
 The |sbc| supports up to 4 different display outputs. Three can be used
 simultaneously. The following table shows the required extensions and devicetree
 overlays for the different interfaces.
@@ -15,6 +17,8 @@ LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
 MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo
 ========= ======================== ======================================
 
+.. supported-display-interfaces-marker-end
+
 .. note::
 
    *  When changing Weston output, make sure to match the audio output as well.
@@ -24,7 +28,7 @@ HDMI is always enabled in the devicetree. The other interfaces can be enabled
 with Device Tree Overlay.
 
 The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-010). We support a
-10'' edt,etml1010g0dka display for the PEB-AV-10 and PEB-AV-12.
+10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
 
 .. note::
 
@@ -86,6 +90,8 @@ have to be set to the:
    [output]
    name=LVDS-1
    mode=current
+
+.. no-peb-av-12-marker
 
 For dual display at LVDS0 (PEB-AV-010) and MIPI (PEB-AV-012), both dtbos need to
 be loaded at the bootenv.txt and the weston.ini should look like this:

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -112,6 +112,7 @@
 .. |ref-jp4| replace:: :ref:`JP4 <imx8mp-head-components>`
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mp-head-ubootexternalenv>`
+.. |lvds-display-adapters| replace:: PEB-AV-10
 .. |weston-hdmi-mode| replace:: preferred
 
 
@@ -514,6 +515,24 @@ Device Tree Audio configuration:
 .. include:: /bsp/peripherals/video.rsti
 
 .. include:: display.rsti
+   :end-before: .. supported-display-interfaces-marker-start
+
+The |sbc| supports up to 3 different display outputs. Two can be used
+simultaneously. The following table shows the required extensions and devicetree
+overlays for the different interfaces.
+
+========= ======================== ======================================
+Interface Expansion                devicetree overlay
+========= ======================== ======================================
+HDMI      |sbc|                    no overlay needed (enabled by default)
+LVDS0     PEB-AV-10                |dtbo-peb-av-10|
+                                   (loaded by default)
+LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
+========= ======================== ======================================
+
+.. include:: display.rsti
+   :start-after: .. supported-display-interfaces-marker-end
+   :end-before: .. no-peb-av-12-marker
 
 .. include:: /bsp/qt6.rsti
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -295,7 +295,6 @@ To revert to the old style of booting, you may do
    imx8mp-isp-csi1.dtbo
    imx8mp-isp-csi2.dtbo
    |dtbo-peb-av-10|
-   imx8mp-phyboard-pollux-peb-av-012.dtbo
    imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
    imx8mp-phycore-no-eth.dtbo
    imx8mp-phycore-no-rtc.dtbo

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -104,6 +104,7 @@
    Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
    to GPIO fan due to availability. The PWM fan will not be supported
    anymore and will not function with the new release.
+.. |lvds-display-adapters| replace:: PEB-AV-10 and PEB-AV-012
 .. |weston-hdmi-mode| replace:: current
 
 .. |ref-serial| replace:: :ref:`X2 <imx8mp-pd23.1.0-components>`


### PR DESCRIPTION
Need to exclude PEB-AV-12 and tripple display support from next NXP BSP release.

Hope this makes sense. Not sure if this is easier then copying the whole display chapter to the base file of the release and modifying it there.