### PR TITLE
BSPIMX8M-3419: Bluetooth and Wifi updates

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -23,6 +23,7 @@
 .. |som| replace:: phyCORE-i.MX8MM
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
+.. |bluetooth-uart| replace:: UART2
 .. |expansion-connector| replace:: X8
 
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -23,6 +23,7 @@
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |expansion-connector| replace:: X8
+.. |bluetooth-uart| replace:: UART2
 
 
 .. Linux Kernel

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -1191,7 +1191,155 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
+
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 
 .. note::
 

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -22,6 +22,7 @@
 .. |som| replace:: phyCORE-i.MX8MM
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
+.. |bluetooth-uart| replace:: UART2
 .. |expansion-connector| replace:: X8
 
 

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -1241,8 +1241,155 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
+
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 .. note::
 
    If the connection fails with the error message: "Failed to connect:

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -24,6 +24,7 @@
 .. |som| replace:: phyCORE-i.MX8MN
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
+.. |bluetooth-uart| replace:: UART2
 
 
 .. Linux Kernel

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -1187,7 +1187,155 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
+
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 
 .. note::
 

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -23,6 +23,7 @@
 .. |som| replace:: phyCORE-i.MX8MN
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
+.. |bluetooth-uart| replace:: UART2
 
 
 .. Linux Kernel

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -23,6 +23,7 @@
 .. |som| replace:: phyCORE-i.MX8MN
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
+.. |bluetooth-uart| replace:: UART2
 
 
 .. Linux Kernel

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -1222,7 +1222,156 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
+
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
+
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -24,6 +24,7 @@
 .. |som| replace:: phyCORE-i.MX8MP
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART3
 .. |expansion-connector| replace:: X6
 
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -389,6 +389,13 @@ module and board.
 .. include:: wireless-network.rsti
 
 .. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. bluetooth_chapter_start_label
+
+Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
+is described in the WLAN section.
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :start-after: .. bluetooth_chapter_start_label
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -1217,7 +1217,42 @@ module and board.
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
 
-.. include:: wireless-network.rsti
+WLAN
+....
+
+WLAN and Bluetooth on the |sbc| are provided by the PEB-WLBT-05 expansion card.
+The PEB-WLBT-05 for |sbc| Quickstart Guide shows you how to install the
+PEB-WLBT-05.
+
+.. tip::
+
+   With the BSP Version PD22.1 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   otherwise the PEB-WLBT-05 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
+module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
+information about the module can be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -1255,11 +1255,158 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
-   :end-before: .. bluetooth_chapter_start_label
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
 
 Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
 is described in the WLAN section.
+
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 
 .. include:: ../../peripherals/wireless-network.rsti
    :start-after: .. bluetooth_chapter_start_label

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -1255,6 +1255,13 @@ information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. bluetooth_chapter_start_label
+
+Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
+is described in the WLAN section.
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :start-after: .. bluetooth_chapter_start_label
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -22,6 +22,7 @@
 .. |som| replace:: phyCORE-i.MX8MP
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART3
 .. |expansion-connector| replace:: X6
 
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -1285,6 +1285,13 @@ information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. bluetooth_chapter_start_label
+
+Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
+is described in the WLAN section.
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :start-after: .. bluetooth_chapter_start_label
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -1285,14 +1285,158 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
-   :end-before: .. bluetooth_chapter_start_label
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
 
 Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
 is described in the WLAN section.
 
-.. include:: ../../peripherals/wireless-network.rsti
-   :start-after: .. bluetooth_chapter_start_label
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -1247,7 +1247,42 @@ module and board.
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
 
-.. include:: wireless-network.rsti
+WLAN
+....
+
+WLAN and Bluetooth on the |sbc| are provided by the PEB-WLBT-05 expansion card.
+The PEB-WLBT-05 for |sbc| Quickstart Guide shows you how to install the
+PEB-WLBT-05.
+
+.. tip::
+
+   With the BSP Version PD22.1 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   otherwise the PEB-WLBT-05 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
+module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
+information about the module can be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -22,6 +22,7 @@
 .. |som| replace:: phyCORE-i.MX8MP
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART3
 .. |expansion-connector| replace:: X6
 
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -1317,6 +1317,13 @@ information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. bluetooth_chapter_start_label
+
+Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
+is described in the WLAN section.
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :start-after: .. bluetooth_chapter_start_label
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -1279,7 +1279,42 @@ module and board.
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
 
-.. include:: wireless-network.rsti
+WLAN
+....
+
+WLAN and Bluetooth on the |sbc| are provided by the PEB-WLBT-05 expansion card.
+The PEB-WLBT-05 for |sbc| Quickstart Guide shows you how to install the
+PEB-WLBT-05.
+
+.. tip::
+
+   With the BSP Version PD22.1 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   otherwise the PEB-WLBT-05 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
+module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
+information about the module can be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. include:: ../../peripherals/wireless-network.rsti
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -1317,14 +1317,158 @@ mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
 information about the module can be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
-.. include:: ../../peripherals/wireless-network.rsti
-   :end-before: .. bluetooth_chapter_start_label
+Connecting to a WLAN Network
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First set the correct regulatory domain for your country:
+
+.. code-block:: console
+
+   target:~$ iw reg set DE
+   target:~$ iw reg get
+
+You will see:
+
+.. code-block::
+
+   country DE: DFS-ETSI
+      (2400 - 2483 @ 40), (N/A, 20), (N/A)
+      (5150 - 5250 @ 80), (N/A, 20), (N/A), NO-OUTDOOR
+      (5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS
+      (5470 - 5725 @ 160), (N/A, 26), (0 ms), DFS
+      (57000 - 66000 @ 2160), (N/A, 40), (N/A)
+
+Set up the wireless interface:
+
+.. code-block:: console
+
+   target:~$ ip link
+   target:~$ ip link set up dev wlan0
+
+Now you can scan for available networks:
+
+.. code-block:: console
+
+   target:~$ iw wlan0 scan | grep SSID
+
+You can use a cross-platform supplicant with support for WEP, WPA, and WPA2 called wpa_supplicant for an encrypted connection.
+
+To do so, add the network-credentials to the file ``/etc/wpa_supplicant.conf``:
+
+.. code-block::
+
+   country=DE
+   network={
+       ssid="<SSID>"
+       proto=WPA2
+       psk="<KEY>"
+   }
+
+Now a connection can be established:
+
+.. code-block:: console
+
+   target:~$ wpa_supplicant -D nl80211 -c /etc/wpa_supplicant.conf -i wlan0 -B
+
+This should result in the following output:
+
+.. code-block::
+
+   ...
+   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+
+To finish the configuration you can configure DHCP to receive an IP address
+(supported by most WLAN access points). For other possible IP configurations,
+see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
+
+First, create the directory:
+
+.. code-block:: console
+
+   target:~$ mkdir -p /etc/systemd/network/
+
+Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
+
+.. code-block::
+
+   # file /etc/systemd/network/10-wlan0.network
+   [Match]
+   Name=wlan0
+
+   [Network]
+   DHCP=yes
+
+Now, restart the network daemon so that the configuration takes effect:
+
+.. code-block:: console
+
+   target:~$ systemctl restart systemd-networkd
+
+Bluetooth
+.........
 
 Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this can be activated
 is described in the WLAN section.
 
-.. include:: ../../peripherals/wireless-network.rsti
-   :start-after: .. bluetooth_chapter_start_label
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
+be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+The Bluetooth device needs to be set up manually:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 up
+
+   target:~$ hciconfig -a
+
+   hci0:   Type: Primary  Bus: UART
+           BD Address: 00:25:CA:2F:39:96  ACL MTU: 1021:8  SCO MTU: 64:1
+           UP RUNNING PSCAN
+           RX bytes:1392 acl:0 sco:0 events:76 errors:0
+           TX bytes:1198 acl:0 sco:0 commands:76 errors:0
+           ...
+
+Now you can scan your environment for visible Bluetooth devices. Bluetooth is
+not visible during a default startup.
+
+.. code-block:: console
+
+   target:~$ hcitool scan
+   Scanning ...
+          XX:XX:XX:XX:XX:XX       <SSID>
+
+Visibility
+~~~~~~~~~~
+
+To activate visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 piscan
+
+To disable visibility:
+
+.. code-block:: console
+
+   target:~$ hciconfig hci0 noscan
+
+Connect
+~~~~~~~
+
+.. code-block:: console
+
+   target:~$ bluetoothctl
+   [bluetooth]# discoverable on
+   Changing discoverable on succeeded
+   [bluetooth]# pairable on
+   Changing pairable on succeeded
+   [bluetooth]# agent on
+   Agent registered
+   [bluetooth]# default-agent
+   Default agent request successful
+   [bluetooth]# scan on
+   [NEW] Device XX:XX:XX:XX:XX:XX <name>
+   [bluetooth]# connect XX:XX:XX:XX:XX:XX
 
 .. note::
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -22,6 +22,7 @@
 .. |som| replace:: phyCORE-i.MX8MP
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART3
 .. |expansion-connector| replace:: X6
 
 

--- a/source/bsp/imx8/imx8mp/wireless-network.rsti
+++ b/source/bsp/imx8/imx8mp/wireless-network.rsti
@@ -19,7 +19,7 @@ PEB-WLBT-05.
 
    .. code-block::
 
-      overlays=imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+      overlays=conf-imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
 
    The changes will be applied after a reboot:
 

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -55,8 +55,7 @@ This should result in the following output:
 
 .. code-block::
 
-   ...
-   ENT-CONNECTED - Connection to 88:33:14:5d:db:b1 completed [id=0 id_str=]
+   Successfully initialized wpa_supplicant
 
 To finish the configuration you can configure DHCP to receive an IP address
 (supported by most WLAN access points). For other possible IP configurations,

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -88,6 +88,8 @@ Now, restart the network daemon so that the configuration takes effect:
 Bluetooth
 .........
 
+.. bluetooth_chapter_start_label
+
 Bluetooth is connected to UART2 interface. More information about the module can
 be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -57,32 +57,8 @@ This should result in the following output:
 
    Successfully initialized wpa_supplicant
 
-To finish the configuration you can configure DHCP to receive an IP address
-(supported by most WLAN access points). For other possible IP configurations,
+The ip address is automatically configured over DHCP. For other possible IP configurations,
 see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
-
-First, create the directory:
-
-.. code-block:: console
-
-   target:~$ mkdir -p /etc/systemd/network/
-
-Then add the following configuration snippet in ``/etc/systemd/network/10-wlan0.network``:
-
-.. code-block::
-
-   # file /etc/systemd/network/10-wlan0.network
-   [Match]
-   Name=wlan0
-
-   [Network]
-   DHCP=yes
-
-Now, restart the network daemon so that the configuration takes effect:
-
-.. code-block:: console
-
-   target:~$ systemctl restart systemd-networkd
 
 Bluetooth
 .........

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -90,7 +90,7 @@ Bluetooth
 
 .. bluetooth_chapter_start_label
 
-Bluetooth is connected to UART2 interface. More information about the module can
+Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
 be found at
 https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
 The Bluetooth device needs to be set up manually:


### PR DESCRIPTION
Small updates for Bluetooth and wifi contain:
- Update overlays parameter names for fitImage configs on i.MX8MP
- Add a note in the Bluetooth chapter where PEB-WLBT-05 configuration can be found (i.MX8MP)
- Make UART device for Bluetooth configurable. It was set fix to UART3 but this only fits for i.MX8MP and not i.MX8MM/N 
- wpa-suplicant command output changed
- wifi is automatically configured as DHCP in scarthgap. No need to explain how to set this up