### PR TITLE
gh action: deploy: increase timeout

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
     - name: Clone repo with all tags (required for git describe)
       uses: actions/checkout@v4


### PR DESCRIPTION
The deploy action builds the pdf since #238 is merged. The deploy action now takes longer than 5 min to build everything.