### PR TITLE
BSPIMX8M-3496 adapt dt-overlays chapter to external boot script

### DIFF
--- a/source/bsp/dt-overlays.rsti
+++ b/source/bsp/dt-overlays.rsti
@@ -1,0 +1,138 @@
+The usage of overlays can be configured during runtime in Linux or U-Boot.
+Overlays are applied during the boot process in the bootloader after the
+boot command is called and before the kernel is loaded. The next sections
+explain the configuration in more detail.
+
+Set ``${overlays}`` variable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``${overlays}`` U-Boot environment variable contains a number-sign (#)
+separated list of overlays that will be applied during boot. The overlays
+listed in the overlays variable must be included in the FIT image. Overlays set
+in the $KERNEL_DEVICETREE Yocto machine variable will automatically be added to
+the FIT image.
+
+The ``${overlays}`` variable can either be set directly in the U-Boot
+environment or can be part of the external ``bootenv.txt`` environment file.
+When desired to use the overlays variable as set manually in the U-Boot
+environment, disable bootenv by setting ``env set no_bootenv 1`` as the overlays
+variable may be overwritten during the execution of the boot script.
+By default, the ``${overlays}`` variable comes from the external ``bootenv.txt``
+environment file which is located in the boot partition.
+You can read and write the file on booted target from linux:
+
+.. code-block:: console
+   :substitutions:
+
+   target:~$ cat /boot/bootenv.txt
+   overlays=conf-|dt-carrierboard|-peb-eval-01.dtbo#|dtbo-peb-av-10|
+
+Changes will take effect after the next reboot. If no ``bootenv.txt`` file is
+available the overlays variable can be set directly in the U-Boot environment.
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> setenv overlays conf-|dtbo-peb-av-10|
+   u-boot=> printenv overlays
+   overlays=conf-|dtbo-peb-av-10|
+   u-boot=> boot
+
+If a user defined ``${overlays}`` variable should be directly loaded from U-Boot
+environment but there is still an external ``bootenv.txt`` available, the ``${no_bootenv}``
+variable needs to be set as a flag:
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> setenv no_bootenv 1
+   u-boot=> setenv overlays conf-|dtbo-peb-av-10|
+   u-boot=> boot
+
+More information about the external environment can be found in
+|ubootexternalenv|.
+
+We use the ``${overlays}`` variable for overlays describing expansion boards and
+cameras that can not be detected during run time. To prevent applying overlays
+unset the overlays variable and set no_bootenv to anything other than 0.
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> env delete overlays
+   u-boot=> env set no_bootenv 1
+
+
+If desired to use the bootenv.txt file for setting U-Boot variables other than
+overlays and having overlays disabled, remove the overlays definition line from
+the bootenv.txt file instead of setting no_bootenv.
+
+SoM Variants
+~~~~~~~~~~~~
+
+Additional overlays are applied automatically to disable components that are not
+populated on the SoM. The detection is done with the EEPROM data (EEPROM SoM
+Detection) found on the SoM i2c EEPROM.
+
+It depends on the SoM variant if any device tree overlays will be applied. To check
+if an overlay will be applied on the running SoM in U-Boot, run:
+
+.. code-block::
+   :substitutions:
+
+   u-boot=> env print fit_extensions
+
+If the EEPROM data is not available, no device tree overlays are applied.
+
+To prevent application of the SoM variant related overlays the
+``${no_extensions}`` variable can be set to `1` in the bootloader environment::
+
+   u-boot=> setenv no_extensions 1
+   u-boot=> boot
+
+U-boot External Environment
+...........................
+
+During the start of the Linux Kernel the external environment ``bootenv.txt``
+text file will be loaded from the boot partition of an MMC device or via TFTP.
+The main intention of this file is to store the ``${overlays}`` variable. This makes
+it easy to pre-define the overlays in Yocto depending on the used machine. The
+content from the file is defined in the Yocto recipe bootenv found in
+meta-phytec:
+|yocto-bootenv-link|
+
+Other variables can be set in this file, too. They will overwrite the existing
+settings in the environment. But only variables evaluated after issuing the boot
+command can be overwritten, such as ``${nfsroot}`` or ``${mmcargs}``. Changing other
+variables in that file will not have an effect. See the usage during netboot as
+an example.
+
+If the external environment can not be loaded the boot process will be anyway
+continued with the values of the existing environment settings.
+
+Change U-boot Environment from Linux on Target
+..............................................
+
+Libubootenv is a tool included in our images to modify the U-Boot environment of
+Linux on the target machine.
+
+Print the U-Boot environment using the following command:
+
+.. code-block:: console
+
+   target:~$ fw_printenv
+
+Modify a U-Boot environment variable using the following command:
+
+.. code-block:: console
+
+   target:~$ fw_setenv <variable> <value>
+
+.. caution::
+   Libubootenv takes the environment selected in a configuration file. The
+   environment to use is inserted there, and by default it is configured to use
+   the eMMC environment (known as the default used environment).
+
+   If the eMMC is not flashed or the eMMC environment is deleted, libubootenv
+   will not work. You should modify the ``/etc/fw_env.config`` file to match the
+   environment source that you want to use.

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -311,7 +311,7 @@ To revert to the old style of booting, you may do
    imx8mp-vm017-csi2-fpdlink.dtbo
 
 .. _imx8mp-head-ubootexternalenv:
-.. include:: ../dt-overlays.rsti
+.. include:: ../../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
 .. ACCESSING PERIPHERALS


### PR DESCRIPTION
Handling of device tree overlays changed due to introduction of loading and executing an external boot script.
As the boot script can be used for all PHYTEC products (using U-Boot) make a generic include file for overlay handling.
The new file is mostly a copy of the existing imx8 one, but does not contain any product specific info (examples include a specific expansion board, though).

This PR introduces a generic dt-overlays file, that may be included by any product family.
In addition the imx8mp includes this newly generated file as it is the only product making use of the U-Boot standard boot bootflow.