### PR TITLE
PDF generation: fix some problems that came up with the U&D manual

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -131,8 +131,8 @@ latex_elements = {
         \fancyhf{}
         \fancyfoot[R]{{\py@HeaderFamily\thepage}}
         \fancyfoot[L]{{\py@HeaderFamily\nouppercase{\leftmark}}}
-        \fancyhead[L]{{\py@HeaderFamily \@title}}
-        \fancyhead[R]{{\py@HeaderFamily Documentation Rev.: \textit{''' + version + r'''}}}
+        \fancyhead[L]{{\py@HeaderFamily \fontsize{9}{10.8}\selectfont \@title}}
+        \fancyhead[R]{{\py@HeaderFamily \fontsize{9}{10.8}\selectfont Doc-rev.: \textit{''' + version + r'''}}}
         \renewcommand{\headrulewidth}{0.4pt}
         \renewcommand{\footrulewidth}{0.4pt}
       }

--- a/source/conf.py
+++ b/source/conf.py
@@ -306,7 +306,7 @@ latex_documents = [
     (
         'rauc/kirkstone',
         'rauc-kirkstone.tex',
-        'RAUC Update \& Device Management Manual Kirkstone',
+        'RAUC Update \\& Device Management Manual Kirkstone',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -314,7 +314,7 @@ latex_documents = [
     (
         'rauc/mickledore',
         'rauc-mickledore.tex',
-        'RAUC Update \& Device Management Manual Mickledore',
+        'RAUC Update \\& Device Management Manual Mickledore',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,
@@ -322,7 +322,7 @@ latex_documents = [
     (
         'rauc/scarthgap',
         'rauc-scarthgap.tex',
-        'RAUC Update \& Device Management Manual Scarthgap',
+        'RAUC Update \\& Device Management Manual Scarthgap',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,


### PR DESCRIPTION
Fixes some problems that have been introduced in #256:

- escaping warnings during build.
- headline overlap in manual headings.