### PR TITLE
gh action: deploy: add building of pdf documentation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,12 +17,13 @@ jobs:
     - name: Install dependencies
       run: |
           sudo apt update
-          sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
+          sudo apt install tox texlive-latex-extra texlive-xetex texlive-lang-chinese latexmk python3-pip -y
           pip3 install -r requirements/setup.txt
     - name: Render Documentation
       run: |
         tox -e py3-intl
         tox -e py3-html
+        tox -e py3-pdf
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
The pdf documentation has been build in the build action, but not in the depoy action. Since pdf files are now linked in the manuals, the pdf build action has to be triggered in the deploy action as well.

Just noticed after merging #204 that I forgot to execute the pdf build in the deploy action.