### PR TITLE
bsp: peripherals: rs485: use |serial-uart|

### DIFF
--- a/source/bsp/peripherals/rs485-fullduplex.rsti
+++ b/source/bsp/peripherals/rs485-fullduplex.rsti
@@ -12,8 +12,8 @@ For full-duplex mode you can set the ioctls manually like this:
 .. code-block:: console
    :substitutions:
 
-   target:~$ rs485conf /dev/ttymxc1 -e 1 -r 1
-   target:~$ rs485conf /dev/ttymxc1
+   target:~$ rs485conf /dev/|serial-uart| -e 1 -r 1
+   target:~$ rs485conf /dev/|serial-uart|
    = Current configuration:
    RS485 enabled:                true
    RTS on send:                  high
@@ -28,8 +28,8 @@ Also here you can do the echo test to see if sending and receiving works:
 .. code-block:: console
    :substitutions:
 
-   target1:~$ cat /dev/ttymxc1
-   target2:~$ echo test > /dev/ttymxc1
+   target1:~$ cat /dev/|serial-uart|
+   target2:~$ echo test > /dev/|serial-uart|
 
 You should see "test" printed out on target1. You can also switch the roles and
 send on target2 and receive on target1.
@@ -40,12 +40,12 @@ linux-serial-test tool:
 .. code-block:: console
    :substitutions:
 
-   target1:~$ linux-serial-test -s -e -f -p /dev/ttymxc1 -b 115200 --rs485 0 -o 10 -i 15 -W 2
+   target1:~$ linux-serial-test -s -e -f -p /dev/|serial-uart| -b 115200 --rs485 0 -o 10 -i 15 -W 2
    ...
-   /dev/ttymxc1: count for this session: rx=114660, tx=118755, rx err=0
-   target2:~$ linux-serial-test -s -e -f -p /dev/ttymxc1 -b 115200 --rs485 0 -o 10 -i 15 -W 2
+   /dev/|serial-uart|: count for this session: rx=114660, tx=118755, rx err=0
+   target2:~$ linux-serial-test -s -e -f -p /dev/|serial-uart| -b 115200 --rs485 0 -o 10 -i 15 -W 2
    ...
-   /dev/ttymxc1: count for this session: rx=118755, tx=114660, rx err=0
+   /dev/|serial-uart|: count for this session: rx=118755, tx=114660, rx err=0
 
 In this example both targets will send and receive simultaneously. They will
 receive for 15sec and send for 10sec. The receiver needs to receive a bit

--- a/source/bsp/peripherals/rs485-halfduplex.rsti
+++ b/source/bsp/peripherals/rs485-halfduplex.rsti
@@ -12,8 +12,8 @@ For half-duplex mode you can set the ioctls manually like this:
 .. code-block:: console
    :substitutions:
 
-   target:~$ rs485conf /dev/ttymxc1 -e 1 -r 0
-   target:~$ rs485conf /dev/ttymxc1
+   target:~$ rs485conf /dev/|serial-uart| -e 1 -r 0
+   target:~$ rs485conf /dev/|serial-uart|
    = Current configuration:
    RS485 enabled:                true
    RTS on send:                  high
@@ -28,8 +28,8 @@ Then you can test if sending and receiving works like this:
 .. code-block:: console
    :substitutions:
 
-   target1:~$ cat /dev/ttymxc1
-   target2:~$ echo test > /dev/ttymxc1
+   target1:~$ cat /dev/|serial-uart|
+   target2:~$ echo test > /dev/|serial-uart|
 
 You should see "test" printed out on target1. You can also switch the roles and
 send on target2 and receive on target1.
@@ -39,12 +39,12 @@ Alternatively you can also test with the linux-serial-test tool:
 .. code-block:: console
    :substitutions:
 
-   target1:~$ linux-serial-test -s -e -f -p /dev/ttymxc1 -b 115200 --rs485 0 -t -i 8
+   target1:~$ linux-serial-test -s -e -f -p /dev/|serial-uart| -b 115200 --rs485 0 -t -i 8
    ...
-   /dev/ttymxc1: count for this session: rx=57330, tx=0, rx err=0
-   target2:~$ linux-serial-test -s -e -f -p /dev/ttymxc1 -b 115200 --rs485 0 -r -o 5
+   /dev/|serial-uart|: count for this session: rx=57330, tx=0, rx err=0
+   target2:~$ linux-serial-test -s -e -f -p /dev/|serial-uart| -b 115200 --rs485 0 -r -o 5
    ...
-   /dev/ttymxc1: count for this session: rx=0, tx=57330, rx err=0
+   /dev/|serial-uart|: count for this session: rx=0, tx=57330, rx err=0
 
 In this example target1 will be the receiver and target2 will be the
 transmitter. You should also be able to switch the roles. Remember to first

--- a/source/bsp/peripherals/rs485.rsti
+++ b/source/bsp/peripherals/rs485.rsti
@@ -25,14 +25,14 @@ You can show the current config with:
 .. code-block:: console
    :substitutions:
 
-   target:~$ rs485conf /dev/ttymxc1
+   target:~$ rs485conf /dev/|serial-uart|
 
 You can show all options with:
 
 .. code-block:: console
    :substitutions:
 
-   target:~$ rs485conf /dev/ttymxc1 -h
+   target:~$ rs485conf /dev/|serial-uart| -h
 
 Documentation for calling the IOCTL within c-code is described in the Linux
 kernel documentation:


### PR DESCRIPTION
Replace the fixed tty device specification with the replacement |serial-uart|.