### PR TITLE
SEO: add html file for google-site-verification

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -73,7 +73,8 @@ html_show_sphinx = False
 html_baseurl = 'https://phytec.github.io/doc-bsp-yocto/'
 
 # Add robots.txt so search engines can index the site
-html_extra_path = ['sphinx/static/robots.txt']
+html_extra_path = ['sphinx/static/robots.txt',
+                   'sphinx/static/googledd12f2e41658d61e.html']
 
 # Link scheme
 sitemap_url_scheme = "{lang}{link}"

--- a/source/sphinx/static/googledd12f2e41658d61e.html
+++ b/source/sphinx/static/googledd12f2e41658d61e.html
@@ -1,0 +1,1 @@
+google-site-verification: googledd12f2e41658d61e.html


### PR DESCRIPTION
Depends on #236 to be merged

Adding this file allows to check https://github.com/phytec/doc-bsp-yocto/ in the Google Search Console. This will not track any users or collect any data, it only allows to analyze the website to check if the newly introduced sitemap works properly.