### PR TITLE
i.MX93 PD24.2.0 update

### DIFF
--- a/source/bsp/imx9/imx93/imx93.rst
+++ b/source/bsp/imx9/imx93/imx93.rst
@@ -2,6 +2,16 @@
 i.MX 93 Manuals
 ====================
 
+BSP-Yocto-NXP-i.MX93-PD24.2.0
+=============================
+
+.. toctree::
+   :caption: Table of Contents
+   :numbered:
+   :maxdepth: 2
+
+   pd24.2.0
+
 BSP-Yocto-NXP-i.MX93-PD24.1.1
 =============================
 

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -231,7 +231,275 @@ select the phyCORE-|soc| default bootsource.
 .. _imx93-pd24.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
 
-.. include:: ../installing-os.rsti
+Flash eMMC
+----------
+
+To boot from eMMC, make sure that the BSP image is flashed correctly to the eMMC
+and the |ref-bootswitch| is set to **eMMC**.
+
+.. warning::
+   When eMMC and SD card are flashed with the same (identical) image, the UUIDs
+   of the boot partitions are also identical. If the SD card is connected when
+   booting, this leads to non-deterministic behavior as Linux mounts the boot
+   partition based on UUID.
+
+   .. code-block:: console
+
+      target:~$ blkid
+
+   can be run to inspect whether the current setup is affected. If |emmcdev|\p1
+   and mmcblk1p1 have an identical UUID, the setup is affected.
+
+Flash eMMC from SD Card
+.......................
+
+If there is no network available, you can update the eMMC from SD card. For
+that, you only need a ready-to-use image file (``*.wic``) located on the
+SD card. Because the image file is quite large, you have to enlarge your SD card
+to use its full space (if it was not enlarged before). To enlarge your SD card,
+see Resizing ext4 Root Filesystem.
+
+Alternatively, flash a partup package to the SD card, as described in
+|ref-getting-started|. This will ensure the full space of the SD card is used.
+
+Flash eMMC from SD card in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can flash the eMMC on Linux. You only need a partup package or WIC image
+saved on the SD card.
+
+*  Show your saved partup package or WIC image or WIC.XZ image files on the SD card:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.partup
+      |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      |emmcdev|
+      |emmcdev|boot0
+      |emmcdev|boot1
+      |emmcdev|p1
+      |emmcdev|p2
+      |emmcdev|rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
+*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without**
+   partition) using `partup`_:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ partup install |yocto-imagename|-|yocto-machinename|.partup /dev/|emmcdev|
+
+   .. tip::
+
+      **Using partup is highly recommended since it is easier to use and has the
+      advantage of using the full capacity of the eMMC device, adjusting
+      partitions accordingly.**
+
+   .. note::
+
+      Alternatively, ``dd`` may be used instead.
+
+      For uncompressed WIC images (\*.wic):
+
+      .. code-block:: console
+         :substitutions:
+
+         target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+      For compressed WIC images (\*.wic.xz):
+
+      .. code-block:: console
+         :substitutions:
+
+         target:~$ zstdcat |yocto-imagename|-|yocto-machinename|.wic.xz | sudo dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+      Keep in mind that the root partition does not make use of the full space
+      when flashing with ``dd``.
+
+*  After a complete write, your board can boot from eMMC.
+
+   .. warning::
+
+      Before this will work, you need to configure the |ref-bootswitch| to eMMC.
+
+Flash eMMC from Network
+.......................
+
+|soc| boards have an Ethernet connector and can be updated over a network. Be
+sure to set up the development host correctly. The IP needs to be set to
+192.168.3.10, the netmask to 255.255.255.0, and a TFTP server needs to be
+available. From a high-level point of view, an eMMC device is like an SD card.
+Therefore, it is possible to flash the **WIC image** (``<name>.wic``) from
+the Yocto build system directly to the eMMC. The image contains the
+bootloader, kernel, device tree, device tree overlays, and root file system.
+
+.. note::
+
+   Some PHYTECs BSPs produce compressed ``.wic.xz`` images. In this case, the
+   compressed image must first be uncompressed.
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ unxz phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
+
+Flash eMMC via Network in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update the eMMC from your target.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Take an uncompressed image on the host and send it with ssh through
+the network to the eMMC of the target with a one-line command:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ ssh <USER>@192.168.3.10 "dd if=<path_to_file>/|yocto-imagename|-|yocto-machinename|.wic" | dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+Flash eMMC via Network in Linux on Host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is also possible to install the OS at eMMC from your Linux host. As before,
+you need a complete image on your host.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Show your available image files on the host:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ ls
+   |yocto-imagename|-|yocto-machinename|.wic
+
+Send the image with the ``dd`` command combined with ssh through the network
+to the eMMC of your device:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic bs=1M status=progress | ssh root@192.168.3.11 "dd of=/dev/|emmcdev| conv=fsync"
+
+Flash eMMC U-Boot image via Network from running U-Boot
+.......................................................
+
+Update the standalone U-Boot image imx-boot is also possible from U-Boot. This
+can be used if the bootloader on eMMC is located in the eMMC user area.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Load image over tftp into RAM and then write it to eMMC:
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> tftp ${loadaddr} imx-boot
+   u-boot=> setexpr nblk ${filesize} / 0x200
+   u-boot=> mmc dev 0
+   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${nblk}
+
+.. hint::
+   The hexadecimal value represents the offset as a multiple of 512 byte
+   blocks. See the `offset table <#offset-table>`__ for the correct value
+   of the corresponding SoC.
+
+Flash eMMC from USB
+...................
+
+Flash eMMC from USB in Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These steps will show how to flash the eMMC on Linux with a USB stick. You only
+need a complete image saved on the USB stick and a bootable WIC image. (e.g.
+|yocto-imagename|-|yocto-machinename|.wic). Set the |ref-bootswitch| to SD Card.
+
+*  Insert and mount the USB stick:
+
+   .. code-block:: console
+
+      [   60.458908] usb-storage 1-1.1:1.0: USB Mass Storage device detected
+      [   60.467286] scsi host0: usb-storage 1-1.1:1.0
+      [   61.504607] scsi 0:0:0:0: Direct-Access                               8.07 PQ: 0 ANSI: 2
+      [   61.515283] sd 0:0:0:0: [sda] 3782656 512-byte logical blocks: (1.94 GB/1.80 GiB)
+      [   61.523285] sd 0:0:0:0: [sda] Write Protect is off
+      [   61.528509] sd 0:0:0:0: [sda] No Caching mode page found
+      [   61.533889] sd 0:0:0:0: [sda] Assuming drive cache: write through
+      [   61.665969]  sda: sda1
+      [   61.672284] sd 0:0:0:0: [sda] Attached SCSI removable disk
+      target:~$ mount /dev/sda1 /mnt
+
+*  Now show your saved image files on the USB Stick:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ cd /mnt
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.wic
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      |emmcdev|
+      |emmcdev|boot0
+      |emmcdev|boot1
+      |emmcdev|p1
+      |emmcdev|p2
+      |emmcdev|rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
+*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without partition):
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+*  After a complete write, your board can boot from eMMC.
+
+   .. tip::
+
+      Before this will work, you need to configure the |ref-bootswitch| to
+      **eMMC**.
+
+RAUC
+----
+
+The RAUC (Robust Auto-Update Controller) mechanism support has been added to
+meta-ampliphy. It controls the procedure of updating a device with new firmware.
+This includes updating the Linux kernel, Device Tree, and root filesystem.
+PHYTEC has written an online manual on how we have intergraded RAUC into our
+BSPs: `L-1006e.A5 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=fgByJg>`__.
 
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -19,6 +19,7 @@
 .. |socfamily| replace:: i.MX 9
 .. |som| replace:: phyCORE-i.MX93
 .. |debug-uart| replace:: ttyLP0
+.. |serial-uart| replace:: ttyLP6
 .. |expansion-connector| replace:: X16
 
 

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -240,7 +240,275 @@ select the phyCORE-|soc| default bootsource.
 .. _imx93-PD24.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
 
-.. include:: ../installing-os.rsti
+Flash eMMC
+----------
+
+To boot from eMMC, make sure that the BSP image is flashed correctly to the eMMC
+and the |ref-bootswitch| is set to **eMMC**.
+
+.. warning::
+   When eMMC and SD card are flashed with the same (identical) image, the UUIDs
+   of the boot partitions are also identical. If the SD card is connected when
+   booting, this leads to non-deterministic behavior as Linux mounts the boot
+   partition based on UUID.
+
+   .. code-block:: console
+
+      target:~$ blkid
+
+   can be run to inspect whether the current setup is affected. If |emmcdev|\p1
+   and mmcblk1p1 have an identical UUID, the setup is affected.
+
+Flash eMMC from SD Card
+.......................
+
+If there is no network available, you can update the eMMC from SD card. For
+that, you only need a ready-to-use image file (``*.wic``) located on the
+SD card. Because the image file is quite large, you have to enlarge your SD card
+to use its full space (if it was not enlarged before). To enlarge your SD card,
+see Resizing ext4 Root Filesystem.
+
+Alternatively, flash a partup package to the SD card, as described in
+|ref-getting-started|. This will ensure the full space of the SD card is used.
+
+Flash eMMC from SD card in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can flash the eMMC on Linux. You only need a partup package or WIC image
+saved on the SD card.
+
+*  Show your saved partup package or WIC image or WIC.XZ image files on the SD card:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.partup
+      |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      |emmcdev|
+      |emmcdev|boot0
+      |emmcdev|boot1
+      |emmcdev|p1
+      |emmcdev|p2
+      |emmcdev|rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
+*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without**
+   partition) using `partup`_:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ partup install |yocto-imagename|-|yocto-machinename|.partup /dev/|emmcdev|
+
+   .. tip::
+
+      **Using partup is highly recommended since it is easier to use and has the
+      advantage of using the full capacity of the eMMC device, adjusting
+      partitions accordingly.**
+
+   .. note::
+
+      Alternatively, ``dd`` may be used instead.
+
+      For uncompressed WIC images (\*.wic):
+
+      .. code-block:: console
+         :substitutions:
+
+         target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+      For compressed WIC images (\*.wic.xz):
+
+      .. code-block:: console
+         :substitutions:
+
+         target:~$ zstdcat |yocto-imagename|-|yocto-machinename|.wic.xz | sudo dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+      Keep in mind that the root partition does not make use of the full space
+      when flashing with ``dd``.
+
+*  After a complete write, your board can boot from eMMC.
+
+   .. warning::
+
+      Before this will work, you need to configure the |ref-bootswitch| to eMMC.
+
+Flash eMMC from Network
+.......................
+
+|soc| boards have an Ethernet connector and can be updated over a network. Be
+sure to set up the development host correctly. The IP needs to be set to
+192.168.3.10, the netmask to 255.255.255.0, and a TFTP server needs to be
+available. From a high-level point of view, an eMMC device is like an SD card.
+Therefore, it is possible to flash the **WIC image** (``<name>.wic``) from
+the Yocto build system directly to the eMMC. The image contains the
+bootloader, kernel, device tree, device tree overlays, and root file system.
+
+.. note::
+
+   Some PHYTECs BSPs produce compressed ``.wic.xz`` images. In this case, the
+   compressed image must first be uncompressed.
+
+   .. code-block:: console
+      :substitutions:
+
+      host:~$ unxz phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
+
+Flash eMMC via Network in Linux on Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update the eMMC from your target.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Take an uncompressed image on the host and send it with ssh through
+the network to the eMMC of the target with a one-line command:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ ssh <USER>@192.168.3.10 "dd if=<path_to_file>/|yocto-imagename|-|yocto-machinename|.wic" | dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+Flash eMMC via Network in Linux on Host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is also possible to install the OS at eMMC from your Linux host. As before,
+you need a complete image on your host.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Show your available image files on the host:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ ls
+   |yocto-imagename|-|yocto-machinename|.wic
+
+Send the image with the ``dd`` command combined with ssh through the network
+to the eMMC of your device:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic bs=1M status=progress | ssh root@192.168.3.11 "dd of=/dev/|emmcdev| conv=fsync"
+
+Flash eMMC U-Boot image via Network from running U-Boot
+.......................................................
+
+Update the standalone U-Boot image imx-boot is also possible from U-Boot. This
+can be used if the bootloader on eMMC is located in the eMMC user area.
+
+.. tip::
+
+   A working network is necessary! |ref-setup-network-host|
+
+Load image over tftp into RAM and then write it to eMMC:
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> tftp ${loadaddr} imx-boot
+   u-boot=> setexpr nblk ${filesize} / 0x200
+   u-boot=> mmc dev 0
+   u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${nblk}
+
+.. hint::
+   The hexadecimal value represents the offset as a multiple of 512 byte
+   blocks. See the `offset table <#offset-table>`__ for the correct value
+   of the corresponding SoC.
+
+Flash eMMC from USB
+...................
+
+Flash eMMC from USB in Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These steps will show how to flash the eMMC on Linux with a USB stick. You only
+need a complete image saved on the USB stick and a bootable WIC image. (e.g.
+|yocto-imagename|-|yocto-machinename|.wic). Set the |ref-bootswitch| to SD Card.
+
+*  Insert and mount the USB stick:
+
+   .. code-block:: console
+
+      [   60.458908] usb-storage 1-1.1:1.0: USB Mass Storage device detected
+      [   60.467286] scsi host0: usb-storage 1-1.1:1.0
+      [   61.504607] scsi 0:0:0:0: Direct-Access                               8.07 PQ: 0 ANSI: 2
+      [   61.515283] sd 0:0:0:0: [sda] 3782656 512-byte logical blocks: (1.94 GB/1.80 GiB)
+      [   61.523285] sd 0:0:0:0: [sda] Write Protect is off
+      [   61.528509] sd 0:0:0:0: [sda] No Caching mode page found
+      [   61.533889] sd 0:0:0:0: [sda] Assuming drive cache: write through
+      [   61.665969]  sda: sda1
+      [   61.672284] sd 0:0:0:0: [sda] Attached SCSI removable disk
+      target:~$ mount /dev/sda1 /mnt
+
+*  Now show your saved image files on the USB Stick:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ cd /mnt
+      target:~$ ls
+      |yocto-imagename|-|yocto-machinename|.wic
+
+*  Show list of available MMC devices:
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ ls /dev | grep mmc
+      mmcblk1
+      mmcblk1p1
+      mmcblk1p2
+      |emmcdev|
+      |emmcdev|boot0
+      |emmcdev|boot1
+      |emmcdev|p1
+      |emmcdev|p2
+      |emmcdev|rpmb
+
+*  The eMMC device can be recognized by the fact that it contains two boot
+   partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
+*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without partition):
+
+   .. code-block:: console
+      :substitutions:
+
+      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+
+*  After a complete write, your board can boot from eMMC.
+
+   .. tip::
+
+      Before this will work, you need to configure the |ref-bootswitch| to
+      **eMMC**.
+
+RAUC
+----
+
+The RAUC (Robust Auto-Update Controller) mechanism support has been added to
+meta-ampliphy. It controls the procedure of updating a device with new firmware.
+This includes updating the Linux kernel, Device Tree, and root filesystem.
+PHYTEC has written an online manual on how we have intergraded RAUC into our
+BSPs: `L-1006e.A5 RAUC Update & Device Management Manual
+<https://www.phytec.de/cdocuments/?doc=fgByJg>`__.
 
 .. +---------------------------------------------------------------------------+
 .. DEVELOPMENT

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -381,7 +381,7 @@ Available overlays for phyboard-nash-imx93-1.conf are:
 
 ::
 
-   imx93-phyboard-nash-peb-av-010.dtbo
+   imx93-phyboard-nash-peb-av-10.dtbo
    imx93-phycore-rpmsg.dtbo
    imx93-phycore-no-emmc.dtbo
    imx93-phycore-no-eth.dtbo
@@ -621,7 +621,7 @@ headphones, and line-in signals.
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:
-:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.6.23-2.0.0-phy8#n57`
+:imx-dt:`imx93-phyboard-nash-peb-av-10.dtso?h=v6.6.23-2.0.0-phy8#n57`
 
 .. include:: /bsp/peripherals/video.rsti
 
@@ -635,7 +635,7 @@ The device tree of PEB-AV-02 can be found here:
 :imx-dt:`imx93-phyboard-segin-peb-av-02.dtso?h=v6.6.23-2.0.0-phy8`
 
 The device tree of PEB-AV-10 can be found here:
-:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.6.23-2.0.0-phy8`
+:imx-dt:`imx93-phyboard-nash-peb-av-10.dtso?h=v6.6.23-2.0.0-phy8`
 
 .. include:: peripherals/pm.rsti
 

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -445,6 +445,11 @@ Network
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
 
+.. include:: wireless-network.rsti
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. no-bluetooth-marker
+
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -1,0 +1,661 @@
+.. Download links
+.. |dlpage-bsp| replace:: our BSP
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.1.1
+.. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-91-93/#downloads
+.. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/sdk/ampliphy-vendor-wayland/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+
+.. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
+
+.. General Substitutions
+.. |kit| replace:: **phyBOARD-Segin i.MX 93 and phyBOARD-Nash i.MX 93 Kit**
+.. |kit-ram-size| replace:: 1GiB
+.. |sbc| replace:: phyBOARD-Segin/Nash i.MX 93
+.. |soc| replace:: i.MX 93
+.. |socfamily| replace:: i.MX 9
+.. |som| replace:: phyCORE-i.MX93
+.. |debug-uart| replace:: ttyLP0
+.. |expansion-connector| replace:: X16
+
+
+.. Linux Kernel
+.. |kernel-defconfig| replace:: imx_v8_defconfig imx9_phytec_distro.config imx9_phytec_platform.config
+.. |kernel-recipe-path| replace:: meta-phytec/dynamic-layers/freescale-layer/recipes-kernel/linux/linux-imx_*.bb
+.. |kernel-repo-name| replace:: linux-imx
+.. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
+.. |kernel-socname| replace:: imx93
+.. |kernel-tag| replace:: v6.1.55_2.2.0-phy3
+.. |emmcdev| replace:: mmcblk0
+
+.. Bootloader
+.. |u-boot-offset| replace:: 32
+.. |u-boot-offset-boot-part| replace:: 0
+.. |u-boot-mmc-flash-offset| replace:: 0x40
+.. |u-boot-emmc-devno| replace:: 0
+.. |u-boot-defconfig| replace:: imx93-phyboard-segin_defconfig
+.. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phyboard-segin_defconfig`` or ``imx93-phyboard-nash_defconfig``, depending on the board you are about to build for.
+.. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb`` or ``imx93-phyboard-nash.dtb``, depending on the board you are about to build for.
+.. |u-boot-imx-mkimage-tag| replace:: lf-6.1.55-2.2.0
+.. |u-boot-soc-name| replace:: iMX9
+.. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
+.. |u-boot-repo-name| replace:: u-boot-imx
+.. |u-boot-repo-url| replace:: git://git.phytec.de/u-boot-imx
+
+.. IMX93 specific
+.. |u-boot-socname-config| replace:: IMX93
+.. |u-boot-tag| replace:: v2023.04_2.2.0-phy3
+
+
+.. Devicetree
+.. |dt-carrierboard| replace:: imx93-phyboard-segin
+.. |dt-som| replace:: imx93-phycore-som
+.. |dtbo-rpmsg| replace:: imx93-phycore-rpmsg.dtso
+
+.. IMX93 specific
+.. |dt-somnetwork| replace:: :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n61`
+
+.. Yocto
+.. |yocto-bootenv-link| replace:: :yocto-bootenv:`mickledore`
+.. |yocto-bsp-name| replace:: BSP-Yocto-i.MX93
+.. _yocto-bsp-name: `dl-server`_
+.. |yocto-codename| replace:: mickledore
+.. |yocto-distro| replace:: ampliphy-vendor-wayland
+.. |yocto-imagename| replace:: phytec-qt6demo-image
+.. |yocto-imageext| replace:: wic.xz
+.. |yocto-machinename| replace:: phyboard-segin-imx93-2
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.1.1
+.. |yocto-ref-manual| replace:: Yocto Reference Manual (mickledore)
+.. _yocto-ref-manual: https://phytec.github.io/doc-bsp-yocto/yocto/manual-index.html#mickledore
+.. |yocto-sdk-rev| replace:: 4.2.3
+.. |yocto-sdk-a-core| replace:: cortexa55
+
+.. Ref Substitutions
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.1.1-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.1.1-images>`
+.. |ref-debugusbconnector| replace:: UART1 console on PEB-EVAL-01 for **phyBOARD-Segin** and X-37
+   USB-C debug for **phyBOARD-Nash**
+.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.1.1-device-tree>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.1.1-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.1.1-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.1.1-development>`
+.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.1.1-components>`
+.. |ref-disable-emmc-part| replace:: :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
+.. |ref-getting-started-find-correct-device| replace:: :ref:`Finding the Correct Device <getting-started-find-correct-device>`
+
+
+.. IMX93 specific
+.. |sbc-network| replace::
+   The device tree set up for EQOS Ethernet IP core where the PHY is populated
+   on the |sbc| can be found here:
+   :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n114` or here:
+   :imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n83`.
+
+.. |ubootexternalenv| replace:: U-boot External Environment subsection of the
+   :ref:`device tree overlay section <imx93-PD24.1.1-ubootexternalenv>`
+
+
+.. M-Core specific
+.. |mcore| replace:: M33 Core
+.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.1.1-components>`
+.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-sdk-version| replace:: 2.13.0
+
++-----------------------+----------------------+
+| |soc| BSP Manual                             |
++-----------------------+----------------------+
+| Document Title        | |soc| BSP Manual     |
++-----------------------+----------------------+
+| Document Type         | BSP Manual           |
++-----------------------+----------------------+
+| Yocto Manual          | Mickledore           |
++-----------------------+----------------------+
+| Release Date          | 2024/01/31           |
++-----------------------+----------------------+
+| Is Branch of          | |soc| BSP Manual     |
++-----------------------+----------------------+
+
+The table below shows the Compatible BSPs for this manual:
+
+==================== ================ ================ ==========
+Compatible BSP'S     BSP Release Type BSP Release Date BSP Status
+
+==================== ================ ================ ==========
+|yocto-manifestname| Minor            2024/05/07       Released
+==================== ================ ================ ==========
+
+
+.. include:: ../../intro.rsti
+
+Supported Hardware
+------------------
+
+On our web page, you can see all supported Machines with the available Article
+Numbers for this release: |yocto-manifestname|, see `download <dlpage-bsp_>`_.
+
+If you choose a specific **Machine Name** in the section **Supported Machines**,
+you can see which **Article Numbers** are available under this machine and also
+a short description of the hardware information. In case you only have
+the **Article Number** of your hardware, you can leave the **Machine
+Name** drop-down menu empty and only choose your **Article Number**. Now it
+should show you the necessary **Machine Name** for your specific hardware.
+
+.. tip::
+
+   **Console examples in this BSP manual only focus on phyBOARD-Segin i.MX 93.
+   Similar commands can also be executed for/on phyBOARD-Nash i.MX 93**
+
+.. _imx93-PD24.1.1-components:
+.. include:: components.rsti
+
+.. +---------------------------------------------------------------------------+
+.. Getting Started
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.1.1-getting-started:
+.. include:: /bsp/getting-started.rsti
+
+First Start-up
+--------------
+
+*  To boot from an SD card, the |ref-bootswitch| needs to be set to the
+   following position:
+
+.. image:: images/SD_Card_Boot.png
+
+*  Insert the SD card
+*  Connect the targets debug console with your host. Use |ref-debugusbconnector|.
+*  Power up the board
+*  Open serial/usb port with 115200 baud and 8N1 (you should see u-boot/linux
+   start on the console
+
+.. +---------------------------------------------------------------------------+
+.. Building the BSP
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/building-bsp.rsti
+
+.. _imx93-PD24.1.1-images:
+
+*  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
+   Bootloader image!
+*  **oftree**: Default kernel device tree
+*  **u-boot-spl.bin**: Secondary program loader (SPL)
+*  **bl31-imx93.bin**: ARM Trusted Firmware binary
+*  **lpddr4_dmem_1d_v202201.bin, lpddr4_dmem_2d_v202201.bin,
+   lpddr4_imem_1d_v202201.bin,
+   lpddr4_imem_2d_v202201.bin**: DDR PHY firmware images
+*  **imx-boot**: Bootloader build by imx-mkimage which includes SPL, U-Boot, ARM
+   Trusted Firmware and DDR firmware. This is the final bootloader image which
+   is bootable.
+*  **Image**: Linux kernel image
+*  **Image.config**: Kernel configuration
+*  **imx93-phyboard-*.dtb**: Kernel device tree file
+*  **imx93-phy\*.dtbo**: Kernel device tree overlay files
+*  **phytec-\*.tar.gz**: Root file system,
+   of bitbake-image that was built.
+
+   * **phytec-qt6demo-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build
+     was processed for ``phytec-qt6demo-image``
+   * **phytec-headless-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build
+     was processed for ``phytec-headless-image``
+*  **phytec-\*.wic.xz**: Compressed bootable SD
+   card image of bitbake-image that was built. Includes bootloader, DTBs, Kernel
+   and Root file system.
+
+   * **phytec-qt6demo-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build
+     was processed for ``phytec-qt6demo-image``
+   * **phytec-headless-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build
+     was processed for ``phytec-headless-image``
+*  **imx93-11x11-evk_m33_\*.bin**, binaries of demo applications for the
+   Cortex-M33 MCU; can be manually loaded and started with U-Boot or Linux
+
+.. +---------------------------------------------------------------------------+
+.. INSTALLING THE OS
+.. +---------------------------------------------------------------------------+
+
+Installing the OS
+=================
+
+Bootmode Switch (S3)
+--------------------
+
+.. tip::
+
+   Hardware revision baseboard:
+
+   *  phyBOARD-Segin-i.MX 93: 1472.5
+   *  phyBOARD-Nash-i.MX 93: 1616.0
+
+The |sbc| features a boot switch with four individually switchable ports to
+select the phyCORE-|soc| default bootsource.
+
+.. _imx93-PD24.1.1-bootswitch:
+.. include:: bootmode-switch.rsti
+
+.. include:: ../installing-os.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVELOPMENT
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.1.1-development:
+
+Development
+===========
+
+.. include:: ../../imx-common/development/host_network_setup.rsti
+.. include:: ../../imx-common/development/netboot.rsti
+
+Working with UUU-Tool
+---------------------
+
+The Universal Update Utility Tool (UUU-Tool) from NXP is a software to execute
+on the host to load and run the bootloader on the board through SDP (Serial
+Download Protocol). For detailed information visit
+https://github.com/nxp-imx/mfgtools or download the `Official UUU-tool
+documentation <https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-processors/140261/1/UUU.pdf>`_.
+
+Host preparations for UUU-Tool Usage
+....................................
+
+*  Follow the instructions from https://github.com/nxp-imx/mfgtools#linux.
+
+*  If you built UUU from source, add it to ``PATH``:
+
+   This BASH command adds UUU only temporarily to ``PATH``. To add it permanently, add this line to
+   ``~/.bashrc``.
+
+   .. code-block:: console
+
+      export PATH=~/mfgtools/uuu/:"$PATH"
+
+*  Set udev rules (documented in ``uuu -udev``):
+
+   .. code-block:: console
+
+      host:~$ sudo sh -c "uuu -udev >> /etc/udev/rules.d/70-uuu.rules"
+      host:~$ sudo udevadm control --reload
+
+Get Images
+..........
+
+Download imx-boot from our server or get it from your Yocto build directory at
+build/deploy/images/|yocto-machinename|/. For flashing a wic image to eMMC,
+you will also need |yocto-imagename|-|yocto-machinename|.wic.
+
+Prepare Target
+..............
+
+Set the |ref-bootswitch| to **USB Serial Download**. Also, connect USB port
+|ref-usb-otg| to your host.
+
+Starting bootloader via UUU-Tool
+................................
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b spl imx-boot
+
+You can see the bootlog on the console via |ref-debugusbconnector|, as usual.
+
+.. note::
+   The default boot command when booting with UUU-Tool is set to fastboot. If
+   you want to change this, please adjust the environment variable bootcmd_mfg
+   in U-boot prompt with setenv bootcmd_mfg. Please note, when booting with
+   UUU-tool the default environment is loaded. Saveenv has no effect. If you
+   want to change the boot command permanently for UUU-boot, you need to change
+   this in U-Boot code.
+
+Flashing U-boot Image to eMMC via UUU-Tool
+...........................................
+
+.. warning::
+
+   UUU flashes U-boot into eMMC BOOT (hardware) boot partitions, and it sets
+   the BOOT_PARTITION_ENABLE in the eMMC! This is a problem since we want the
+   bootloader to reside in the eMMC USER partition. Flashing next U-Boot version
+   .wic image and not disabling BOOT_PARTITION_ENABLE bit will result in device
+   always using U-boot saved in BOOT partitions. To fix this in U-Boot:
+
+   .. code-block:: console
+      :substitutions:
+
+      u-boot=> mmc partconf |u-boot-emmc-devno| 0 0 0
+      u-boot=> mmc partconf |u-boot-emmc-devno|
+      EXT_CSD[179], PARTITION_CONFIG:
+      BOOT_ACK: 0x0
+      BOOT_PARTITION_ENABLE: 0x0
+      PARTITION_ACCESS: 0x0
+
+   or check |ref-disable-emmc-part| from Linux.
+
+   This way the bootloader is still flashed to eMMC BOOT partitions but it is
+   not used!
+
+   When using **partup** tool and ``.partup`` package for eMMC flashing this is
+   done by default, which makes partup again superior flash option.
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b emmc imx-boot
+
+Flashing wic Image to eMMC via UUU-Tool
+...........................................
+
+Execute and power up the board:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ sudo uuu -b emmc_all imx-boot |yocto-imagename|-|yocto-machinename|.wic
+
+.. include:: ../../imx-common/development/standalone_build_preface.rsti
+.. include:: ../../imx-common/development/standalone_build_u-boot_imxmkimage.rsti
+.. include:: ../../imx-common/development/standalone_build_kernel.rsti
+
+.. include:: ../../imx-common/development/format_sd-card.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVICE TREE
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.1.1-device-tree:
+.. include:: /bsp/device-tree.rsti
+
+::
+
+   imx93-phyboard-segin-peb-av-02.dtbo
+   imx93-phyboard-segin-peb-eval-01.dtbo
+   imx93-phycore-rpmsg.dtbo
+   imx93-phycore-no-emmc.dtbo
+   imx93-phycore-no-eth.dtbo
+
+Available overlays for phyboard-nash-imx93-1.conf are:
+
+::
+
+   imx93-phyboard-nash-peb-av-010.dtbo
+   imx93-phycore-rpmsg.dtbo
+   imx93-phycore-no-emmc.dtbo
+   imx93-phycore-no-eth.dtbo
+
+.. _imx93-PD24.1.1-ubootexternalenv:
+.. include:: ../dt-overlays.rsti
+
+.. +---------------------------------------------------------------------------+
+.. ACCESSING PERIPHERALS
+.. +---------------------------------------------------------------------------+
+
+
+.. include:: /bsp/peripherals/introduction.rsti
+
+.. include:: /bsp/imx-common/peripherals/pin-muxing.rsti
+
+The following is an example of the pin muxing of the UART1 device in
+|dt-carrierboard|.dts:
+
+.. code-block::
+
+   pinctrl_uart1: uart1grp {
+           fsl,pins = <
+                   MX93_PAD_UART1_RXD__LPUART1_RX     0x31e
+                   MX93_PAD_UART1_TXD__LPUART1_TX     0x30e
+           >;
+   };
+
+The first part of the string MX93_PAD_UART1_RXD__LPUART1_RX names the pad
+(in this example UART1_RXD). The second part of the string (LPUART1_RX) is the
+desired muxing option for this pad. The pad setting value (hex value on the
+right) defines different modes of the pad, for example, if internal pull
+resistors are activated or not. In this case, the internal pull up is
+activated.
+
+The device tree representation for UART1 pinmuxing:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n262`
+
+.. _imx93-PD24.1.1-network:
+
+Network
+-------
+
+|sbc| provides two ethernet interfaces.
+
+*  On **phyBOARD-Segin** we have:
+
+   *  a 100 megabit Ethernet provided by |som|
+   *  and 100 megabit Ethernet provided by phyBOARD.
+
+*  On **phyBOARD-Nash** we have:
+
+   *  a 100 megabit Ethernet provided by |som|
+   *  and 1 gigabit Ethernet provided by phyBOARD.
+
+.. include:: /bsp/imx-common/peripherals/network.rsti
+
+.. include:: /bsp/imx-common/peripherals/sd-card.rsti
+
+DT configuration for the MMC (SD card slot) interface can be found here:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n216` or here:
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n201`
+
+DT configuration for the eMMC interface can be found here:
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n194` or here:
+
+.. include:: /bsp/peripherals/emmc.rsti
+
+.. include:: /bsp/imx-common/emmc.rsti
+
+.. include:: ../peripherals/gpios.rsti
+
+.. include:: /bsp/peripherals/adc.rsti
+
+On phyBOARD-Nash the ADC lines are accessible on X16 expansion connector:
+
+========= ========
+ADC input X16 pin
+========= ========
+ADC_IN0        47
+ADC_IN2        49
+========= ========
+
+.. include:: ../peripherals/leds.rsti
+
+Device tree configuration for the User I/O configuration can be found here:
+:imx-dt:`imx93-phyboard-segin-peb-eval-01.dtso?h=v6.1.55_2.2.0-phy3#n33`
+
+.. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
+
+General I²C1 bus configuration (e.g. |dt-som|.dtsi):
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n88`
+
+General I²C2 bus configuration for |dt-carrierboard|.dts:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n155` or for
+imx93-phyboard-nash.dts:
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n113`
+
+
+EEPROM
+------
+
+There are two different I2C EEPROM flashes populated on |som| SoM and on the
+|sbc|. For now only the one on the |som| is enabled, and it is used for board
+detection.
+
+.. include:: ../peripherals/eeprom.rsti
+
+DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n172`
+
+.. include:: ../../peripherals/rtc.rsti
+
+DT representation for I²C RTCs:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n173` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n122`
+
+USB Host Controller
+-------------------
+
+The USB controller of the |soc| SoC provides a low-cost connectivity solution
+for numerous consumer portable devices by providing a mechanism for data
+transfer between USB devices with a line/bus speed of up to 480 Mbps (HighSpeed
+'HS'). The USB subsystem has two independent USB controller cores. Both cores
+are capable of acting as a USB peripheral device or a USB host, but on the |sbc|
+one of them is used as a host-only port (USB-A connector).
+
+.. include:: /bsp/peripherals/usb-host.rsti
+
+The OTG port provides an additional pin for over-current protection, which is
+not used on the |sbc|. Since it's not used, the driver part is also disabled
+from within the device tree. In case this pin is used, activate this
+over-current in the device tree and set the correct polarity (active high/low)
+according to the device specification. For the correct setup, please refer to
+the Kernel documentation under
+Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
+
+DT representation for USB Host:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n190` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n180`
+
+RS232/RS485
+-----------
+
+The **phyBOARD-Nash** i.MX 93 SoC provides one RS232/RS485 serial port.
+
+.. warning::
+   RS232 with HW flow control and RS485 are not working due to HW bug on the
+   phyBOARD-Nash PCB revision 1616.0
+
+.. include:: /bsp/peripherals/rs232.rsti
+.. include:: /bsp/peripherals/rs485.rsti
+
+The device tree representation for RS232 and RS485:
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n173`
+
+CAN FD
+------
+
+The |sbc| has one flexCAN interface supporting CAN FD. They are supported by the
+Linux standard CAN framework which builds upon the Linux network layer. Using
+this framework, the CAN interfaces behave like an ordinary Linux network device,
+with some additional features special to CAN. More information can be found in
+the Linux Kernel
+documentation: https://www.kernel.org/doc/html/latest/networking/can.html
+
+.. include:: ../peripherals/canfd.rsti
+
+Device Tree CAN configuration of |dt-carrierboard|.dts:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n147` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n105`
+
+Audio on phyBOARD-Segin
+-----------------------
+
+On phyBOARD-Segin i.MX 93 the TI TLV320AIC3007 audio codec is used. It uses I2S
+for data transmission and I2C for codec control. The audio signals available
+are:
+
+* Stereo LINE IN,
+* Stereo LINE OUT,
+* Output where D-Class 1W speaker can be connected
+
+.. include:: /bsp/peripherals/audio.rsti
+	:end-before: .. audio_alsa_configuration_start_label
+
+.. include:: /bsp/peripherals/audio.rsti
+   :start-after: .. audio_playback_start_label
+   :end-before: .. audio_capture_start_label
+
+If Speaker volume it too low you can increase its volume with (values 0-3):
+
+.. code-block:: console
+
+   target:~$ amixer -c 0 sset Class-D 3
+
+.. hint::
+
+   Speaker output is only mono so when stereo track is played only left channel
+   will be played by speaker.
+
+Capture
+.......
+
+``arecord`` is a command-line tool for capturing audio streams which use Line In
+as the default input source.
+
+.. code-block:: console
+
+   target:~$ arecord -t wav -c 2 -r 44100 -f S16_LE test.wav
+
+.. hint::
+
+   Since playback and capture share hardware interfaces, it is not possible to
+   use different sampling rates and formats for simultaneous playback and
+   capture operations.
+
+Device Tree Audio configuration:
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n62`
+
+Audio on phyBOARD-Nash
+----------------------
+
+.. warning::
+
+   Due to HW bug Audio is broken on phyBOARD-Nash i.MX 93 PCB revision: 1616.0
+
+To use audio with phyBOARD-Nash an additional adapter for the Audio/Video
+connector is needed. The PEB-AV-10 (1531.1 revision) can be bought separately to
+the Kit. PEB-AV-10 is populated with a TI TLV320AIC3007 audio codec. Audio
+support is done via the I2S interface and controlled via I2C.
+
+There is a 3.5mm headset jack with OMTP standard and an 8-pin header to connect
+audio devices with the AV-Connector.  The 8-pin header contains a mono speaker,
+headphones, and line-in signals.
+
+.. include:: /bsp/peripherals/audio.rsti
+
+Device Tree Audio configuration:
+:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.1.55_2.2.0-phy3#n57`
+
+.. include:: /bsp/peripherals/video.rsti
+
+.. include:: display.rsti
+
+.. include:: /bsp/qt6.rsti
+
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+The device tree of PEB-AV-02 can be found here:
+:imx-dt:`imx93-phyboard-segin-peb-av-02.dtso?h=v6.1.55_2.2.0-phy3`
+
+The device tree of PEB-AV-10 can be found here:
+:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.1.55_2.2.0-phy3`
+
+.. include:: peripherals/pm.rsti
+
+.. include:: ../peripherals/tm.rsti
+
+.. include:: /bsp/peripherals/watchdog.rsti
+
+.. include:: ../peripherals/bbnsm-power-key.rsti
+
+.. include:: ../peripherals/pxp.rsti
+
+.. include:: ../peripherals/ocotp-ctrl.rsti
+
+.. include:: /bsp/imx9/imx93/peripherals/tpm.rsti
+
+Device tree TPM configuration can be found here:
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n151`
+
+.. +---------------------------------------------------------------------------+
+.. i.MX 8M Plus M7 Core
+.. +---------------------------------------------------------------------------+
+
+.. include:: ../mcu.rsti

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -373,6 +373,7 @@ Execute and power up the board:
 
    imx93-phyboard-segin-peb-av-02.dtbo
    imx93-phyboard-segin-peb-eval-01.dtbo
+   imx93-phyboard-segin-peb-wlbt-05.dtbo
    imx93-phycore-rpmsg.dtbo
    imx93-phycore-no-emmc.dtbo
    imx93-phycore-no-eth.dtbo
@@ -381,7 +382,10 @@ Available overlays for phyboard-nash-imx93-1.conf are:
 
 ::
 
+   imx93-phyboard-nash-jtag.dtbo
    imx93-phyboard-nash-peb-av-10.dtbo
+   imx93-phyboard-nash-pwm-fan.dtbo
+   imx93-phyboard-nash-vm016.dtbo
    imx93-phycore-rpmsg.dtbo
    imx93-phycore-no-emmc.dtbo
    imx93-phycore-no-eth.dtbo

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -4,8 +4,8 @@
 .. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-91-93/#downloads
 .. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/
 .. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/sdk/ampliphy-vendor-wayland/
-.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
-.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -35,9 +35,9 @@
 .. |u-boot-offset-boot-part| replace:: 0
 .. |u-boot-mmc-flash-offset| replace:: 0x40
 .. |u-boot-emmc-devno| replace:: 0
-.. |u-boot-defconfig| replace:: imx93-phyboard-segin_defconfig
-.. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phyboard-segin_defconfig`` or ``imx93-phyboard-nash_defconfig``, depending on the board you are about to build for.
-.. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb`` or ``imx93-phyboard-nash.dtb``, depending on the board you are about to build for.
+.. |u-boot-defconfig| replace:: imx93-phycore_defconfig
+.. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phycore_defconfig``
+.. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb``
 .. |u-boot-imx-mkimage-tag| replace:: lf-6.6.23-2.0.0
 .. |u-boot-soc-name| replace:: iMX9
 .. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -230,7 +230,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard:
 
    *  |sbc-segin|: 1472.5
-   *  |sbc-nash|: 1616.0
+   *  |sbc-nash|: 1616.0, 1616.1
 
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -1,12 +1,12 @@
 .. Download links
 .. |dlpage-bsp| replace:: our BSP
-.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.1.1
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.2.0
 .. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-91-93/#downloads
 .. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/
-.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/sdk/ampliphy-vendor-wayland/
-.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
-.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
-.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.1.1/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/sdk/ampliphy-vendor-wayland/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
 
@@ -27,7 +27,7 @@
 .. |kernel-repo-name| replace:: linux-imx
 .. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
 .. |kernel-socname| replace:: imx93
-.. |kernel-tag| replace:: v6.1.55_2.2.0-phy3
+.. |kernel-tag| replace:: v6.6.23-2.0.0-phy8
 .. |emmcdev| replace:: mmcblk0
 
 .. Bootloader
@@ -38,7 +38,7 @@
 .. |u-boot-defconfig| replace:: imx93-phyboard-segin_defconfig
 .. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phyboard-segin_defconfig`` or ``imx93-phyboard-nash_defconfig``, depending on the board you are about to build for.
 .. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb`` or ``imx93-phyboard-nash.dtb``, depending on the board you are about to build for.
-.. |u-boot-imx-mkimage-tag| replace:: lf-6.1.55-2.2.0
+.. |u-boot-imx-mkimage-tag| replace:: lf-6.6.23-2.0.0
 .. |u-boot-soc-name| replace:: iMX9
 .. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
 .. |u-boot-repo-name| replace:: u-boot-imx
@@ -46,7 +46,7 @@
 
 .. IMX93 specific
 .. |u-boot-socname-config| replace:: IMX93
-.. |u-boot-tag| replace:: v2023.04_2.2.0-phy3
+.. |u-boot-tag| replace:: v2024.04-2.0.0-phy6
 
 
 .. Devicetree
@@ -55,33 +55,33 @@
 .. |dtbo-rpmsg| replace:: imx93-phycore-rpmsg.dtso
 
 .. IMX93 specific
-.. |dt-somnetwork| replace:: :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n61`
+.. |dt-somnetwork| replace:: :imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n61`
 
 .. Yocto
-.. |yocto-bootenv-link| replace:: :yocto-bootenv:`mickledore`
+.. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
 .. |yocto-bsp-name| replace:: BSP-Yocto-i.MX93
 .. _yocto-bsp-name: `dl-server`_
-.. |yocto-codename| replace:: mickledore
+.. |yocto-codename| replace:: scarthgap
 .. |yocto-distro| replace:: ampliphy-vendor-wayland
 .. |yocto-imagename| replace:: phytec-qt6demo-image
 .. |yocto-imageext| replace:: wic.xz
 .. |yocto-machinename| replace:: phyboard-segin-imx93-2
-.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.1.1
-.. |yocto-ref-manual| replace:: Yocto Reference Manual (mickledore)
-.. _yocto-ref-manual: https://phytec.github.io/doc-bsp-yocto/yocto/manual-index.html#mickledore
-.. |yocto-sdk-rev| replace:: 4.2.3
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.2.0
+.. |yocto-ref-manual| replace:: Yocto Reference Manual (scarthgap)
+.. _yocto-ref-manual: https://phytec.github.io/doc-bsp-yocto/yocto/manual-index.html#scarthgap
+.. |yocto-sdk-rev| replace:: 5.0
 .. |yocto-sdk-a-core| replace:: cortexa55
 
 .. Ref Substitutions
-.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.1.1-bootswitch>`
-.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.1.1-images>`
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.2.0-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.2.0-images>`
 .. |ref-debugusbconnector| replace:: UART1 console on PEB-EVAL-01 for **phyBOARD-Segin** and X-37
    USB-C debug for **phyBOARD-Nash**
-.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.1.1-device-tree>`
-.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.1.1-getting-started>`
-.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.1.1-network>`
-.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.1.1-development>`
-.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.1.1-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.2.0-device-tree>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.2.0-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.2.0-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.2.0-development>`
+.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.2.0-components>`
 .. |ref-disable-emmc-part| replace:: :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
 .. |ref-getting-started-find-correct-device| replace:: :ref:`Finding the Correct Device <getting-started-find-correct-device>`
 
@@ -90,16 +90,16 @@
 .. |sbc-network| replace::
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
-   :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n114` or here:
-   :imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n83`.
+   :imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n114` or here:
+   :imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n83`.
 
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
-   :ref:`device tree overlay section <imx93-PD24.1.1-ubootexternalenv>`
+   :ref:`device tree overlay section <imx93-PD24.2.0-ubootexternalenv>`
 
 
 .. M-Core specific
 .. |mcore| replace:: M33 Core
-.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.1.1-components>`
+.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.2.0-components>`
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
 
@@ -110,9 +110,9 @@
 +-----------------------+----------------------+
 | Document Type         | BSP Manual           |
 +-----------------------+----------------------+
-| Yocto Manual          | Mickledore           |
+| Yocto Manual          | Scarthgap            |
 +-----------------------+----------------------+
-| Release Date          | 2024/01/31           |
+| Release Date          | 2024/10/08           |
 +-----------------------+----------------------+
 | Is Branch of          | |soc| BSP Manual     |
 +-----------------------+----------------------+
@@ -123,7 +123,7 @@ The table below shows the Compatible BSPs for this manual:
 Compatible BSP'S     BSP Release Type BSP Release Date BSP Status
 
 ==================== ================ ================ ==========
-|yocto-manifestname| Minor            2024/05/07       Released
+|yocto-manifestname| Major            2024/10/08       Released
 ==================== ================ ================ ==========
 
 
@@ -147,14 +147,14 @@ should show you the necessary **Machine Name** for your specific hardware.
    **Console examples in this BSP manual only focus on phyBOARD-Segin i.MX 93.
    Similar commands can also be executed for/on phyBOARD-Nash i.MX 93**
 
-.. _imx93-PD24.1.1-components:
+.. _imx93-PD24.2.0-components:
 .. include:: components.rsti
 
 .. +---------------------------------------------------------------------------+
 .. Getting Started
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.1.1-getting-started:
+.. _imx93-PD24.2.0-getting-started:
 .. include:: /bsp/getting-started.rsti
 
 First Start-up
@@ -177,7 +177,7 @@ First Start-up
 
 .. include:: /bsp/building-bsp.rsti
 
-.. _imx93-PD24.1.1-images:
+.. _imx93-PD24.2.0-images:
 
 *  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
    Bootloader image!
@@ -232,7 +232,7 @@ Bootmode Switch (S3)
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.
 
-.. _imx93-PD24.1.1-bootswitch:
+.. _imx93-PD24.2.0-bootswitch:
 .. include:: bootmode-switch.rsti
 
 .. include:: ../installing-os.rsti
@@ -241,7 +241,7 @@ select the phyCORE-|soc| default bootsource.
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.1.1-development:
+.. _imx93-PD24.2.0-development:
 
 Development
 ===========
@@ -366,7 +366,7 @@ Execute and power up the board:
 .. DEVICE TREE
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.1.1-device-tree:
+.. _imx93-PD24.2.0-device-tree:
 .. include:: /bsp/device-tree.rsti
 
 ::
@@ -386,7 +386,7 @@ Available overlays for phyboard-nash-imx93-1.conf are:
    imx93-phycore-no-emmc.dtbo
    imx93-phycore-no-eth.dtbo
 
-.. _imx93-PD24.1.1-ubootexternalenv:
+.. _imx93-PD24.2.0-ubootexternalenv:
 .. include:: ../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
@@ -418,9 +418,9 @@ resistors are activated or not. In this case, the internal pull up is
 activated.
 
 The device tree representation for UART1 pinmuxing:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n262`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n262`
 
-.. _imx93-PD24.1.1-network:
+.. _imx93-PD24.2.0-network:
 
 Network
 -------
@@ -442,11 +442,11 @@ Network
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n216` or here:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n201`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n216` or here:
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n201`
 
 DT configuration for the eMMC interface can be found here:
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n194` or here:
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n194` or here:
 
 .. include:: /bsp/peripherals/emmc.rsti
 
@@ -468,17 +468,17 @@ ADC_IN2        49
 .. include:: ../peripherals/leds.rsti
 
 Device tree configuration for the User I/O configuration can be found here:
-:imx-dt:`imx93-phyboard-segin-peb-eval-01.dtso?h=v6.1.55_2.2.0-phy3#n33`
+:imx-dt:`imx93-phyboard-segin-peb-eval-01.dtso?h=v6.6.23-2.0.0-phy8#n33`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 
 General I²C1 bus configuration (e.g. |dt-som|.dtsi):
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n88`
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n88`
 
 General I²C2 bus configuration for |dt-carrierboard|.dts:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n155` or for
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n155` or for
 imx93-phyboard-nash.dts:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n113`
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n113`
 
 
 EEPROM
@@ -491,13 +491,13 @@ detection.
 .. include:: ../peripherals/eeprom.rsti
 
 DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n172`
+:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n172`
 
 .. include:: ../../peripherals/rtc.rsti
 
 DT representation for I²C RTCs:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n173` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n122`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n173` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n122`
 
 USB Host Controller
 -------------------
@@ -520,8 +520,8 @@ the Kernel documentation under
 Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
 
 DT representation for USB Host:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n190` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n180`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n190` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n180`
 
 RS232/RS485
 -----------
@@ -536,7 +536,7 @@ The **phyBOARD-Nash** i.MX 93 SoC provides one RS232/RS485 serial port.
 .. include:: /bsp/peripherals/rs485.rsti
 
 The device tree representation for RS232 and RS485:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n173`
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n173`
 
 CAN FD
 ------
@@ -551,8 +551,8 @@ documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n147` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n105`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n147` or
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n105`
 
 Audio on phyBOARD-Segin
 -----------------------
@@ -600,7 +600,7 @@ as the default input source.
    capture operations.
 
 Device Tree Audio configuration:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n62`
+:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n62`
 
 Audio on phyBOARD-Nash
 ----------------------
@@ -621,7 +621,7 @@ headphones, and line-in signals.
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:
-:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.1.55_2.2.0-phy3#n57`
+:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.6.23-2.0.0-phy8#n57`
 
 .. include:: /bsp/peripherals/video.rsti
 
@@ -632,10 +632,10 @@ Device Tree Audio configuration:
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 The device tree of PEB-AV-02 can be found here:
-:imx-dt:`imx93-phyboard-segin-peb-av-02.dtso?h=v6.1.55_2.2.0-phy3`
+:imx-dt:`imx93-phyboard-segin-peb-av-02.dtso?h=v6.6.23-2.0.0-phy8`
 
 The device tree of PEB-AV-10 can be found here:
-:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.1.55_2.2.0-phy3`
+:imx-dt:`imx93-phyboard-nash-peb-av-010.dtso?h=v6.6.23-2.0.0-phy8`
 
 .. include:: peripherals/pm.rsti
 
@@ -652,7 +652,7 @@ The device tree of PEB-AV-10 can be found here:
 .. include:: /bsp/imx9/imx93/peripherals/tpm.rsti
 
 Device tree TPM configuration can be found here:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n151`
+:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n151`
 
 .. +---------------------------------------------------------------------------+
 .. i.MX 8M Plus M7 Core

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -201,13 +201,13 @@ First Start-up
      was processed for ``phytec-qt6demo-image``
    * **phytec-headless-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build
      was processed for ``phytec-headless-image``
-*  **phytec-\*.wic.xz**: Compressed bootable SD
+*  **phytec-\*.rootfs.wic.xz**: Compressed bootable SD
    card image of bitbake-image that was built. Includes bootloader, DTBs, Kernel
    and Root file system.
 
-   * **phytec-qt6demo-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build
+   * **phytec-qt6demo-image-phyboard-*-imx93-*.rootfs.wic.xz**: when bitbake-build
      was processed for ``phytec-qt6demo-image``
-   * **phytec-headless-image-phyboard-*-imx93-*.wic.xz**: when bitbake-build
+   * **phytec-headless-image-phyboard-*-imx93-*.rootfs.wic.xz**: when bitbake-build
      was processed for ``phytec-headless-image``
 *  **imx93-11x11-evk_m33_\*.bin**, binaries of demo applications for the
    Cortex-M33 MCU; can be manually loaded and started with U-Boot or Linux

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -14,6 +14,8 @@
 .. |kit| replace:: **phyBOARD-Segin i.MX 93 and phyBOARD-Nash i.MX 93 Kit**
 .. |kit-ram-size| replace:: 1GiB
 .. |sbc| replace:: phyBOARD-Segin/Nash i.MX 93
+.. |sbc-segin| replace:: phyBOARD-Segin i.MX 93
+.. |sbc-nash| replace:: phyBOARD-Nash i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
 .. |som| replace:: phyCORE-i.MX93
@@ -226,8 +228,8 @@ Bootmode Switch (S3)
 
    Hardware revision baseboard:
 
-   *  phyBOARD-Segin-i.MX 93: 1472.5
-   *  phyBOARD-Nash-i.MX 93: 1616.0
+   *  |sbc-segin|: 1472.5
+   *  |sbc-nash|: 1616.0
 
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.
@@ -431,12 +433,12 @@ Network
 
 |sbc| provides two ethernet interfaces.
 
-*  On **phyBOARD-Segin** we have:
+*  On |sbc-segin| we have:
 
    *  a 100 megabit Ethernet provided by |som|
    *  and 100 megabit Ethernet provided by phyBOARD.
 
-*  On **phyBOARD-Nash** we have:
+*  On |sbc-nash| we have:
 
    *  a 100 megabit Ethernet provided by |som|
    *  and 1 gigabit Ethernet provided by phyBOARD.
@@ -460,7 +462,7 @@ DT configuration for the eMMC interface can be found here:
 
 .. include:: /bsp/peripherals/adc.rsti
 
-On phyBOARD-Nash the ADC lines are accessible on X16 expansion connector:
+On |sbc-nash| the ADC lines are accessible on X16 expansion connector:
 
 ========= ========
 ADC input X16 pin
@@ -530,11 +532,11 @@ DT representation for USB Host:
 RS232/RS485
 -----------
 
-The **phyBOARD-Nash** i.MX 93 SoC provides one RS232/RS485 serial port.
+The |sbc-nash| i.MX 93 SoC provides one RS232/RS485 serial port.
 
 .. warning::
    RS232 with HW flow control and RS485 are not working due to HW bug on the
-   phyBOARD-Nash PCB revision 1616.0
+   |sbc-nash| PCB revision 1616.0
 
 .. include:: /bsp/peripherals/rs232.rsti
 .. include:: /bsp/peripherals/rs485.rsti
@@ -558,10 +560,10 @@ Device Tree CAN configuration of |dt-carrierboard|.dts:
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L147` or
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L105`
 
-Audio on phyBOARD-Segin
------------------------
+Audio on |sbc-segin|
+--------------------
 
-On phyBOARD-Segin i.MX 93 the TI TLV320AIC3007 audio codec is used. It uses I2S
+On |sbc-segin| the TI TLV320AIC3007 audio codec is used. It uses I2S
 for data transmission and I2C for codec control. The audio signals available
 are:
 
@@ -606,14 +608,14 @@ as the default input source.
 Device Tree Audio configuration:
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L62`
 
-Audio on phyBOARD-Nash
-----------------------
+Audio on |sbc-nash|
+-------------------
 
 .. warning::
 
-   Due to HW bug Audio is broken on phyBOARD-Nash i.MX 93 PCB revision: 1616.0
+   Due to HW bug Audio is broken on |sbc-nash| PCB revision: 1616.0
 
-To use audio with phyBOARD-Nash an additional adapter for the Audio/Video
+To use audio with |sbc-nash| an additional adapter for the Audio/Video
 connector is needed. The PEB-AV-10 (1531.1 revision) can be bought separately to
 the Kit. PEB-AV-10 is populated with a TI TLV320AIC3007 audio codec. Audio
 support is done via the I2S interface and controlled via I2C.

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -22,10 +22,10 @@
 
 
 .. Linux Kernel
-.. |kernel-defconfig| replace:: imx_v8_defconfig imx9_phytec_distro.config imx9_phytec_platform.config
-.. |kernel-recipe-path| replace:: meta-phytec/dynamic-layers/freescale-layer/recipes-kernel/linux/linux-imx_*.bb
-.. |kernel-repo-name| replace:: linux-imx
-.. |kernel-repo-url| replace:: git://git.phytec.de/linux-imx
+.. |kernel-defconfig| replace:: imx9_phytec_defconfig
+.. |kernel-recipe-path| replace:: meta-phytec/recipes-kernel/linux/linux-phytec-imx_*.bb
+.. |kernel-repo-name| replace:: linux-phytec-imx
+.. |kernel-repo-url| replace:: git://github.com/phytec/linux-phytec-imx.git
 .. |kernel-socname| replace:: imx93
 .. |kernel-tag| replace:: v6.6.23-2.0.0-phy8
 .. |emmcdev| replace:: mmcblk0

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -20,6 +20,7 @@
 .. |socfamily| replace:: i.MX 9
 .. |som| replace:: phyCORE-i.MX93
 .. |debug-uart| replace:: ttyLP0
+.. |serial-uart| replace:: ttyLP6
 .. |expansion-connector| replace:: X16
 
 

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -55,7 +55,7 @@
 .. |dtbo-rpmsg| replace:: imx93-phycore-rpmsg.dtso
 
 .. IMX93 specific
-.. |dt-somnetwork| replace:: :imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n61`
+.. |dt-somnetwork| replace:: :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L61`
 
 .. Yocto
 .. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
@@ -90,8 +90,8 @@
 .. |sbc-network| replace::
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
-   :imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n114` or here:
-   :imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n83`.
+   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L114` or here:
+   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L83`.
 
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx93-PD24.2.0-ubootexternalenv>`
@@ -422,7 +422,7 @@ resistors are activated or not. In this case, the internal pull up is
 activated.
 
 The device tree representation for UART1 pinmuxing:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n262`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L259`
 
 .. _imx93-PD24.2.0-network:
 
@@ -446,11 +446,11 @@ Network
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n216` or here:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n201`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L213` or here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L202`
 
 DT configuration for the eMMC interface can be found here:
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n194` or here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L194` or here:
 
 .. include:: /bsp/peripherals/emmc.rsti
 
@@ -472,17 +472,17 @@ ADC_IN2        49
 .. include:: ../peripherals/leds.rsti
 
 Device tree configuration for the User I/O configuration can be found here:
-:imx-dt:`imx93-phyboard-segin-peb-eval-01.dtso?h=v6.6.23-2.0.0-phy8#n33`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-eval-01.dtso#L33`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 
-General I²C1 bus configuration (e.g. |dt-som|.dtsi):
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n88`
+General I²C3 bus configuration (e.g. |dt-som|.dtsi):
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L88`
 
 General I²C2 bus configuration for |dt-carrierboard|.dts:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n155` or for
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L155` or for
 imx93-phyboard-nash.dts:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n113`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L113`
 
 
 EEPROM
@@ -495,13 +495,13 @@ detection.
 .. include:: ../peripherals/eeprom.rsti
 
 DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
-:imx-dt:`imx93-phycore-som.dtsi?h=v6.6.23-2.0.0-phy8#n172`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
 
 .. include:: ../../peripherals/rtc.rsti
 
 DT representation for I²C RTCs:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n173` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n122`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L173` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L122`
 
 USB Host Controller
 -------------------
@@ -524,8 +524,8 @@ the Kernel documentation under
 Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
 
 DT representation for USB Host:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n190` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n180`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L193` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L181`
 
 RS232/RS485
 -----------
@@ -540,7 +540,7 @@ The **phyBOARD-Nash** i.MX 93 SoC provides one RS232/RS485 serial port.
 .. include:: /bsp/peripherals/rs485.rsti
 
 The device tree representation for RS232 and RS485:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n173`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L174`
 
 CAN FD
 ------
@@ -555,8 +555,8 @@ documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n147` or
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n105`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L147` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L105`
 
 Audio on phyBOARD-Segin
 -----------------------
@@ -604,7 +604,7 @@ as the default input source.
    capture operations.
 
 Device Tree Audio configuration:
-:imx-dt:`imx93-phyboard-segin.dts?h=v6.6.23-2.0.0-phy8#n62`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L62`
 
 Audio on phyBOARD-Nash
 ----------------------
@@ -625,7 +625,7 @@ headphones, and line-in signals.
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:
-:imx-dt:`imx93-phyboard-nash-peb-av-10.dtso?h=v6.6.23-2.0.0-phy8#n57`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso#L56`
 
 .. include:: /bsp/peripherals/video.rsti
 
@@ -636,10 +636,10 @@ Device Tree Audio configuration:
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 The device tree of PEB-AV-02 can be found here:
-:imx-dt:`imx93-phyboard-segin-peb-av-02.dtso?h=v6.6.23-2.0.0-phy8`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-av-02.dtso`
 
 The device tree of PEB-AV-10 can be found here:
-:imx-dt:`imx93-phyboard-nash-peb-av-10.dtso?h=v6.6.23-2.0.0-phy8`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso`
 
 .. include:: peripherals/pm.rsti
 
@@ -656,7 +656,7 @@ The device tree of PEB-AV-10 can be found here:
 .. include:: /bsp/imx9/imx93/peripherals/tpm.rsti
 
 Device tree TPM configuration can be found here:
-:imx-dt:`imx93-phyboard-nash.dts?h=v6.6.23-2.0.0-phy8#n151`
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L151`
 
 .. +---------------------------------------------------------------------------+
 .. i.MX 8M Plus M7 Core

--- a/source/bsp/imx9/imx93/peripherals/pm.rsti
+++ b/source/bsp/imx9/imx93/peripherals/pm.rsti
@@ -28,6 +28,11 @@ LowDrive (LD) with SWFFC  900 MHz          625 MT/s         800mV
 The |soc| BSP supports the VFS feature. The Linux kernel provides a LPM driver
 that allows setting VDD_SOC, CPU freq and DDR speed.
 
+.. note::
+   Low-cost |soc| SoC variants such as parts numbers NXP IMX9301/IMX9302 do not
+   support VFS features. Those SoCs always run in LowDrive (LD) mode. Hence,
+   the Linux LPM driver is disabled automatically for SoMs with such SoCs.
+
 * To put the device in **OverDrive (OD)** mode type:
 
    .. code-block:: console

--- a/source/bsp/imx9/imx93/wireless-network.rsti
+++ b/source/bsp/imx9/imx93/wireless-network.rsti
@@ -1,0 +1,46 @@
+WLAN
+....
+
+.. note::
+   For now, only |sbc-segin| supports WLAN/Bluetooth features. WLAN/Bluetooth is
+   thus not supported on |sbc-nash| yet.
+
+WLAN and Bluetooth on the |sbc-segin| are provided by the PEB-WLBT-05 expansion card.
+The PEB-WLBT-05 for |sbc-segin| Quickstart Guide shows you how to install the
+PEB-WLBT-05.
+
+.. tip::
+
+   With the BSP Version PD24.2 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   otherwise the PEB-WLBT-05 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx93-phyboard-segin-peb-wlbt-05.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
+module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
+information about the module can be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
+
+.. note::
+   By default, bluetooth is not supported on |sbc-segin| with PEB-WLBT-05
+   expansion card due to hard-wired connections. However, it is possible to
+   re-work PEB-WLBT-05 card by adjusting solder pads and enabling bluetooth in
+   the software. Please contact your PHYTEC representative for more information.

--- a/source/bsp/imx9/installing-os.rsti
+++ b/source/bsp/imx9/installing-os.rsti
@@ -41,8 +41,8 @@ saved on the SD card.
       :substitutions:
 
       target:~$ ls
-      |yocto-imagename|-|yocto-machinename|.partup
-      |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
+      |yocto-imagename|-|yocto-machinename|.rootfs.partup
+      |yocto-imagename|-|yocto-machinename|.rootfs.|yocto-imageext|
 
 *  Show list of available MMC devices:
 
@@ -68,7 +68,7 @@ saved on the SD card.
    .. code-block:: console
       :substitutions:
 
-      target:~$ partup install |yocto-imagename|-|yocto-machinename|.partup /dev/|emmcdev|
+      target:~$ partup install |yocto-imagename|-|yocto-machinename|.rootfs.partup /dev/|emmcdev|
 
    .. tip::
 
@@ -85,14 +85,14 @@ saved on the SD card.
       .. code-block:: console
          :substitutions:
 
-         target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+         target:~$ dd if=|yocto-imagename|-|yocto-machinename|.rootfs.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
 
       For compressed WIC images (\*.wic.xz):
 
       .. code-block:: console
          :substitutions:
 
-         target:~$ zstdcat |yocto-imagename|-|yocto-machinename|.wic.xz | sudo dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+         target:~$ zstdcat |yocto-imagename|-|yocto-machinename|.rootfs.|yocto-imageext| | sudo dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
 
       Keep in mind that the root partition does not make use of the full space
       when flashing with ``dd``.
@@ -122,7 +122,7 @@ bootloader, kernel, device tree, device tree overlays, and root file system.
    .. code-block:: console
       :substitutions:
 
-      host:~$ unxz phytec-qt6demo-image-phyboard-segin-imx93-2.wic.xz
+      host:~$ unxz |yocto-imagename|-|yocto-machinename|.rootfs.|yocto-imageext|
 
 Flash eMMC via Network in Linux on Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -139,7 +139,7 @@ the network to the eMMC of the target with a one-line command:
 .. code-block:: console
    :substitutions:
 
-   target:~$ ssh <USER>@192.168.3.10 "dd if=<path_to_file>/|yocto-imagename|-|yocto-machinename|.wic" | dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+   target:~$ ssh <USER>@192.168.3.10 "dd if=<path_to_file>/|yocto-imagename|-|yocto-machinename|.rootfs.wic" | dd of=/dev/|emmcdev| bs=1M conv=fsync status=progress
 
 Flash eMMC via Network in Linux on Host
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,7 +157,7 @@ Show your available image files on the host:
    :substitutions:
 
    host:~$ ls
-   |yocto-imagename|-|yocto-machinename|.wic
+   |yocto-imagename|-|yocto-machinename|.rootfs.wic
 
 Send the image with the ``dd`` command combined with ssh through the network
 to the eMMC of your device:
@@ -165,7 +165,7 @@ to the eMMC of your device:
 .. code-block:: console
    :substitutions:
 
-   host:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic bs=1M status=progress | ssh root@192.168.3.11 "dd of=/dev/|emmcdev| conv=fsync"
+   host:~$ dd if=|yocto-imagename|-|yocto-machinename|.rootfs.wic bs=1M status=progress | ssh root@192.168.3.11 "dd of=/dev/|emmcdev| conv=fsync"
 
 Flash eMMC U-Boot image via Network from running U-Boot
 .......................................................
@@ -200,7 +200,7 @@ Flash eMMC from USB in Linux
 
 These steps will show how to flash the eMMC on Linux with a USB stick. You only
 need a complete image saved on the USB stick and a bootable WIC image. (e.g.
-|yocto-imagename|-|yocto-machinename|.wic). Set the |ref-bootswitch| to SD Card.
+|yocto-imagename|-|yocto-machinename|.rootfs.wic). Set the |ref-bootswitch| to SD Card.
 
 *  Insert and mount the USB stick:
 
@@ -224,7 +224,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
       target:~$ cd /mnt
       target:~$ ls
-      |yocto-imagename|-|yocto-machinename|.wic
+      |yocto-imagename|-|yocto-machinename|.rootfs.wic
 
 *  Show list of available MMC devices:
 
@@ -249,7 +249,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
    .. code-block:: console
       :substitutions:
 
-      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
+      target:~$ dd if=|yocto-imagename|-|yocto-machinename|.rootfs.wic of=/dev/|emmcdev| bs=1M conv=fsync status=progress
 
 *  After a complete write, your board can boot from eMMC.
 

--- a/source/bsp/imx9/peripherals/tm.rsti
+++ b/source/bsp/imx9/peripherals/tm.rsti
@@ -71,3 +71,49 @@ default policy used in the BSP is step_wise.
 
    The actual values of the thermal trip points may differ since we mount CPUs
    with different temperature grades.
+
+PWM Fan
+........
+
+A PWM fan can be connected to the phyBOARD-Nash i.MX 93 connector X48 (label FAN).
+
+Afterwards, a PWM fan overlay needs to be activated, otherwise PWM fan won't
+be recognized.
+
+.. code-block:: console
+
+   target:~$ vi /boot/bootenv.txt
+
+The bootenv.txt file should look like this (it can also contain other devicetree
+overlays!):
+
+.. code-block::
+
+   overlays=imx93-phyboard-nash-pwm-fan.dtbo
+
+The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+For further information about devicetree overlays, read the |ref-dt| chapter.
+
+The SoC only contains one temperature sensor which is already used by the
+thermal frequency scaling. The fan thus can not be controlled by the kernel.
+We use lmsensors with hwmon for this instead. lmsensors reads the temperature
+periodically and adjusts output PWM duty-cycle accordingly. By default,
+temperature threshold for PWM fan to activate is set to 60°C.
+
+The settings can be configured in the configuration file:
+
+.. code-block::
+
+   /etc/fancontrol
+
+Fan control is started by a systemd service during boot. This can be disabled
+with:
+
+.. code-block:: console
+
+   target:~$ systemctl disable fancontrol

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -60,6 +60,8 @@ This should result in the following output:
 The ip address is automatically configured over DHCP. For other possible IP configurations,
 see section `Changing the Network Configuration` in the |yocto-ref-manual|_.
 
+.. no-bluetooth-marker
+
 Bluetooth
 .........
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -45,6 +45,7 @@ exclude_patterns = [
 extlinks = {
     'imx-dt': ('https://git.phytec.de/linux-imx/tree/arch/arm64/boot/dts/freescale/%s', None),
     'linux-phytec': ('https://github.com/phytec/linux-phytec/%s', None),
+    'linux-phytec-imx': ('https://github.com/phytec/linux-phytec-imx/%s', None),
     'yocto-bootenv': ('https://git.phytec.de/meta-phytec/tree/recipes-bsp/bootenv?h=%s', None)
 }
 


### PR DESCRIPTION
Add i.MX93 documentation update for the PD24.2.0 release.

Changes:
- Component versions update (based on NXP lf-6.6.23-2.0.0)
- Rename PEB-AV-10 overlay
- Add additional overlays
- Bootloader unified defconfig
- Kernel defconfig changes
- Note about disabled VFS driver on 900MHz CPU
- Rename output images to contain ".rootfs."