### PR TITLE
bsp: imx8mp: Fix remoteproc overlay substitution variable

### DIFF
--- a/source/bsp/dt-overlays.rsti
+++ b/source/bsp/dt-overlays.rsti
@@ -39,7 +39,7 @@ You can read and write the file on booted target from linux:
    :substitutions:
 
    target:~$ cat /boot/bootenv.txt
-   overlays=conf-|dt-carrierboard|-peb-eval-01.dtbo#|dtbo-peb-av-10|
+   overlays=conf-|dt-carrierboard|-peb-eval-01.dtbo#conf-|dtbo-peb-av-10|
 
 Changes will take effect after the next reboot. If no ``bootenv.txt`` file is
 available the overlays variable can be set directly in the U-Boot environment.

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -63,7 +63,7 @@
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
-.. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-rpmsg| replace:: conf-imx8mp-phycore-rpmsg.dtbo
 .. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-10.dtbo
 
 .. IMX8(MP) specific

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -63,7 +63,7 @@
 .. Devicetree
 .. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
 .. |dt-som| replace:: imx8mp-phycore-som
-.. |dtbo-rpmsg| replace:: imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-rpmsg| replace:: conf-imx8mp-phycore-rpmsg.dtbo
 .. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-10.dtbo
 
 .. IMX8(MP) specific


### PR DESCRIPTION
Update the remoteproc substition variable "dtbo-rpmsg" with the prefix "conf-" for head.rst and pd24.1.0_nxp.rst.