### PR TITLE
bsp: imx93: add pdf build, link to html documentation

### DIFF
--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -7,6 +7,7 @@
 .. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.wic.xz
 .. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.partup
 .. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+.. _`static-pdf-dl`: ../../../_static/imx93-pd24.2.0.pdf
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
 
@@ -105,6 +106,10 @@
 .. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.2.0-components>`
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
 
 +-----------------------+----------------------+
 | |soc| BSP Manual                             |

--- a/source/conf.py
+++ b/source/conf.py
@@ -261,6 +261,14 @@ latex_documents = [
         False,
     ),
     (
+        'bsp/imx9/imx93/pd24.2.0',
+        'imx93-pd24.2.0.tex',
+        'i.MX 93 BSP Manual PD24.2.0',
+        'PHYTEC Messtechnik GmbH',
+        'manual',
+        False,
+    ),
+    (
         'yocto/kirkstone',
         'kirkstone.tex',
         'Yocto Reference Manual Kirkstone',


### PR DESCRIPTION
As described in #228, this is a follow-up PR to enable and link the pdf version of the manual.