### PR TITLE
source: yocto: Fix headline for own-layer-creation section

### DIFF
--- a/source/yocto/kirkstone.rst
+++ b/source/yocto/kirkstone.rst
@@ -1505,7 +1505,7 @@ to your *build/conf/local.conf*. Do not forget to rebuild the image
 
    host:~$ bitbake phytec-qt6demo-image
 
-Create your own Layer create layer
+Create your own layer
 ..................................
 
 Creating your layer should be one of the first tasks when customizing the BSP.

--- a/source/yocto/mickledore.rst
+++ b/source/yocto/mickledore.rst
@@ -1454,7 +1454,7 @@ to your *build/conf/local.conf*. Do not forget to rebuild the image
 
    host:~$ bitbake phytec-qt6demo-image
 
-Create your own Layer create layer
+Create your own layer
 ..................................
 
 Creating your layer should be one of the first tasks when customizing the BSP.

--- a/source/yocto/scarthgap.rst
+++ b/source/yocto/scarthgap.rst
@@ -1499,7 +1499,7 @@ to your *build/conf/local.conf*. Do not forget to rebuild the image
 
    host:~$ bitbake phytec-qt6demo-image
 
-Create your own Layer create layer
+Create your own layer
 ..................................
 
 Creating your layer should be one of the first tasks when customizing the BSP.


### PR DESCRIPTION
Did not fix the id in the translation file, nor the translated string.

Fixes #253