### PR TITLE
gh actions: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,13 @@ jobs:
     - name: Install dependencies
       run: |
           sudo apt update
-          sudo apt install tox texlive-latex-extra texlive-xetex latexmk python3-pip -y
+          sudo apt install tox texlive-latex-extra texlive-xetex texlive-lang-chinese latexmk python3-pip -y
           pip3 install -r requirements/setup.txt
 
     - name: Build PDF Documentation
       run: |
         tox -e py3-intl
+        tox -e py3-html
         tox -e py3-pdf
 
       ######## CREATE RELEASE and UPLOAD BUILD ARTIFACTS ########


### PR DESCRIPTION
As general support for pdf manuals in chinese language has been added, an invocation of the pdf build will build pdf files in all languages. This commit adds tex support for chinese language to the build machine as the release action will otherwise fail.

Note: PDF files are build for all languages, but only filed for the default language (en).