### PR TITLE
SEO: add sitemap, robot.txt

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,3 +2,4 @@ Sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
 Sphinx-Substitution-Extensions==2022.2.16.0
 sphinx-intl==2.2.0
+sphinx-sitemap==2.6.0

--- a/source/conf.py
+++ b/source/conf.py
@@ -75,6 +75,9 @@ html_title = 'PHYTEC BSP Documentation'
 html_show_sphinx = False
 html_baseurl = 'https://phytec.github.io/doc-bsp-yocto/'
 
+# Add robots.txt so search engines can index the site
+html_extra_path = ['sphinx/static/robots.txt']
+
 # Link scheme
 sitemap_url_scheme = "{lang}{link}"
 sitemap_locales = ['zh_CN']

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx_rtd_theme',
     'sphinx_substitution_extensions',
+    'sphinx_sitemap',
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -72,6 +73,11 @@ html_logo = 'sphinx/static/logo-phytec.svg'
 html_favicon = 'sphinx/static/favicon.ico'
 html_title = 'PHYTEC BSP Documentation'
 html_show_sphinx = False
+html_baseurl = 'https://phytec.github.io/doc-bsp-yocto/'
+
+# Link scheme
+sitemap_url_scheme = "{lang}{link}"
+sitemap_locales = ['zh_CN']
 
 html_theme_options = {
     'logo_only': False,

--- a/source/sphinx/static/robots.txt
+++ b/source/sphinx/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://phytec.github.io/doc-bsp-yocto/sitemap.xml


### PR DESCRIPTION
the sphinx extension `sphinx-sitemap` allows to generate a sitemap automatically. robot.txt points to the sitemap so that the documentation page is better indexed and users can find it easier when they search for a topic in their search engine.