### PR TITLE
yocto: Fix headline duplication

### DIFF
--- a/source/yocto/kirkstone.rst
+++ b/source/yocto/kirkstone.rst
@@ -1045,8 +1045,8 @@ working correctly
 The first compile process takes about 40 minutes on a modern Intel Core i7. All
 subsequent builds will use the filled caches and should take about 3 minutes.
 
-Images images
--------------
+Images
+------
 
 If everything worked, the images can be found under
 

--- a/source/yocto/mickledore.rst
+++ b/source/yocto/mickledore.rst
@@ -994,8 +994,8 @@ working correctly
 The first compile process takes about 40 minutes on a modern Intel Core i7. All
 subsequent builds will use the filled caches and should take about 3 minutes.
 
-Images images
--------------
+Images
+------
 
 If everything worked, the images can be found under
 

--- a/source/yocto/scarthgap.rst
+++ b/source/yocto/scarthgap.rst
@@ -1047,8 +1047,8 @@ working correctly
 The first compile process takes about 40 minutes on a modern Intel Core i7. All
 subsequent builds will use the filled caches and should take about 3 minutes.
 
-Images images
--------------
+Images
+------
 
 If everything worked, the images can be found under
 


### PR DESCRIPTION
Did not fix the id in the translation file, nor the translated string.