### PR TITLE
bsp: periphals: introduction: Fix spelling "reused"

### DIFF
--- a/source/bsp/peripherals/introduction.rsti
+++ b/source/bsp/peripherals/introduction.rsti
@@ -11,7 +11,7 @@ To achieve maximum software reuse, the Linux kernel offers a sophisticated
 infrastructure that layers software components into board-specific parts. The
 BSP tries to modularize the kit features as much as possible. When a customized
 baseboard or even a customer-specific module is developed, most of the software
-support can be re-used without error-prone copy-and-paste. The kernel code
+support can be reused without error-prone copy-and-paste. The kernel code
 corresponding to the boards can be found in device trees (DT) in the kernel
 repository under ``arch/arm64/boot/dts/freescale/*.dts``.
 


### PR DESCRIPTION
Fix the spelling of "reused".