### PR TITLE
gh actions: do not preserve history on gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,3 +29,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: build/html
+        force_orphan: true


### PR DESCRIPTION
Currently each deploy action and subsequent push to the gh-pages branch adds a commit with build artifacts. This makes the size of the branch very large over time.

To fix this issue the action-gh-pages supports the orphan option, which creates a new commit without considering the build history, effectively overwriting the whole branch at each deploy.