### PR TITLE
eeprom: fix 256 bytes typo

### DIFF
--- a/source/bsp/imx8/peripherals/eeprom.rsti
+++ b/source/bsp/imx8/peripherals/eeprom.rsti
@@ -3,7 +3,7 @@ I2C EEPROM on |som|
 
 .. warning::
 
-   The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 265 bytes of the
+   The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 256 bytes of the
    normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or
    overwritten. As this will influence the behavior of the bootloader. The board
    might not boot correctly anymore.
@@ -43,13 +43,13 @@ select the correct RAM configuration. This makes it possible to use the same
 bootloader image for different RAM sizes and choose the correct DTS overlays
 automatically.
 
-If the EEPROM ID page data and the first 265 bytes of the normal area are
+If the EEPROM ID page data and the first 256 bytes of the normal area are
 deleted, the bootloader will fall back to the |som| Kit RAM setup, which
 is |kit-ram-size| RAM.
 
 .. warning::
 
-   The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 265 bytes of the
+   The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 256 bytes of the
    normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or
    overwritten. As this will influence the behavior of the bootloader. The board
    might not boot correctly anymore.

--- a/source/bsp/imx9/peripherals/eeprom.rsti
+++ b/source/bsp/imx9/peripherals/eeprom.rsti
@@ -48,12 +48,12 @@ select the correct RAM configuration. This makes it possible to use the same
 bootloader image for different RAM sizes and choose the correct DTS overlays
 automatically.
 
-If the first 265 bytes of the normal area are deleted, the bootloader will fall
+If the first 256 bytes of the normal area are deleted, the bootloader will fall
 back to the |som| Kit RAM setup, which is |kit-ram-size| RAM.
 
 .. warning::
 
-   Data in the first 265 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50)
+   Data in the first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50)
    shouldn't be erased or corrupted! This might influence the behavior of the
    bootloader. The board might not boot correctly anymore.
 

--- a/source/locale/zh_CN/LC_MESSAGES/bsp.po
+++ b/source/locale/zh_CN/LC_MESSAGES/bsp.po
@@ -4911,8 +4911,8 @@ msgstr "|som| 上的I2C EEPROM"
 
 #: ../../source/bsp/imx8/peripherals/eeprom.rsti:6
 #: ../../source/bsp/imx8/peripherals/eeprom.rsti:52
-msgid "The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 265 bytes of the normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or overwritten. As this will influence the behavior of the bootloader. The board might not boot correctly anymore."
-msgstr "EEPROM ID页面（总线：I2C-0 地址：0x59）和正常EEPROM区域的前265个字节（总线：I2C-0 地址：0x51）不可被擦除或修改。这将影响bootloader的行为。板子可能无法正确启动。"
+msgid "The EEPROM ID page (bus: I2C-0 addr: 0x59) and the first 256 bytes of the normal EEPROM area (bus: I2C-0 addr: 0x51) should not be erased or overwritten. As this will influence the behavior of the bootloader. The board might not boot correctly anymore."
+msgstr "EEPROM ID页面（总线：I2C-0 地址：0x59）和正常EEPROM区域的前256个字节（总线：I2C-0 地址：0x51）不可被擦除或修改。这将影响bootloader的行为。板子可能无法正确启动。"
 
 #: ../../source/bsp/imx8/peripherals/eeprom.rsti:12
 msgid "The I2C EEPROM on the |som| SoM is connected to I2C address 0x51 on the I2C-0 bus. It is possible to read and write directly to the device populated:"
@@ -4942,8 +4942,8 @@ msgid "The EEPROM data is read at a really early stage during startup. It is use
 msgstr "在启动的早期阶段读取EEPROM数据。它用于选择正确的DDR RAM配置。这使得可以使用相同的bootloader镜像来支持不同的RAM大小，并自动选择正确的DTS overlay。"
 
 #: ../../source/bsp/imx8/peripherals/eeprom.rsti:46
-msgid "If the EEPROM ID page data and the first 265 bytes of the normal area are deleted, the bootloader will fall back to the |som| Kit RAM setup, which is |kit-ram-size| RAM."
-msgstr "如果EEPROM ID页面数据和正常区域的前265个字节被删除，bootloader程序将回退到 |som| Kit RAM设置，即 |kit-ram-size| RAM。"
+msgid "If the EEPROM ID page data and the first 256 bytes of the normal area are deleted, the bootloader will fall back to the |som| Kit RAM setup, which is |kit-ram-size| RAM."
+msgstr "如果EEPROM ID页面数据和正常区域的前256个字节被删除，bootloader程序将回退到 |som| Kit RAM设置，即 |kit-ram-size| RAM。"
 
 #: ../../source/bsp/imx8/peripherals/eeprom.rsti:57
 msgid "SoMs that are flashed with data format API revision 2 will print out information about the module in the early stage."
@@ -9184,12 +9184,12 @@ msgid "PHYTEC uses first 256 bytes in EEPROM normal area to store information ab
 msgstr "PHYTEC在EEPROM正常区域的前256字节中存储有关核心板的信息。这包括PCB版本和贴装选项。"
 
 #: ../../source/bsp/imx9/peripherals/eeprom.rsti:51
-msgid "If the first 265 bytes of the normal area are deleted, the bootloader will fall back to the |som| Kit RAM setup, which is |kit-ram-size| RAM."
-msgstr "如果正常区域的前265个字节被删除，启动加载程序将回退到 |som| 开发板内存配置，即 |kit-ram-size| RAM。"
+msgid "If the first 256 bytes of the normal area are deleted, the bootloader will fall back to the |som| Kit RAM setup, which is |kit-ram-size| RAM."
+msgstr "如果正常区域的前256个字节被删除，启动加载程序将回退到 |som| 开发板内存配置，即 |kit-ram-size| RAM。"
 
 #: ../../source/bsp/imx9/peripherals/eeprom.rsti:56
-msgid "Data in the first 265 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50) shouldn't be erased or corrupted! This might influence the behavior of the bootloader. The board might not boot correctly anymore."
-msgstr "正常EEPROM区域的前265个字节（总线：I2C-2 地址：0x50）不应被擦除或损坏！这可能会影响bootloader的行为。板子可能无法正确启动。"
+msgid "Data in the first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50) shouldn't be erased or corrupted! This might influence the behavior of the bootloader. The board might not boot correctly anymore."
+msgstr "正常EEPROM区域的前256个字节（总线：I2C-2 地址：0x50）不应被擦除或损坏！这可能会影响bootloader的行为。板子可能无法正确启动。"
 
 #: ../../source/bsp/imx9/peripherals/eeprom.rsti:63
 msgid "The hardware introspection data is pre-written on the EEPROM data spaces. If you have accidentally deleted or overwritten the HW data, you could contact our support!"


### PR DESCRIPTION
Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
