### PR TITLE
translation: do not wrap lines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -362,6 +362,17 @@ the language path to the ``languages`` list in the ``conf.py`` file.::
        ]
    }
 
+Edit translation messages with Poedit
+-------------------------------------
+
+Poedit is a popular translation editor that can be used to edit the po files.
+To align with the linebreaks that Sphinx is using, make sure to set the
+following options in Files/Preferences/Advanced.::
+
+   Line endings: Unix
+   Unselect "Wrap at"
+   Select "Preserve formatting of existing files"
+
 Unresolved Issues
 =================
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ deps =
 [testenv:py3-intl]
 commands =
     sphinx-build -b gettext source build/locale
-    sphinx-intl update -p build/locale -l zh_CN
+    # Do now wrap lines in the .pot files
+    sphinx-intl update -p build/locale -l zh_CN --line-width=10000
     sphinx-build -E -W --keep-going -b html -D language=zh_CN source build/html/zh_CN -j auto
 
 [testenv:py3-html]


### PR DESCRIPTION
We agreed to not wrap lines in the translation messages. This is an option that can be set in Poedit. This commit represents the related setting in Sphinx.

Follow-up PR to #229 