### PR TITLE
i.MX93 BSP documentation update for PD24.2.1

### DIFF
--- a/source/bsp/imx9/imx93/display.rsti
+++ b/source/bsp/imx9/imx93/display.rsti
@@ -2,10 +2,10 @@ Display
 -------
 
 The **phyBOARD-Segin** i.MX 93 supports PEB-AV-02 with 7'' ``edt,etm0700g0edh6``
-parallel display with capacitive touchscreen. Overlay for said display is
-enabled in ``BOOT/bootenv.txt`` by default!
+parallel display with capacitive touchscreen. Device-tree overlay for the
+aforementioned display is enabled in ``/boot/bootenv.txt`` by default!
 
 The **phyBOARD-Nash** i.MX 93 needs additional adapter to support 10''
 ``edt,etml1010g3dra`` LVDS display with capacitive touchscreen. The PEB-AV-10
-(1531.1 revision) can be bought separately to the Kit. Overlay for said display
-is enabled in ``BOOT/bootenv.txt`` by default!
+(1531.1 revision) can be bought separately to the Kit. Device-tree overlay for
+the aforementioned adapter is enabled in ``/boot/bootenv.txt`` by default!

--- a/source/bsp/imx9/imx93/imx93.rst
+++ b/source/bsp/imx9/imx93/imx93.rst
@@ -2,6 +2,16 @@
 i.MX 93 Manuals
 ====================
 
+BSP-Yocto-NXP-i.MX93-PD24.2.1
+=============================
+
+.. toctree::
+   :caption: Table of Contents
+   :numbered:
+   :maxdepth: 2
+
+   pd24.2.1
+
 BSP-Yocto-NXP-i.MX93-PD24.2.0
 =============================
 

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -759,7 +759,89 @@ with some additional features special to CAN. More information can be found in
 the Linux Kernel
 documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 
-.. include:: ../peripherals/canfd.rsti
+*  Use:
+
+   .. code-block:: console
+
+      target:~$ ip link
+
+   to see the state of the interfaces. The CAN interface should show up as
+   can0.
+
+*  To get information on can0, such as bit rate and error counters, type:
+
+   .. code-block:: console
+
+      target:~$ ip -d -s link show can0
+      4: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
+         link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0
+         can state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 0
+               bitrate 500000 sample-point 0.875
+               tq 25 prop-seg 37 phase-seg1 32 phase-seg2 10 sjw 1 brp 1
+               flexcan: tseg1 2..96 tseg2 2..32 sjw 1..16 brp 1..1024 brp_inc 1
+               flexcan: dtseg1 2..39 dtseg2 2..8 dsjw 1..4 dbrp 1..1024 dbrp_inc 1
+               clock 40000000
+               re-started bus-errors arbit-lost error-warn error-pass bus-off
+               0          0          0          0          0          0         numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus platform parentdev 443a0000.can
+         RX:  bytes packets errors dropped  missed   mcast
+                  0       0      0       0       0       0
+         TX:  bytes packets errors dropped carrier collsns
+                  0       0      0       0       0       0
+
+The output contains a standard set of parameters also shown for Ethernet
+interfaces, so not all of these are necessarily relevant for CAN (for example
+the MAC address). The following output parameters contain useful information:
+
+========== =============================
+can0       Interface Name
+========== =============================
+NOARP	     CAN cannot use ARP protocol
+MTU	     Maximum Transfer Unit
+RX packets Number of Received Packets
+TX packets Number of Transmitted Packets
+RX bytes   Number of Received Bytes
+TX bytes   Number of Transmitted Bytes
+errors...  Bus Error Statistics
+========== =============================
+
+
+The CAN configuration is done in the systemd configuration
+file ``/lib/systemd/network/can0.network``. For a persistent change of (as an
+example, the default bitrates), change the configuration in the BSP
+under ``./meta-ampliphy/recipes-core/systemd/systemd-conf/can0.network`` in
+the root filesystem and rebuild the root filesystem.
+
+.. code-block::
+
+   [Match]
+   Name=can0
+
+   [Can]
+   BitRate=500000
+
+The bitrate can also be changed manually, for example, to make use of the
+flexible bitrate:
+
+.. code-block:: console
+
+   target:~$ ip link set can0 down
+   target:~$ ip link set can0 txqueuelen 10 up type can bitrate 500000 sample-point 0.75 dbitrate 4000000 dsample-point 0.8 fd on
+
+You can send messages with cansend or receive messages with candump:
+
+.. code-block:: console
+
+   target:~$ cansend can0 123#45.67
+   target:~$ candump can0
+
+To generate random CAN traffic for testing purposes, use cangen:
+
+.. code-block:: console
+
+   target:~$ cangen
+
+``cansend --help`` and ``candump --help`` provide help messages for further information
+on options and usage.
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
 :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n147`

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -842,7 +842,71 @@ There are two different I2C EEPROM flashes populated on |som| SoM and on the
 |sbc|. For now only the one on the |som| is enabled, and it is used for board
 detection.
 
-.. include:: ../peripherals/eeprom.rsti
+I2C EEPROM on |som|
+...........................
+
+The I2C EEPROM on the |som| SoM has its memory divided into two parts.
+
+* normal area (size: 4096 bytes, bus: I2C-2, addr: 0x50)
+* ID page (size: 32 bytes, bus: I2C-2, addr: 0x58)
+
+It is possible to read and write from the device populated:
+
+.. code-block:: console
+
+   target:~$ hexdump -C /sys/class/i2c-dev/i2c-2/device/2-0058/eeprom
+
+To read and print the first 1024 bytes of the EEPROM as a hex number,
+execute:
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-2/device/2-0050/eeprom bs=1 count=1024  | od -x
+
+To fill the whole EEPROM (ID page) with zeros we first need to disable the
+EEPROM write protection, use:
+
+.. code-block:: console
+
+   target:~$ gpioset 2 21=0
+
+Then the EEPROM can be written to:
+
+.. code-block:: console
+
+   target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-2/device/2-0058/eeprom bs=32 count=1
+
+.. warning::
+
+   The first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50) are
+   reserved and should not be overwritten! (See below)
+
+EEPROM SoM Detection
+....................
+
+PHYTEC uses first 256 bytes in EEPROM normal area to store information about the
+SoM. This includes PCB revision and mounting options.
+
+The EEPROM data is read at a really early stage during startup. It is used to
+select the correct RAM configuration. This makes it possible to use the same
+bootloader image for different RAM sizes and choose the correct DTS overlays
+automatically.
+
+If the first 256 bytes of the normal area are deleted, the bootloader will fall
+back to the |som| Kit RAM setup, which is |kit-ram-size| RAM.
+
+.. warning::
+
+   Data in the first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50)
+   shouldn't be erased or corrupted! This might influence the behavior of the
+   bootloader. The board might not boot correctly anymore.
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on the EEPROM data spaces. If
+you have accidentally deleted or overwritten the HW data, you could contact our
+support!
 
 DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
 :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.36_2.1.0-phy1#n173`

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -693,7 +693,133 @@ DT configuration for the eMMC interface can be found here:
 
 .. include:: /bsp/imx-common/emmc.rsti
 
-.. include:: ../peripherals/gpios.rsti
+GPIOs
+-----
+
+The |sbc| doesn't have a set of pins especially dedicated for user I/Os since
+all GPIOs are used by kernel device drivers or used for a specific purpose. The
+processor has organized its GPIOs into five banks of 32 GPIOs each (GPIO1 –
+GPIO4) GPIOs. gpiochip0, gpiochip32, gpiochip64 and gpiochip96 are the sysfs
+representation of these internal |soc| GPIO banks GPIO1 – GPIO4.
+
+The GPIOs are identified as GPIO<X>_<Y> (e.g. GPIO4_07). <X> identifies the GPIO
+bank and counts from 1 to 4, while <Y> stands for the GPIO within the bank. <Y>
+is being counted from 0 to 31 (32 GPIOs on each bank).
+
+By contrast, the Linux kernel uses a single integer to enumerate all available
+GPIOs in the system. The formula to calculate the right number is:
+
+.. code-block::
+
+   Linux GPIO number: <N> = (<X> - 1) * 32 + <Y>
+
+Accessing GPIOs from userspace will be done using the libgpiod. It provides a
+library and tools for interacting with the Linux GPIO character device. Examples
+of some usages of various tools:
+
+*  Detecting the gpiochips on the chip:
+
+   .. code-block:: console
+
+      target:~$ gpiodetect
+      gpiochip0 [43810080.gpio] (32 lines)
+      gpiochip1 [43820080.gpio] (32 lines)
+      gpiochip2 [43830080.gpio] (32 lines)
+      gpiochip3 [47400080.gpio] (32 lines)
+
+.. note::
+
+   Order of GPIOchips in ``i.MX 93 Application Processor Reference Manual`` and
+   in Linux kernel differ!
+
+   +------------------+-----------+------------------+
+   | GPIOchip address | Linux     | Reference Manual |
+   +------------------+-----------+------------------+
+   | 0x43810080       | gpiochip0 | gpiochip2        |
+   +------------------+-----------+------------------+
+   | 0x43820080       | gpiochip1 | gpiochip3        |
+   +------------------+-----------+------------------+
+   | 0x43830080       | gpiochip2 | gpiochip4        |
+   +------------------+-----------+------------------+
+   | 0x47400080       | gpiochip3 | gpiochip1        |
+   +------------------+-----------+------------------+
+
+*  Show detailed information about the gpiochips. Like their names, consumers,
+   direction, active state, and additional flags:
+
+   .. code-block:: console
+
+      target:~$ gpioinfo gpiochip0
+
+*  Read the value of a GPIO (e.g GPIO 3 from chip0):
+
+   .. code-block:: console
+
+      target:~$ gpioget gpiochip0 3
+
+*  Set the value of GPIO 3 on chip0 to 0 and exit tool:
+
+   .. code-block:: console
+
+      target:~$ gpioset --mode=exit gpiochip0 3=0
+
+*  Help text of gpioset shows possible options:
+
+   .. code-block:: console
+
+      target:~$ gpioset --help
+      Usage: gpioset [OPTIONS] <chip name/number> <offset1>=<value1> <offset2>=<value2> ...
+      Set GPIO line values of a GPIO chip
+
+      Options:
+        -h, --help:           display this message and exit
+        -v, --version:        display the version and exit
+        -l, --active-low:     set the line active state to low
+        -m, --mode=[exit|wait|time|signal] (defaults to 'exit'):
+                      tell the program what to do after setting values
+        -s, --sec=SEC:        specify the number of seconds to wait (only valid for --mode=time)
+        -u, --usec=USEC:      specify the number of microseconds to wait (only valid for --mode=time)
+        -b, --background:     after setting values: detach from the controlling terminal
+
+      Modes:
+        exit:         set values and exit immediately
+        wait:         set values and wait for user to press ENTER
+        time:         set values and sleep for a specified amount of time
+        signal:       set values and wait for SIGINT or SIGTERM
+
+      Note: the state of a GPIO line controlled over the character device reverts to default
+      when the last process referencing the file descriptor representing the device file exits.
+      This means that it's wrong to run gpioset, have it exit and expect the line to continue
+      being driven high or low. It may happen if given pin is floating but it must be interpreted
+      as undefined behavior.
+
+
+.. warning::
+
+   Some of the user IOs are used for special functions. Before using a user IO,
+   refer to the schematic or the hardware manual of your board to ensure that it
+   is not already in use.
+
+GPIOs via sysfs
+...............
+
+.. warning::
+
+   Accessing gpios via sysfs is deprecated and we encourage to use libgpiod
+   instead.
+
+Support to access GPIOs via sysfs is not enabled by default any more.
+It is only possible with manually enabling CONFIG_GPIO_SYSFS in the kernel
+configuration. To make CONFIG_GPIO_SYSFS visible in menuconfig the option
+CONFIG_EXPERT has to be enabled first.
+
+You can also add this option for example to the
+imx9_phytec_distro.config config fragment in the linux kernel sources
+under arch/arm64/configs ::
+
+   ..
+   CONFIG_GPIO_SYSFS=y
+   ..
 
 .. include:: ../peripherals/leds.rsti
 

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -820,7 +820,89 @@ with some additional features special to CAN. More information can be found in
 the Linux Kernel
 documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 
-.. include:: ../peripherals/canfd.rsti
+*  Use:
+
+   .. code-block:: console
+
+      target:~$ ip link
+
+   to see the state of the interfaces. The CAN interface should show up as
+   can0.
+
+*  To get information on can0, such as bit rate and error counters, type:
+
+   .. code-block:: console
+
+      target:~$ ip -d -s link show can0
+      4: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
+         link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0
+         can state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 0
+               bitrate 500000 sample-point 0.875
+               tq 25 prop-seg 37 phase-seg1 32 phase-seg2 10 sjw 1 brp 1
+               flexcan: tseg1 2..96 tseg2 2..32 sjw 1..16 brp 1..1024 brp_inc 1
+               flexcan: dtseg1 2..39 dtseg2 2..8 dsjw 1..4 dbrp 1..1024 dbrp_inc 1
+               clock 40000000
+               re-started bus-errors arbit-lost error-warn error-pass bus-off
+               0          0          0          0          0          0         numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus platform parentdev 443a0000.can
+         RX:  bytes packets errors dropped  missed   mcast
+                  0       0      0       0       0       0
+         TX:  bytes packets errors dropped carrier collsns
+                  0       0      0       0       0       0
+
+The output contains a standard set of parameters also shown for Ethernet
+interfaces, so not all of these are necessarily relevant for CAN (for example
+the MAC address). The following output parameters contain useful information:
+
+========== =============================
+can0       Interface Name
+========== =============================
+NOARP	     CAN cannot use ARP protocol
+MTU	     Maximum Transfer Unit
+RX packets Number of Received Packets
+TX packets Number of Transmitted Packets
+RX bytes   Number of Received Bytes
+TX bytes   Number of Transmitted Bytes
+errors...  Bus Error Statistics
+========== =============================
+
+
+The CAN configuration is done in the systemd configuration
+file ``/lib/systemd/network/can0.network``. For a persistent change of (as an
+example, the default bitrates), change the configuration in the BSP
+under ``./meta-ampliphy/recipes-core/systemd/systemd-conf/can0.network`` in
+the root filesystem and rebuild the root filesystem.
+
+.. code-block::
+
+   [Match]
+   Name=can0
+
+   [Can]
+   BitRate=500000
+
+The bitrate can also be changed manually, for example, to make use of the
+flexible bitrate:
+
+.. code-block:: console
+
+   target:~$ ip link set can0 down
+   target:~$ ip link set can0 txqueuelen 10 up type can bitrate 500000 sample-point 0.75 dbitrate 4000000 dsample-point 0.8 fd on
+
+You can send messages with cansend or receive messages with candump:
+
+.. code-block:: console
+
+   target:~$ cansend can0 123#45.67
+   target:~$ candump can0
+
+To generate random CAN traffic for testing purposes, use cangen:
+
+.. code-block:: console
+
+   target:~$ cangen
+
+``cansend --help`` and ``candump --help`` provide help messages for further information
+on options and usage.
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
 :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n147` or

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -724,7 +724,133 @@ DT configuration for the eMMC interface can be found here:
 
 .. include:: /bsp/imx-common/emmc.rsti
 
-.. include:: ../peripherals/gpios.rsti
+GPIOs
+-----
+
+The |sbc| doesn't have a set of pins especially dedicated for user I/Os since
+all GPIOs are used by kernel device drivers or used for a specific purpose. The
+processor has organized its GPIOs into five banks of 32 GPIOs each (GPIO1 –
+GPIO4) GPIOs. gpiochip0, gpiochip32, gpiochip64 and gpiochip96 are the sysfs
+representation of these internal |soc| GPIO banks GPIO1 – GPIO4.
+
+The GPIOs are identified as GPIO<X>_<Y> (e.g. GPIO4_07). <X> identifies the GPIO
+bank and counts from 1 to 4, while <Y> stands for the GPIO within the bank. <Y>
+is being counted from 0 to 31 (32 GPIOs on each bank).
+
+By contrast, the Linux kernel uses a single integer to enumerate all available
+GPIOs in the system. The formula to calculate the right number is:
+
+.. code-block::
+
+   Linux GPIO number: <N> = (<X> - 1) * 32 + <Y>
+
+Accessing GPIOs from userspace will be done using the libgpiod. It provides a
+library and tools for interacting with the Linux GPIO character device. Examples
+of some usages of various tools:
+
+*  Detecting the gpiochips on the chip:
+
+   .. code-block:: console
+
+      target:~$ gpiodetect
+      gpiochip0 [43810080.gpio] (32 lines)
+      gpiochip1 [43820080.gpio] (32 lines)
+      gpiochip2 [43830080.gpio] (32 lines)
+      gpiochip3 [47400080.gpio] (32 lines)
+
+.. note::
+
+   Order of GPIOchips in ``i.MX 93 Application Processor Reference Manual`` and
+   in Linux kernel differ!
+
+   +------------------+-----------+------------------+
+   | GPIOchip address | Linux     | Reference Manual |
+   +------------------+-----------+------------------+
+   | 0x43810080       | gpiochip0 | gpiochip2        |
+   +------------------+-----------+------------------+
+   | 0x43820080       | gpiochip1 | gpiochip3        |
+   +------------------+-----------+------------------+
+   | 0x43830080       | gpiochip2 | gpiochip4        |
+   +------------------+-----------+------------------+
+   | 0x47400080       | gpiochip3 | gpiochip1        |
+   +------------------+-----------+------------------+
+
+*  Show detailed information about the gpiochips. Like their names, consumers,
+   direction, active state, and additional flags:
+
+   .. code-block:: console
+
+      target:~$ gpioinfo gpiochip0
+
+*  Read the value of a GPIO (e.g GPIO 3 from chip0):
+
+   .. code-block:: console
+
+      target:~$ gpioget gpiochip0 3
+
+*  Set the value of GPIO 3 on chip0 to 0 and exit tool:
+
+   .. code-block:: console
+
+      target:~$ gpioset --mode=exit gpiochip0 3=0
+
+*  Help text of gpioset shows possible options:
+
+   .. code-block:: console
+
+      target:~$ gpioset --help
+      Usage: gpioset [OPTIONS] <chip name/number> <offset1>=<value1> <offset2>=<value2> ...
+      Set GPIO line values of a GPIO chip
+
+      Options:
+        -h, --help:           display this message and exit
+        -v, --version:        display the version and exit
+        -l, --active-low:     set the line active state to low
+        -m, --mode=[exit|wait|time|signal] (defaults to 'exit'):
+                      tell the program what to do after setting values
+        -s, --sec=SEC:        specify the number of seconds to wait (only valid for --mode=time)
+        -u, --usec=USEC:      specify the number of microseconds to wait (only valid for --mode=time)
+        -b, --background:     after setting values: detach from the controlling terminal
+
+      Modes:
+        exit:         set values and exit immediately
+        wait:         set values and wait for user to press ENTER
+        time:         set values and sleep for a specified amount of time
+        signal:       set values and wait for SIGINT or SIGTERM
+
+      Note: the state of a GPIO line controlled over the character device reverts to default
+      when the last process referencing the file descriptor representing the device file exits.
+      This means that it's wrong to run gpioset, have it exit and expect the line to continue
+      being driven high or low. It may happen if given pin is floating but it must be interpreted
+      as undefined behavior.
+
+
+.. warning::
+
+   Some of the user IOs are used for special functions. Before using a user IO,
+   refer to the schematic or the hardware manual of your board to ensure that it
+   is not already in use.
+
+GPIOs via sysfs
+...............
+
+.. warning::
+
+   Accessing gpios via sysfs is deprecated and we encourage to use libgpiod
+   instead.
+
+Support to access GPIOs via sysfs is not enabled by default any more.
+It is only possible with manually enabling CONFIG_GPIO_SYSFS in the kernel
+configuration. To make CONFIG_GPIO_SYSFS visible in menuconfig the option
+CONFIG_EXPERT has to be enabled first.
+
+You can also add this option for example to the
+imx9_phytec_distro.config config fragment in the linux kernel sources
+under arch/arm64/configs ::
+
+   ..
+   CONFIG_GPIO_SYSFS=y
+   ..
 
 .. include:: /bsp/peripherals/adc.rsti
 

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -886,7 +886,71 @@ There are two different I2C EEPROM flashes populated on |som| SoM and on the
 |sbc|. For now only the one on the |som| is enabled, and it is used for board
 detection.
 
-.. include:: ../peripherals/eeprom.rsti
+I2C EEPROM on |som|
+...........................
+
+The I2C EEPROM on the |som| SoM has its memory divided into two parts.
+
+* normal area (size: 4096 bytes, bus: I2C-2, addr: 0x50)
+* ID page (size: 32 bytes, bus: I2C-2, addr: 0x58)
+
+It is possible to read and write from the device populated:
+
+.. code-block:: console
+
+   target:~$ hexdump -C /sys/class/i2c-dev/i2c-2/device/2-0058/eeprom
+
+To read and print the first 1024 bytes of the EEPROM as a hex number,
+execute:
+
+.. code-block:: console
+
+   target:~$ dd if=/sys/class/i2c-dev/i2c-2/device/2-0050/eeprom bs=1 count=1024  | od -x
+
+To fill the whole EEPROM (ID page) with zeros we first need to disable the
+EEPROM write protection, use:
+
+.. code-block:: console
+
+   target:~$ gpioset 2 21=0
+
+Then the EEPROM can be written to:
+
+.. code-block:: console
+
+   target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-2/device/2-0058/eeprom bs=32 count=1
+
+.. warning::
+
+   The first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50) are
+   reserved and should not be overwritten! (See below)
+
+EEPROM SoM Detection
+....................
+
+PHYTEC uses first 256 bytes in EEPROM normal area to store information about the
+SoM. This includes PCB revision and mounting options.
+
+The EEPROM data is read at a really early stage during startup. It is used to
+select the correct RAM configuration. This makes it possible to use the same
+bootloader image for different RAM sizes and choose the correct DTS overlays
+automatically.
+
+If the first 256 bytes of the normal area are deleted, the bootloader will fall
+back to the |som| Kit RAM setup, which is |kit-ram-size| RAM.
+
+.. warning::
+
+   Data in the first 256 bytes of the normal EEPROM area (bus: I2C-2 addr: 0x50)
+   shouldn't be erased or corrupted! This might influence the behavior of the
+   bootloader. The board might not boot correctly anymore.
+
+Rescue EEPROM Data
+..................
+
+The hardware introspection data is pre-written on the EEPROM data spaces. If
+you have accidentally deleted or overwritten the HW data, you could contact our
+support!
 
 DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
 :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n172`

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -464,7 +464,52 @@ Network
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
 
-.. include:: wireless-network.rsti
+WLAN
+....
+
+.. note::
+   For now, only |sbc-segin| supports WLAN/Bluetooth features. WLAN/Bluetooth is
+   thus not supported on |sbc-nash| yet.
+
+WLAN and Bluetooth on the |sbc-segin| are provided by the PEB-WLBT-05 expansion card.
+The PEB-WLBT-05 for |sbc-segin| Quickstart Guide shows you how to install the
+PEB-WLBT-05.
+
+.. tip::
+
+   With the BSP Version PD24.2 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   otherwise the PEB-WLBT-05 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx93-phyboard-segin-peb-wlbt-05.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
+module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
+information about the module can be found at
+https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
+
+.. note::
+   By default, bluetooth is not supported on |sbc-segin| with PEB-WLBT-05
+   expansion card due to hard-wired connections. However, it is possible to
+   re-work PEB-WLBT-05 card by adjusting solder pads and enabling bluetooth in
+   the software. Please contact your PHYTEC representative for more information.
 
 .. include:: ../../peripherals/wireless-network.rsti
    :end-before: .. no-bluetooth-marker

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -623,7 +623,89 @@ with some additional features special to CAN. More information can be found in
 the Linux Kernel
 documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 
-.. include:: ../peripherals/canfd.rsti
+*  Use:
+
+   .. code-block:: console
+
+      target:~$ ip link
+
+   to see the state of the interfaces. The CAN interface should show up as
+   can0.
+
+*  To get information on can0, such as bit rate and error counters, type:
+
+   .. code-block:: console
+
+      target:~$ ip -d -s link show can0
+      4: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
+         link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0
+         can state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 0
+               bitrate 500000 sample-point 0.875
+               tq 25 prop-seg 37 phase-seg1 32 phase-seg2 10 sjw 1 brp 1
+               flexcan: tseg1 2..96 tseg2 2..32 sjw 1..16 brp 1..1024 brp_inc 1
+               flexcan: dtseg1 2..39 dtseg2 2..8 dsjw 1..4 dbrp 1..1024 dbrp_inc 1
+               clock 40000000
+               re-started bus-errors arbit-lost error-warn error-pass bus-off
+               0          0          0          0          0          0         numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus platform parentdev 443a0000.can
+         RX:  bytes packets errors dropped  missed   mcast
+                  0       0      0       0       0       0
+         TX:  bytes packets errors dropped carrier collsns
+                  0       0      0       0       0       0
+
+The output contains a standard set of parameters also shown for Ethernet
+interfaces, so not all of these are necessarily relevant for CAN (for example
+the MAC address). The following output parameters contain useful information:
+
+========== =============================
+can0       Interface Name
+========== =============================
+NOARP	     CAN cannot use ARP protocol
+MTU	     Maximum Transfer Unit
+RX packets Number of Received Packets
+TX packets Number of Transmitted Packets
+RX bytes   Number of Received Bytes
+TX bytes   Number of Transmitted Bytes
+errors...  Bus Error Statistics
+========== =============================
+
+
+The CAN configuration is done in the systemd configuration
+file ``/lib/systemd/network/can0.network``. For a persistent change of (as an
+example, the default bitrates), change the configuration in the BSP
+under ``./meta-ampliphy/recipes-core/systemd/systemd-conf/can0.network`` in
+the root filesystem and rebuild the root filesystem.
+
+.. code-block::
+
+   [Match]
+   Name=can0
+
+   [Can]
+   BitRate=500000
+
+The bitrate can also be changed manually, for example, to make use of the
+flexible bitrate:
+
+.. code-block:: console
+
+   target:~$ ip link set can0 down
+   target:~$ ip link set can0 txqueuelen 10 up type can bitrate 500000 sample-point 0.75 dbitrate 4000000 dsample-point 0.8 fd on
+
+You can send messages with cansend or receive messages with candump:
+
+.. code-block:: console
+
+   target:~$ cansend can0 123#45.67
+   target:~$ candump can0
+
+To generate random CAN traffic for testing purposes, use cangen:
+
+.. code-block:: console
+
+   target:~$ cangen
+
+``cansend --help`` and ``candump --help`` provide help messages for further information
+on options and usage.
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L147` or

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -477,7 +477,7 @@ PEB-WLBT-05.
 
 .. tip::
 
-   With the BSP Version PD24.2 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   With the BSP Version PD24.2.0 and newer, the PEB-WLBT-05 overlay needs to be activated first,
    otherwise the PEB-WLBT-05 won't be recognized.
 
    .. code-block:: console

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -22,6 +22,7 @@
 .. |som| replace:: phyCORE-i.MX93
 .. |debug-uart| replace:: ttyLP0
 .. |serial-uart| replace:: ttyLP6
+.. |bluetooth-uart| replace:: UART5
 .. |expansion-connector| replace:: X16
 
 
@@ -468,7 +469,6 @@ Network
 .. include:: wireless-network.rsti
 
 .. include:: ../../peripherals/wireless-network.rsti
-   :end-before: .. no-bluetooth-marker
 
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -396,8 +396,8 @@ Execute and power up the board:
    imx93-phyboard-segin-peb-eval-01.dtbo
    imx93-phyboard-segin-peb-wlbt-05.dtbo
    imx93-phycore-rpmsg.dtbo
-   imx93-phycore-no-emmc.dtbo
-   imx93-phycore-no-eth.dtbo
+   imx91-imx93-phycore-no-emmc.dtbo
+   imx91-imx93-phycore-no-eth.dtbo
 
 Available overlays for phyboard-nash-imx93-1.conf are:
 
@@ -408,8 +408,8 @@ Available overlays for phyboard-nash-imx93-1.conf are:
    imx93-phyboard-nash-pwm-fan.dtbo
    imx93-phyboard-nash-vm016.dtbo
    imx93-phycore-rpmsg.dtbo
-   imx93-phycore-no-emmc.dtbo
-   imx93-phycore-no-eth.dtbo
+   imx91-imx93-phycore-no-emmc.dtbo
+   imx91-imx93-phycore-no-eth.dtbo
 
 .. _imx93-PD24.2.1-ubootexternalenv:
 .. include:: ../dt-overlays.rsti

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -1,13 +1,13 @@
 .. Download links
 .. |dlpage-bsp| replace:: our BSP
-.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.2.0
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.2.1
 .. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-91-93/#downloads
 .. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/
-.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/sdk/ampliphy-vendor-wayland/
-.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.wic.xz
-.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.partup
-.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
-.. _`static-pdf-dl`: ../../../_static/imx93-pd24.2.0.pdf
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.1/sdk/ampliphy-vendor/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.1/images/ampliphy-vendor/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.1/images/ampliphy-vendor/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.1/images/ampliphy-vendor/phyboard-segin-imx93-2/imx-boot-tools/
+.. _`static-pdf-dl`: ../../../_static/imx93-pd24.2.1.pdf
 
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
 
@@ -31,7 +31,7 @@
 .. |kernel-repo-name| replace:: linux-phytec-imx
 .. |kernel-repo-url| replace:: git://github.com/phytec/linux-phytec-imx.git
 .. |kernel-socname| replace:: imx93
-.. |kernel-tag| replace:: v6.6.23-2.0.0-phy8
+.. |kernel-tag| replace:: v6.6.52-2.2.0-phy9
 .. |emmcdev| replace:: mmcblk0
 
 .. Bootloader
@@ -42,7 +42,7 @@
 .. |u-boot-defconfig| replace:: imx93-phycore_defconfig
 .. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phycore_defconfig``
 .. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb``
-.. |u-boot-imx-mkimage-tag| replace:: lf-6.6.23-2.0.0
+.. |u-boot-imx-mkimage-tag| replace:: lf-6.6.52-2.2.0
 .. |u-boot-soc-name| replace:: iMX9
 .. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
 .. |u-boot-repo-name| replace:: u-boot-imx
@@ -50,7 +50,7 @@
 
 .. IMX93 specific
 .. |u-boot-socname-config| replace:: PHYCORE_IMX93
-.. |u-boot-tag| replace:: v2024.04-2.0.0-phy6
+.. |u-boot-tag| replace:: v2024.04-2.2.0-phy9
 
 
 .. Devicetree
@@ -59,48 +59,48 @@
 .. |dtbo-rpmsg| replace:: imx93-phycore-rpmsg.dtso
 
 .. IMX93 specific
-.. |dt-somnetwork| replace:: :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L61`
+.. |dt-somnetwork| replace:: :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L61`
 
 .. Yocto
 .. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
 .. |yocto-bsp-name| replace:: BSP-Yocto-i.MX93
 .. _yocto-bsp-name: `dl-server`_
 .. |yocto-codename| replace:: scarthgap
-.. |yocto-distro| replace:: ampliphy-vendor-wayland
+.. |yocto-distro| replace:: ampliphy-vendor
 .. |yocto-imagename| replace:: phytec-qt6demo-image
 .. |yocto-imageext| replace:: wic.xz
 .. |yocto-machinename| replace:: phyboard-segin-imx93-2
-.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.2.0
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.2.1
 .. |yocto-ref-manual| replace:: :ref:`Yocto Reference Manual (scarthgap) <yocto-man-scarthgap>`
-.. |yocto-sdk-rev| replace:: 5.0
+.. |yocto-sdk-rev| replace:: 5.0.8
 .. |yocto-sdk-a-core| replace:: cortexa55
 
 .. Ref Substitutions
-.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.2.0-bootswitch>`
-.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.2.0-images>`
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.2.1-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.2.1-images>`
 .. |ref-debugusbconnector| replace:: UART1 console on PEB-EVAL-01 for **phyBOARD-Segin** and X-37
    USB-C debug for **phyBOARD-Nash**
-.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.2.0-device-tree>`
-.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.2.0-getting-started>`
-.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.2.0-network>`
-.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.2.0-development>`
-.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.2.0-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.2.1-device-tree>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.2.1-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.2.1-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.2.1-development>`
+.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.2.1-components>`
 
 
 .. IMX93 specific
 .. |sbc-network| replace::
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
-   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L114` or here:
-   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L83`.
+   :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L118` or here:
+   :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L87`.
 
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
-   :ref:`device tree overlay section <imx93-PD24.2.0-ubootexternalenv>`
+   :ref:`device tree overlay section <imx93-PD24.2.1-ubootexternalenv>`
 
 
 .. M-Core specific
 .. |mcore| replace:: M33 Core
-.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.2.0-components>`
+.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.2.1-components>`
 .. |mcore-jtag-dev| replace:: MIMX8MM6_M4
 .. |mcore-sdk-version| replace:: 2.13.0
 
@@ -117,7 +117,7 @@
 +-----------------------+----------------------+
 | Yocto Manual          | Scarthgap            |
 +-----------------------+----------------------+
-| Release Date          | 2024/10/08           |
+| Release Date          | 2025/03/21           |
 +-----------------------+----------------------+
 | Is Branch of          | |soc| BSP Manual     |
 +-----------------------+----------------------+
@@ -128,7 +128,7 @@ The table below shows the Compatible BSPs for this manual:
 Compatible BSPs      BSP Release Type BSP Release Date BSP Status
 
 ==================== ================ ================ ==========
-|yocto-manifestname| Major            2024/10/08       Released
+|yocto-manifestname| Minor            2025/03/21       Released
 ==================== ================ ================ ==========
 
 
@@ -152,14 +152,14 @@ should show you the necessary **Machine Name** for your specific hardware.
    **Console examples in this BSP manual only focus on phyBOARD-Segin i.MX 93.
    Similar commands can also be executed for/on phyBOARD-Nash i.MX 93**
 
-.. _imx93-PD24.2.0-components:
+.. _imx93-PD24.2.1-components:
 .. include:: components.rsti
 
 .. +---------------------------------------------------------------------------+
 .. Getting Started
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.2.0-getting-started:
+.. _imx93-PD24.2.1-getting-started:
 .. include:: /bsp/getting-started.rsti
 
 First Start-up
@@ -182,7 +182,7 @@ First Start-up
 
 .. include:: /bsp/building-bsp.rsti
 
-.. _imx93-PD24.2.0-images:
+.. _imx93-PD24.2.1-images:
 
 *  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
    Bootloader image!
@@ -237,7 +237,7 @@ Bootmode Switch (S3)
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.
 
-.. _imx93-PD24.2.0-bootswitch:
+.. _imx93-PD24.2.1-bootswitch:
 .. include:: bootmode-switch.rsti
 
 .. include:: ../installing-os.rsti
@@ -246,7 +246,7 @@ select the phyCORE-|soc| default bootsource.
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.2.0-development:
+.. _imx93-PD24.2.1-development:
 
 Development
 ===========
@@ -387,7 +387,7 @@ Execute and power up the board:
 .. DEVICE TREE
 .. +---------------------------------------------------------------------------+
 
-.. _imx93-PD24.2.0-device-tree:
+.. _imx93-PD24.2.1-device-tree:
 .. include:: /bsp/device-tree.rsti
 
 ::
@@ -411,7 +411,7 @@ Available overlays for phyboard-nash-imx93-1.conf are:
    imx93-phycore-no-emmc.dtbo
    imx93-phycore-no-eth.dtbo
 
-.. _imx93-PD24.2.0-ubootexternalenv:
+.. _imx93-PD24.2.1-ubootexternalenv:
 .. include:: ../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
@@ -443,9 +443,9 @@ resistors are activated or not. In this case, the internal pull up is
 activated.
 
 The device tree representation for UART1 pinmuxing:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L259`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L263`
 
-.. _imx93-PD24.2.0-network:
+.. _imx93-PD24.2.1-network:
 
 Network
 -------
@@ -472,11 +472,11 @@ Network
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L213` or here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L202`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L217` or here:
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L206`
 
 DT configuration for the eMMC interface can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L194` or here:
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L194` or here:
 
 .. include:: /bsp/peripherals/emmc.rsti
 
@@ -498,17 +498,17 @@ ADC_IN2        49
 .. include:: ../peripherals/leds.rsti
 
 Device tree configuration for the User I/O configuration can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-eval-01.dtso#L33`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-eval-01.dtso#L33`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 
 General I²C3 bus configuration (e.g. |dt-som|.dtsi):
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L88`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L88`
 
 General I²C2 bus configuration for |dt-carrierboard|.dts:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L155` or for
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L159` or for
 imx93-phyboard-nash.dts:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L113`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L117`
 
 
 EEPROM
@@ -521,13 +521,13 @@ detection.
 .. include:: ../peripherals/eeprom.rsti
 
 DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
 
 .. include:: ../../peripherals/rtc.rsti
 
 DT representation for I²C RTCs:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L173` or
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L122`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L177` or
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L126`
 
 USB Host Controller
 -------------------
@@ -550,8 +550,8 @@ the Kernel documentation under
 Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
 
 DT representation for USB Host:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L193` or
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L181`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L196` or
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L185`
 
 RS232/RS485
 -----------
@@ -566,7 +566,7 @@ The |sbc-nash| i.MX 93 SoC provides one RS232/RS485 serial port.
 .. include:: /bsp/peripherals/rs485.rsti
 
 The device tree representation for RS232 and RS485:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L174`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L178`
 
 CAN FD
 ------
@@ -581,8 +581,8 @@ documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 .. include:: ../peripherals/canfd.rsti
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L147` or
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L105`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L151` or
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L109`
 
 Audio on |sbc-segin|
 --------------------
@@ -630,7 +630,7 @@ as the default input source.
    capture operations.
 
 Device Tree Audio configuration:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L62`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L62`
 
 Audio on |sbc-nash|
 -------------------
@@ -651,7 +651,7 @@ headphones, and line-in signals.
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso#L56`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso#L56`
 
 .. include:: /bsp/peripherals/video.rsti
 
@@ -662,10 +662,10 @@ Device Tree Audio configuration:
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 The device tree of PEB-AV-02 can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-av-02.dtso`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-av-02.dtso`
 
 The device tree of PEB-AV-10 can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso`
 
 .. include:: peripherals/pm.rsti
 
@@ -682,7 +682,7 @@ The device tree of PEB-AV-10 can be found here:
 .. include:: /bsp/imx9/imx93/peripherals/tpm.rsti
 
 Device tree TPM configuration can be found here:
-:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L151`
+:linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L161`
 
 .. +---------------------------------------------------------------------------+
 .. i.MX 8M Plus M7 Core

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -1,0 +1,691 @@
+.. Download links
+.. |dlpage-bsp| replace:: our BSP
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX93-PD24.2.0
+.. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-91-93/#downloads
+.. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/sdk/ampliphy-vendor-wayland/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/phytec-qt6demo-image-phyboard-segin-imx93-2.rootfs.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX93/BSP-Yocto-NXP-i.MX93-PD24.2.0/images/ampliphy-vendor-wayland/phyboard-segin-imx93-2/imx-boot-tools/
+.. _`static-pdf-dl`: ../../../_static/imx93-pd24.2.0.pdf
+
+.. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx93
+
+.. General Substitutions
+.. |kit| replace:: **phyBOARD-Segin i.MX 93 and phyBOARD-Nash i.MX 93 Kit**
+.. |kit-ram-size| replace:: 1GiB
+.. |sbc| replace:: phyBOARD-Segin/Nash i.MX 93
+.. |sbc-segin| replace:: phyBOARD-Segin i.MX 93
+.. |sbc-nash| replace:: phyBOARD-Nash i.MX 93
+.. |soc| replace:: i.MX 93
+.. |socfamily| replace:: i.MX 9
+.. |som| replace:: phyCORE-i.MX93
+.. |debug-uart| replace:: ttyLP0
+.. |serial-uart| replace:: ttyLP6
+.. |expansion-connector| replace:: X16
+
+
+.. Linux Kernel
+.. |kernel-defconfig| replace:: imx9_phytec_defconfig
+.. |kernel-recipe-path| replace:: meta-phytec/recipes-kernel/linux/linux-phytec-imx_*.bb
+.. |kernel-repo-name| replace:: linux-phytec-imx
+.. |kernel-repo-url| replace:: git://github.com/phytec/linux-phytec-imx.git
+.. |kernel-socname| replace:: imx93
+.. |kernel-tag| replace:: v6.6.23-2.0.0-phy8
+.. |emmcdev| replace:: mmcblk0
+
+.. Bootloader
+.. |u-boot-offset| replace:: 32
+.. |u-boot-offset-boot-part| replace:: 0
+.. |u-boot-mmc-flash-offset| replace:: 0x40
+.. |u-boot-emmc-devno| replace:: 0
+.. |u-boot-defconfig| replace:: imx93-phycore_defconfig
+.. |u-boot-multiple-defconfig-note| replace:: In command above replace ``<defconfig>`` with ``imx93-phycore_defconfig``
+.. |u-boot-multiple-dtb-note| replace:: In command above replace ``<dtb>`` with ``imx93-phyboard-segin.dtb``
+.. |u-boot-imx-mkimage-tag| replace:: lf-6.6.23-2.0.0
+.. |u-boot-soc-name| replace:: iMX9
+.. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
+.. |u-boot-repo-name| replace:: u-boot-imx
+.. |u-boot-repo-url| replace:: git://git.phytec.de/u-boot-imx
+
+.. IMX93 specific
+.. |u-boot-socname-config| replace:: PHYCORE_IMX93
+.. |u-boot-tag| replace:: v2024.04-2.0.0-phy6
+
+
+.. Devicetree
+.. |dt-carrierboard| replace:: imx93-phyboard-segin
+.. |dt-som| replace:: imx93-phycore-som
+.. |dtbo-rpmsg| replace:: imx93-phycore-rpmsg.dtso
+
+.. IMX93 specific
+.. |dt-somnetwork| replace:: :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L61`
+
+.. Yocto
+.. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
+.. |yocto-bsp-name| replace:: BSP-Yocto-i.MX93
+.. _yocto-bsp-name: `dl-server`_
+.. |yocto-codename| replace:: scarthgap
+.. |yocto-distro| replace:: ampliphy-vendor-wayland
+.. |yocto-imagename| replace:: phytec-qt6demo-image
+.. |yocto-imageext| replace:: wic.xz
+.. |yocto-machinename| replace:: phyboard-segin-imx93-2
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX93-PD24.2.0
+.. |yocto-ref-manual| replace:: :ref:`Yocto Reference Manual (scarthgap) <yocto-man-scarthgap>`
+.. |yocto-sdk-rev| replace:: 5.0
+.. |yocto-sdk-a-core| replace:: cortexa55
+
+.. Ref Substitutions
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx93-PD24.2.0-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx93-PD24.2.0-images>`
+.. |ref-debugusbconnector| replace:: UART1 console on PEB-EVAL-01 for **phyBOARD-Segin** and X-37
+   USB-C debug for **phyBOARD-Nash**
+.. |ref-dt| replace:: :ref:`device tree <imx93-PD24.2.0-device-tree>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx93-PD24.2.0-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx93-PD24.2.0-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx93-PD24.2.0-development>`
+.. |ref-usb-otg| replace:: :ref:`X8 (USB micro/OTG connector) <imx93-PD24.2.0-components>`
+
+
+.. IMX93 specific
+.. |sbc-network| replace::
+   The device tree set up for EQOS Ethernet IP core where the PHY is populated
+   on the |sbc| can be found here:
+   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L114` or here:
+   :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L83`.
+
+.. |ubootexternalenv| replace:: U-boot External Environment subsection of the
+   :ref:`device tree overlay section <imx93-PD24.2.0-ubootexternalenv>`
+
+
+.. M-Core specific
+.. |mcore| replace:: M33 Core
+.. |ref-m-core-connections| replace:: :ref:`X16 <imx93-PD24.2.0-components>`
+.. |mcore-jtag-dev| replace:: MIMX8MM6_M4
+.. |mcore-sdk-version| replace:: 2.13.0
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
+
++-----------------------+----------------------+
+| |soc| BSP Manual                             |
++-----------------------+----------------------+
+| Document Title        | |soc| BSP Manual     |
++-----------------------+----------------------+
+| Document Type         | BSP Manual           |
++-----------------------+----------------------+
+| Yocto Manual          | Scarthgap            |
++-----------------------+----------------------+
+| Release Date          | 2024/10/08           |
++-----------------------+----------------------+
+| Is Branch of          | |soc| BSP Manual     |
++-----------------------+----------------------+
+
+The table below shows the Compatible BSPs for this manual:
+
+==================== ================ ================ ==========
+Compatible BSPs      BSP Release Type BSP Release Date BSP Status
+
+==================== ================ ================ ==========
+|yocto-manifestname| Major            2024/10/08       Released
+==================== ================ ================ ==========
+
+
+.. include:: ../../intro.rsti
+
+Supported Hardware
+------------------
+
+On our web page, you can see all supported Machines with the available Article
+Numbers for this release: |yocto-manifestname|, see `download <dlpage-bsp_>`_.
+
+If you choose a specific **Machine Name** in the section **Supported Machines**,
+you can see which **Article Numbers** are available under this machine and also
+a short description of the hardware information. In case you only have
+the **Article Number** of your hardware, you can leave the **Machine
+Name** drop-down menu empty and only choose your **Article Number**. Now it
+should show you the necessary **Machine Name** for your specific hardware.
+
+.. tip::
+
+   **Console examples in this BSP manual only focus on phyBOARD-Segin i.MX 93.
+   Similar commands can also be executed for/on phyBOARD-Nash i.MX 93**
+
+.. _imx93-PD24.2.0-components:
+.. include:: components.rsti
+
+.. +---------------------------------------------------------------------------+
+.. Getting Started
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.2.0-getting-started:
+.. include:: /bsp/getting-started.rsti
+
+First Start-up
+--------------
+
+*  To boot from an SD card, the |ref-bootswitch| needs to be set to the
+   following position:
+
+.. image:: images/SD_Card_Boot.png
+
+*  Insert the SD card
+*  Connect the targets debug console with your host. Use |ref-debugusbconnector|.
+*  Power up the board
+*  Open serial/usb port with 115200 baud and 8N1 (you should see u-boot/linux
+   start on the console
+
+.. +---------------------------------------------------------------------------+
+.. Building the BSP
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/building-bsp.rsti
+
+.. _imx93-PD24.2.0-images:
+
+*  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
+   Bootloader image!
+*  **oftree**: Default kernel device tree
+*  **u-boot-spl.bin**: Secondary program loader (SPL)
+*  **bl31-imx93.bin**: ARM Trusted Firmware binary
+*  **lpddr4_dmem_1d_v202201.bin, lpddr4_dmem_2d_v202201.bin,
+   lpddr4_imem_1d_v202201.bin,
+   lpddr4_imem_2d_v202201.bin**: DDR PHY firmware images
+*  **imx-boot**: Bootloader build by imx-mkimage which includes SPL, U-Boot, ARM
+   Trusted Firmware and DDR firmware. This is the final bootloader image which
+   is bootable.
+*  **Image**: Linux kernel image
+*  **Image.config**: Kernel configuration
+*  **imx93-phyboard-*.dtb**: Kernel device tree file
+*  **imx93-phy\*.dtbo**: Kernel device tree overlay files
+*  **phytec-\*.tar.gz**: Root file system,
+   of bitbake-image that was built.
+
+   * **phytec-qt6demo-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build
+     was processed for ``phytec-qt6demo-image``
+   * **phytec-headless-image-phyboard-*-imx93-*.tar.gz**: when bitbake-build
+     was processed for ``phytec-headless-image``
+*  **phytec-\*.rootfs.wic.xz**: Compressed bootable SD
+   card image of bitbake-image that was built. Includes bootloader, DTBs, Kernel
+   and Root file system.
+
+   * **phytec-qt6demo-image-phyboard-*-imx93-*.rootfs.wic.xz**: when bitbake-build
+     was processed for ``phytec-qt6demo-image``
+   * **phytec-headless-image-phyboard-*-imx93-*.rootfs.wic.xz**: when bitbake-build
+     was processed for ``phytec-headless-image``
+*  **imx93-11x11-evk_m33_\*.bin**, binaries of demo applications for the
+   Cortex-M33 MCU; can be manually loaded and started with U-Boot or Linux
+
+.. +---------------------------------------------------------------------------+
+.. INSTALLING THE OS
+.. +---------------------------------------------------------------------------+
+
+Installing the OS
+=================
+
+Bootmode Switch (S3)
+--------------------
+
+.. tip::
+
+   Hardware revision baseboard:
+
+   *  |sbc-segin|: 1472.5
+   *  |sbc-nash|: 1616.0, 1616.1
+
+The |sbc| features a boot switch with four individually switchable ports to
+select the phyCORE-|soc| default bootsource.
+
+.. _imx93-PD24.2.0-bootswitch:
+.. include:: bootmode-switch.rsti
+
+.. include:: ../installing-os.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVELOPMENT
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.2.0-development:
+
+Development
+===========
+
+.. include:: ../../imx-common/development/host_network_setup.rsti
+.. include:: ../../imx-common/development/netboot.rsti
+
+Working with UUU-Tool
+---------------------
+
+The Universal Update Utility Tool (UUU-Tool) from NXP is a software to execute
+on the host to load and run the bootloader on the board through SDP (Serial
+Download Protocol). For detailed information visit
+https://github.com/nxp-imx/mfgtools or download the `Official UUU-tool
+documentation <https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-processors/140261/1/UUU.pdf>`_.
+
+Host preparations for UUU-Tool Usage
+....................................
+
+*  Follow the instructions from https://github.com/nxp-imx/mfgtools#linux.
+
+*  If you built UUU from source, add it to ``PATH``:
+
+   This BASH command adds UUU only temporarily to ``PATH``. To add it permanently, add this line to
+   ``~/.bashrc``.
+
+   .. code-block:: console
+
+      export PATH=~/mfgtools/uuu/:"$PATH"
+
+*  Set udev rules (documented in ``uuu -udev``):
+
+   .. code-block:: console
+
+      host:~$ sudo sh -c "uuu -udev >> /etc/udev/rules.d/70-uuu.rules"
+      host:~$ sudo udevadm control --reload
+
+Get Images
+..........
+
+Download imx-boot from our server or get it from your Yocto build directory at
+build/deploy/images/|yocto-machinename|/. For flashing a wic image to eMMC,
+you will also need |yocto-imagename|-|yocto-machinename|.wic.
+
+Prepare Target
+..............
+
+Set the |ref-bootswitch| to **USB Serial Download**. Also, connect USB port
+|ref-usb-otg| to your host.
+
+Starting bootloader via UUU-Tool
+................................
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b spl imx-boot
+
+You can see the bootlog on the console via |ref-debugusbconnector|, as usual.
+
+.. note::
+   The default boot command when booting with UUU-Tool is set to fastboot. If
+   you want to change this, please adjust the environment variable bootcmd_mfg
+   in U-boot prompt with setenv bootcmd_mfg. Please note, when booting with
+   UUU-tool the default environment is loaded. Saveenv has no effect. If you
+   want to change the boot command permanently for UUU-boot, you need to change
+   this in U-Boot code.
+
+Flashing U-boot Image to eMMC via UUU-Tool
+...........................................
+
+.. warning::
+
+   UUU flashes U-boot into eMMC BOOT (hardware) boot partitions, and it sets
+   the BOOT_PARTITION_ENABLE in the eMMC! This is a problem since we want the
+   bootloader to reside in the eMMC USER partition. Flashing next U-Boot version
+   .wic image and not disabling BOOT_PARTITION_ENABLE bit will result in device
+   always using U-boot saved in BOOT partitions. To fix this in U-Boot:
+
+   .. code-block:: console
+      :substitutions:
+
+      u-boot=> mmc partconf |u-boot-emmc-devno| 0 0 0
+      u-boot=> mmc partconf |u-boot-emmc-devno|
+      EXT_CSD[179], PARTITION_CONFIG:
+      BOOT_ACK: 0x0
+      BOOT_PARTITION_ENABLE: 0x0
+      PARTITION_ACCESS: 0x0
+
+   or check :ref:`Disable booting from eMMC boot partitions <emmc-disable-boot-part>`
+   from Linux.
+
+   This way the bootloader is still flashed to eMMC BOOT partitions but it is
+   not used!
+
+   When using **partup** tool and ``.partup`` package for eMMC flashing this is
+   done by default, which makes partup again superior flash option.
+
+Execute and power up the board:
+
+.. code-block:: console
+
+   host:~$ sudo uuu -b emmc imx-boot
+
+Flashing wic Image to eMMC via UUU-Tool
+...........................................
+
+Execute and power up the board:
+
+.. code-block:: console
+   :substitutions:
+
+   host:~$ sudo uuu -b emmc_all imx-boot |yocto-imagename|-|yocto-machinename|.wic
+
+.. include:: ../../imx-common/development/standalone_build_preface.rsti
+
+.. warning::
+   Using the SDK on older host distributions (e.g., Ubuntu 20.04 LTS) with Scarthgap NXP-based BSPs
+   can cause issues when building U-Boot or Linux kernel tools for host use. If you encounter an
+   "undefined reference" error, a workaround is to prepend the host's binutils to the PATH.
+
+   .. code-block:: console
+
+      host$ export PATH=/usr/bin:$PATH
+
+   Run this after sourcing the SDK *environment-setup* file.
+
+   Note, SDK issue has not been observed on newer distributions, such as Ubuntu 22.04, which appear to work
+   without requiring any modifications.
+
+.. include:: ../../imx-common/development/standalone_build_u-boot_imxmkimage.rsti
+.. include:: ../../imx-common/development/standalone_build_kernel.rsti
+
+.. include:: ../../imx-common/development/format_sd-card.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVICE TREE
+.. +---------------------------------------------------------------------------+
+
+.. _imx93-PD24.2.0-device-tree:
+.. include:: /bsp/device-tree.rsti
+
+::
+
+   imx93-phyboard-segin-peb-av-02.dtbo
+   imx93-phyboard-segin-peb-eval-01.dtbo
+   imx93-phyboard-segin-peb-wlbt-05.dtbo
+   imx93-phycore-rpmsg.dtbo
+   imx93-phycore-no-emmc.dtbo
+   imx93-phycore-no-eth.dtbo
+
+Available overlays for phyboard-nash-imx93-1.conf are:
+
+::
+
+   imx93-phyboard-nash-jtag.dtbo
+   imx93-phyboard-nash-peb-av-10.dtbo
+   imx93-phyboard-nash-pwm-fan.dtbo
+   imx93-phyboard-nash-vm016.dtbo
+   imx93-phycore-rpmsg.dtbo
+   imx93-phycore-no-emmc.dtbo
+   imx93-phycore-no-eth.dtbo
+
+.. _imx93-PD24.2.0-ubootexternalenv:
+.. include:: ../dt-overlays.rsti
+
+.. +---------------------------------------------------------------------------+
+.. ACCESSING PERIPHERALS
+.. +---------------------------------------------------------------------------+
+
+
+.. include:: /bsp/peripherals/introduction.rsti
+
+.. include:: /bsp/imx-common/peripherals/pin-muxing.rsti
+
+The following is an example of the pin muxing of the UART1 device in
+|dt-carrierboard|.dts:
+
+.. code-block::
+
+   pinctrl_uart1: uart1grp {
+           fsl,pins = <
+                   MX93_PAD_UART1_RXD__LPUART1_RX     0x31e
+                   MX93_PAD_UART1_TXD__LPUART1_TX     0x30e
+           >;
+   };
+
+The first part of the string MX93_PAD_UART1_RXD__LPUART1_RX names the pad
+(in this example UART1_RXD). The second part of the string (LPUART1_RX) is the
+desired muxing option for this pad. The pad setting value (hex value on the
+right) defines different modes of the pad, for example, if internal pull
+resistors are activated or not. In this case, the internal pull up is
+activated.
+
+The device tree representation for UART1 pinmuxing:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L259`
+
+.. _imx93-PD24.2.0-network:
+
+Network
+-------
+
+|sbc| provides two ethernet interfaces.
+
+*  On |sbc-segin| we have:
+
+   *  a 100 megabit Ethernet provided by |som|
+   *  and 100 megabit Ethernet provided by phyBOARD.
+
+*  On |sbc-nash| we have:
+
+   *  a 100 megabit Ethernet provided by |som|
+   *  and 1 gigabit Ethernet provided by phyBOARD.
+
+.. include:: /bsp/imx-common/peripherals/network.rsti
+
+.. include:: wireless-network.rsti
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. no-bluetooth-marker
+
+.. include:: /bsp/imx-common/peripherals/sd-card.rsti
+
+DT configuration for the MMC (SD card slot) interface can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L213` or here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L202`
+
+DT configuration for the eMMC interface can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L194` or here:
+
+.. include:: /bsp/peripherals/emmc.rsti
+
+.. include:: /bsp/imx-common/emmc.rsti
+
+.. include:: ../peripherals/gpios.rsti
+
+.. include:: /bsp/peripherals/adc.rsti
+
+On |sbc-nash| the ADC lines are accessible on X16 expansion connector:
+
+========= ========
+ADC input X16 pin
+========= ========
+ADC_IN0        47
+ADC_IN2        49
+========= ========
+
+.. include:: ../peripherals/leds.rsti
+
+Device tree configuration for the User I/O configuration can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-eval-01.dtso#L33`
+
+.. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
+
+General I²C3 bus configuration (e.g. |dt-som|.dtsi):
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L88`
+
+General I²C2 bus configuration for |dt-carrierboard|.dts:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L155` or for
+imx93-phyboard-nash.dts:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L113`
+
+
+EEPROM
+------
+
+There are two different I2C EEPROM flashes populated on |som| SoM and on the
+|sbc|. For now only the one on the |som| is enabled, and it is used for board
+detection.
+
+.. include:: ../peripherals/eeprom.rsti
+
+DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
+
+.. include:: ../../peripherals/rtc.rsti
+
+DT representation for I²C RTCs:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L173` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L122`
+
+USB Host Controller
+-------------------
+
+The USB controller of the |soc| SoC provides a low-cost connectivity solution
+for numerous consumer portable devices by providing a mechanism for data
+transfer between USB devices with a line/bus speed of up to 480 Mbps (HighSpeed
+'HS'). The USB subsystem has two independent USB controller cores. Both cores
+are capable of acting as a USB peripheral device or a USB host, but on the |sbc|
+one of them is used as a host-only port (USB-A connector).
+
+.. include:: /bsp/peripherals/usb-host.rsti
+
+The OTG port provides an additional pin for over-current protection, which is
+not used on the |sbc|. Since it's not used, the driver part is also disabled
+from within the device tree. In case this pin is used, activate this
+over-current in the device tree and set the correct polarity (active high/low)
+according to the device specification. For the correct setup, please refer to
+the Kernel documentation under
+Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
+
+DT representation for USB Host:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L193` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L181`
+
+RS232/RS485
+-----------
+
+The |sbc-nash| i.MX 93 SoC provides one RS232/RS485 serial port.
+
+.. warning::
+   RS232 with HW flow control and RS485 are not working due to HW bug on the
+   |sbc-nash| PCB revision 1616.0
+
+.. include:: /bsp/peripherals/rs232.rsti
+.. include:: /bsp/peripherals/rs485.rsti
+
+The device tree representation for RS232 and RS485:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L174`
+
+CAN FD
+------
+
+The |sbc| has one flexCAN interface supporting CAN FD. They are supported by the
+Linux standard CAN framework which builds upon the Linux network layer. Using
+this framework, the CAN interfaces behave like an ordinary Linux network device,
+with some additional features special to CAN. More information can be found in
+the Linux Kernel
+documentation: https://www.kernel.org/doc/html/latest/networking/can.html
+
+.. include:: ../peripherals/canfd.rsti
+
+Device Tree CAN configuration of |dt-carrierboard|.dts:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L147` or
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L105`
+
+Audio on |sbc-segin|
+--------------------
+
+On |sbc-segin| the TI TLV320AIC3007 audio codec is used. It uses I2S
+for data transmission and I2C for codec control. The audio signals available
+are:
+
+* Stereo LINE IN,
+* Stereo LINE OUT,
+* Output where D-Class 1W speaker can be connected
+
+.. include:: /bsp/peripherals/audio.rsti
+   :end-before: .. audio_alsa_configuration_start_label
+
+.. include:: /bsp/peripherals/audio.rsti
+   :start-after: .. audio_playback_start_label
+   :end-before: .. audio_capture_start_label
+
+If Speaker volume it too low you can increase its volume with (values 0-3):
+
+.. code-block:: console
+
+   target:~$ amixer -c 0 sset Class-D 3
+
+.. hint::
+
+   Speaker output is only mono so when stereo track is played only left channel
+   will be played by speaker.
+
+Capture
+.......
+
+``arecord`` is a command-line tool for capturing audio streams which use Line In
+as the default input source.
+
+.. code-block:: console
+
+   target:~$ arecord -t wav -c 2 -r 44100 -f S16_LE test.wav
+
+.. hint::
+
+   Since playback and capture share hardware interfaces, it is not possible to
+   use different sampling rates and formats for simultaneous playback and
+   capture operations.
+
+Device Tree Audio configuration:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin.dts#L62`
+
+Audio on |sbc-nash|
+-------------------
+
+.. warning::
+
+   Due to HW bug Audio is broken on |sbc-nash| PCB revision: 1616.0
+
+To use audio with |sbc-nash| an additional adapter for the Audio/Video
+connector is needed. The PEB-AV-10 (1531.1 revision) can be bought separately to
+the Kit. PEB-AV-10 is populated with a TI TLV320AIC3007 audio codec. Audio
+support is done via the I2S interface and controlled via I2C.
+
+There is a 3.5mm headset jack with OMTP standard and an 8-pin header to connect
+audio devices with the AV-Connector.  The 8-pin header contains a mono speaker,
+headphones, and line-in signals.
+
+.. include:: /bsp/peripherals/audio.rsti
+
+Device Tree Audio configuration:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso#L56`
+
+.. include:: /bsp/peripherals/video.rsti
+
+.. include:: display.rsti
+
+.. include:: /bsp/qt6.rsti
+
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+The device tree of PEB-AV-02 can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-segin-peb-av-02.dtso`
+
+The device tree of PEB-AV-10 can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash-peb-av-10.dtso`
+
+.. include:: peripherals/pm.rsti
+
+.. include:: ../peripherals/tm.rsti
+
+.. include:: /bsp/peripherals/watchdog.rsti
+
+.. include:: ../peripherals/bbnsm-power-key.rsti
+
+.. include:: ../peripherals/pxp.rsti
+
+.. include:: ../peripherals/ocotp-ctrl.rsti
+
+.. include:: /bsp/imx9/imx93/peripherals/tpm.rsti
+
+Device tree TPM configuration can be found here:
+:linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L151`
+
+.. +---------------------------------------------------------------------------+
+.. i.MX 8M Plus M7 Core
+.. +---------------------------------------------------------------------------+
+
+.. include:: ../mcu.rsti

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -232,7 +232,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard:
 
    *  |sbc-segin|: 1472.5
-   *  |sbc-nash|: 1616.0, 1616.1
+   *  |sbc-nash|: 1616.0, 1616.1, 1616.2
 
 The |sbc| features a boot switch with four individually switchable ports to
 select the phyCORE-|soc| default bootsource.

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -405,6 +405,7 @@ Available overlays for phyboard-nash-imx93-1.conf are:
 
    imx93-phyboard-nash-jtag.dtbo
    imx93-phyboard-nash-peb-av-10.dtbo
+   imx93-phyboard-nash-peb-wlbt-07.dtbo
    imx93-phyboard-nash-pwm-fan.dtbo
    imx93-phyboard-nash-vm016.dtbo
    imx93-phycore-rpmsg.dtbo

--- a/source/bsp/imx9/imx93/wireless-network.rsti
+++ b/source/bsp/imx9/imx93/wireless-network.rsti
@@ -12,7 +12,7 @@ PEB-WLBT-05 on |sbc-segin|
 
 .. tip::
 
-   With the BSP Version PD24.2 and newer, the PEB-WLBT-05 overlay needs to be activated first,
+   With the BSP Version PD24.2.0 and newer, the PEB-WLBT-05 overlay needs to be activated first,
    otherwise the PEB-WLBT-05 won't be recognized.
 
    .. code-block:: console

--- a/source/bsp/imx9/imx93/wireless-network.rsti
+++ b/source/bsp/imx9/imx93/wireless-network.rsti
@@ -1,13 +1,14 @@
-WLAN
-....
+WLAN/Bluetooth
+..............
 
-.. note::
-   For now, only |sbc-segin| supports WLAN/Bluetooth features. WLAN/Bluetooth is
-   thus not supported on |sbc-nash| yet.
+WLAN and Bluetooth connectivity are enabled on the |sbc-segin| using the PEB-WLBT-05
+expansion card, and on the |sbc-nash| with the PEB-WLBT-07 expansion card.
+Installation instructions for these WLAN and Bluetooth expansion cards can be found in
+the "The PEB-WLBT-05 for |sbc-segin| Quickstart Guide" and the "The PEB-WLBT-07 for
+|sbc-nash| Quickstart Guide", respectively."
 
-WLAN and Bluetooth on the |sbc-segin| are provided by the PEB-WLBT-05 expansion card.
-The PEB-WLBT-05 for |sbc-segin| Quickstart Guide shows you how to install the
-PEB-WLBT-05.
+PEB-WLBT-05 on |sbc-segin|
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. tip::
 
@@ -33,14 +34,43 @@ PEB-WLBT-05.
 
    For further information about devicetree overlays, read the |ref-dt| chapter.
 
-For WLAN and Bluetooth support, we use the Sterling-LWB module from LSR. This
-module supports 2,4 GHz bandwidth and can be run in several modes, like client
-mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More
-information about the module can be found at
-https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
+With PEB-WLBT-05 adapter, we use Sterling-LWB module from LSR for WLAN and Bluetooth support.
+This module supports 2,4 GHz bandwidth and can be run in several modes, like client
+mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more. More information about
+the module can be found at https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf
 
 .. note::
-   By default, bluetooth is not supported on |sbc-segin| with PEB-WLBT-05
-   expansion card due to hard-wired connections. However, it is possible to
-   re-work PEB-WLBT-05 card by adjusting solder pads and enabling bluetooth in
-   the software. Please contact your PHYTEC representative for more information.
+   For proper Bluetooth operation please make sure to follow the "The PEB-WLBT-05 for |sbc-segin|
+   Quickstart Guide" to correctly set jumper J9 & J10 configurations.
+
+PEB-WLBT-07 on |sbc-nash|
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tip::
+
+   With the BSP Version PD24.2.1 and newer, the PEB-WLBT-07 overlay needs to be activated first,
+   otherwise the PEB-WLBT-07 won't be recognized.
+
+   .. code-block:: console
+
+      target:~$ vi /boot/bootenv.txt
+
+   Afterwards the bootenv.txt file should look like this (it can also contain other devicetree
+   overlays!):
+
+   .. code-block::
+
+      overlays=imx93-phyboard-nash-peb-wlbt-07.dtbo
+
+   The changes will be applied after a reboot:
+
+   .. code-block:: console
+
+      target:~$ reboot
+
+   For further information about devicetree overlays, read the |ref-dt| chapter.
+
+With PEB-WLBT-07 adapter, we use MAYA-W2 from u-blox for WLAN and Bluetooth support.
+This module supports dual-band 2,4 GHz and 5 GHz bandwidth and can be run in several modes,
+like client mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more.
+More information about the module can be found at https://content.u-blox.com/sites/default/files/documents/MAYA-W2_DataSheet_UBX-22009721.pdf

--- a/source/bsp/imx9/imx93/wireless-network.rsti
+++ b/source/bsp/imx9/imx93/wireless-network.rsti
@@ -74,3 +74,9 @@ With PEB-WLBT-07 adapter, we use MAYA-W2 from u-blox for WLAN and Bluetooth supp
 This module supports dual-band 2,4 GHz and 5 GHz bandwidth and can be run in several modes,
 like client mode, Access Point (AP) mode using WEP, WPA, WPA2 encryption, and more.
 More information about the module can be found at https://content.u-blox.com/sites/default/files/documents/MAYA-W2_DataSheet_UBX-22009721.pdf
+
+.. note::
+   The following WLAN chapter assumes wireless network interface name is ``wlan0``.
+   However with PEB-WLBT-07 adapter the name of the WLAN interface is actually ``mlan0``.
+   Thus when using commands to configure wireless network, substitute ``wlan0`` with
+   ``mlan0`` when using PEB-WLBT-07 on |sbc-nash|.

--- a/source/bsp/imx9/peripherals/canfd.rsti
+++ b/source/bsp/imx9/peripherals/canfd.rsti
@@ -12,16 +12,19 @@
    .. code-block:: console
 
       target:~$ ip -d -s link show can0
-      4: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
-         link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0
-         can state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 0
+      4: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 72 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
+         link/can  promiscuity 0 allmulti 0 minmtu 0 maxmtu 0
+         can <FD> state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 0
                bitrate 500000 sample-point 0.875
-               tq 25 prop-seg 37 phase-seg1 32 phase-seg2 10 sjw 1 brp 1
+               tq 25 prop-seg 37 phase-seg1 32 phase-seg2 10 sjw 5 brp 1
                flexcan: tseg1 2..96 tseg2 2..32 sjw 1..16 brp 1..1024 brp_inc 1
+               dbitrate 2000000 dsample-point 0.750
+               dtq 25 dprop-seg 7 dphase-seg1 7 dphase-seg2 5 dsjw 2 dbrp 1
                flexcan: dtseg1 2..39 dtseg2 2..8 dsjw 1..4 dbrp 1..1024 dbrp_inc 1
                clock 40000000
                re-started bus-errors arbit-lost error-warn error-pass bus-off
-               0          0          0          0          0          0         numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus platform parentdev 443a0000.can
+               0          0          0          0          0          0         numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+      gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 parentbus platform parentdev 443a0000.can
          RX:  bytes packets errors dropped  missed   mcast
                   0       0      0       0       0       0
          TX:  bytes packets errors dropped carrier collsns
@@ -45,26 +48,41 @@ errors...  Bus Error Statistics
 
 
 The CAN configuration is done in the systemd configuration
-file ``/lib/systemd/network/can0.network``. For a persistent change of (as an
+file ``/lib/systemd/network/11-can.network``. For a persistent change of (as an
 example, the default bitrates), change the configuration in the BSP
-under ``./meta-ampliphy/recipes-core/systemd/systemd-conf/can0.network`` in
+under ``./meta-ampliphy/recipes-core/systemd/systemd-conf/11-can.network`` in
 the root filesystem and rebuild the root filesystem.
 
 .. code-block::
 
    [Match]
-   Name=can0
+   Name=can*
 
-   [Can]
+   [CAN]
    BitRate=500000
+   DataBitRate=2000000
+   FDMode=yes
 
-The bitrate can also be changed manually, for example, to make use of the
-flexible bitrate:
+.. note::
+   By default, we enable CAN-FD (flexible datarate) in our BSP. In case CAN Classic
+   is required one needs to remove options ``FDMode`` and ``DataBitRate`` from the
+   ``/lib/systemd/network/11-can.network`` file.
+
+To disable flexible datarate manually, one can use:
+
+.. code-block:: console
+
+   target:~$ ip link set can0 down
+   target:~$ ip link set can0 type can bitrate 500000 dbitrate 0 fd off
+   target:~$ ip link set can0 up
+
+The bitrate can also be changed manually, for example:
 
 .. code-block:: console
 
    target:~$ ip link set can0 down
    target:~$ ip link set can0 txqueuelen 10 up type can bitrate 500000 sample-point 0.75 dbitrate 4000000 dsample-point 0.8 fd on
+   target:~$ ip link set can0 up
 
 You can send messages with cansend or receive messages with candump:
 

--- a/source/bsp/imx9/peripherals/eeprom.rsti
+++ b/source/bsp/imx9/peripherals/eeprom.rsti
@@ -24,13 +24,19 @@ EEPROM write protection, use:
 
 .. code-block:: console
 
-	target:~$ gpioset 2 21=0
+   target:~$ gpioset -t0 -c 2 21=0
 
 Then the EEPROM can be written to:
 
 .. code-block:: console
 
    target:~$ dd if=/dev/zero of=/sys/class/i2c-dev/i2c-2/device/2-0058/eeprom bs=32 count=1
+
+To re-enable EEPROM wire protection, use:
+
+.. code-block:: console
+
+   target:~$ gpioset -t0 -c 2 21=1
 
 .. warning::
 

--- a/source/bsp/imx9/peripherals/gpios.rsti
+++ b/source/bsp/imx9/peripherals/gpios.rsti
@@ -27,10 +27,10 @@ of some usages of various tools:
    .. code-block:: console
 
       target:~$ gpiodetect
-      gpiochip0 [43810080.gpio] (32 lines)
-      gpiochip1 [43820080.gpio] (32 lines)
-      gpiochip2 [43830080.gpio] (32 lines)
-      gpiochip3 [47400080.gpio] (32 lines)
+      gpiochip0 [43810000.gpio] (32 lines)
+      gpiochip1 [43820000.gpio] (32 lines)
+      gpiochip2 [43830000.gpio] (32 lines)
+      gpiochip3 [47400000.gpio] (32 lines)
 
 .. note::
 
@@ -40,13 +40,13 @@ of some usages of various tools:
    +------------------+-----------+------------------+
    | GPIOchip address | Linux     | Reference Manual |
    +------------------+-----------+------------------+
-   | 0x43810080       | gpiochip0 | gpiochip2        |
+   | 0x43810000       | gpiochip0 | gpiochip2        |
    +------------------+-----------+------------------+
-   | 0x43820080       | gpiochip1 | gpiochip3        |
+   | 0x43820000       | gpiochip1 | gpiochip3        |
    +------------------+-----------+------------------+
-   | 0x43830080       | gpiochip2 | gpiochip4        |
+   | 0x43830000       | gpiochip2 | gpiochip4        |
    +------------------+-----------+------------------+
-   | 0x47400080       | gpiochip3 | gpiochip1        |
+   | 0x47400000       | gpiochip3 | gpiochip1        |
    +------------------+-----------+------------------+
 
 *  Show detailed information about the gpiochips. Like their names, consumers,
@@ -54,50 +54,92 @@ of some usages of various tools:
 
    .. code-block:: console
 
-      target:~$ gpioinfo gpiochip0
+      target:~$ gpioinfo -c gpiochip0
 
 *  Read the value of a GPIO (e.g GPIO 3 from chip0):
 
    .. code-block:: console
 
-      target:~$ gpioget gpiochip0 3
+      target:~$ gpioget -c gpiochip0 3
 
-*  Set the value of GPIO 3 on chip0 to 0 and exit tool:
+*  Set the value of GPIO 3 on chip0 to 0 and daemonize:
 
    .. code-block:: console
 
-      target:~$ gpioset --mode=exit gpiochip0 3=0
+      target:~$ gpioset -z -c gpiochip0 3=0
+
+.. note::
+
+   When demonizing gpioset command please note that the process is still running in
+   the background and you need to kill it afterward to release the GPIO. Otherwise
+   you might get an error when trying to change state of the same GPIO:
+
+   .. code-block:: console
+
+      target:~$ gpioset -z -c gpiochip0 3=1
+      gpioset: unable to request lines on chip '/dev/gpiochip0': Device or resource busy
+
+   This is the expected behavior in libgpiod version 2.
+
+   As a workaround it is possible to use the ``-t 0`` switch:
+
+   .. code-block:: console
+
+      target:~$ gpioset -t0 -c gpiochip0 3=0
 
 *  Help text of gpioset shows possible options:
 
    .. code-block:: console
 
       target:~$ gpioset --help
-      Usage: gpioset [OPTIONS] <chip name/number> <offset1>=<value1> <offset2>=<value2> ...
-      Set GPIO line values of a GPIO chip
+      Usage: gpioset [OPTIONS] <line=value>...
+
+      Set values of GPIO lines.
+
+      Lines are specified by name, or optionally by offset if the chip option
+      is provided.
+      Values may be '1' or '0', or equivalently 'active'/'inactive' or 'on'/'off'.
+
+      The line output state is maintained until the process exits, but after that
+      is not guaranteed.
 
       Options:
-        -h, --help:           display this message and exit
-        -v, --version:        display the version and exit
-        -l, --active-low:     set the line active state to low
-        -m, --mode=[exit|wait|time|signal] (defaults to 'exit'):
-                      tell the program what to do after setting values
-        -s, --sec=SEC:        specify the number of seconds to wait (only valid for --mode=time)
-        -u, --usec=USEC:      specify the number of microseconds to wait (only valid for --mode=time)
-        -b, --background:     after setting values: detach from the controlling terminal
+            --banner          display a banner on successful startup
+      -b, --bias <bias>     specify the line bias
+                              Possible values: 'pull-down', 'pull-up', 'disabled'.
+                              (default is to leave bias unchanged)
+            --by-name         treat lines as names even if they would parse as an offset
+      -c, --chip <chip>     restrict scope to a particular chip
+      -C, --consumer <name> consumer name applied to requested lines (default is 'gpioset')
+      -d, --drive <drive>   specify the line drive mode
+                              Possible values: 'push-pull', 'open-drain', 'open-source'.
+                              (default is 'push-pull')
+      -h, --help            display this help and exit
+      -l, --active-low      treat the line as active low
+      -p, --hold-period <period>
+                              the minimum time period to hold lines at the requested values
+      -s, --strict          abort if requested line names are not unique
+      -t, --toggle <period>[,period]...
+                              toggle the line(s) after the specified period(s)
+                              If the last period is non-zero then the sequence repeats.
+            --unquoted        don't quote line names
+      -v, --version         output version information and exit
+      -z, --daemonize       set values then detach from the controlling terminal
 
-      Modes:
-        exit:         set values and exit immediately
-        wait:         set values and wait for user to press ENTER
-        time:         set values and sleep for a specified amount of time
-        signal:       set values and wait for SIGINT or SIGTERM
+      Chips:
+         A GPIO chip may be identified by number, name, or path.
+         e.g. '0', 'gpiochip0', and '/dev/gpiochip0' all refer to the same chip.
 
-      Note: the state of a GPIO line controlled over the character device reverts to default
-      when the last process referencing the file descriptor representing the device file exits.
-      This means that it's wrong to run gpioset, have it exit and expect the line to continue
-      being driven high or low. It may happen if given pin is floating but it must be interpreted
-      as undefined behavior.
+      Periods:
+         Periods are taken as milliseconds unless units are specified. e.g. 10us.
+         Supported units are 's', 'ms', and 'us'.
 
+      *Note*
+         The state of a GPIO line controlled over the character device reverts to default
+         when the last process referencing the file descriptor representing the device file exits.
+         This means that it's wrong to run gpioset, have it exit and expect the line to continue
+         being driven high or low. It may happen if given pin is floating but it must be interpreted
+         as undefined behavior.
 
 .. warning::
 
@@ -118,9 +160,8 @@ It is only possible with manually enabling CONFIG_GPIO_SYSFS in the kernel
 configuration. To make CONFIG_GPIO_SYSFS visible in menuconfig the option
 CONFIG_EXPERT has to be enabled first.
 
-You can also add this option for example to the
-imx9_phytec_distro.config config fragment in the linux kernel sources
-under arch/arm64/configs ::
+You can also add this option for example to the imx9_phytec_defconfig config
+in the linux kernel sources under arch/arm64/configs ::
 
    ..
    CONFIG_GPIO_SYSFS=y

--- a/source/bsp/peripherals/wireless-network.rsti
+++ b/source/bsp/peripherals/wireless-network.rsti
@@ -67,9 +67,7 @@ Bluetooth
 
 .. bluetooth_chapter_start_label
 
-Bluetooth is connected to |bluetooth-uart| interface. More information about the module can
-be found at
-https://connectivity-staging.s3.us-east-2.amazonaws.com/2019-09/CS-DS-SterlingLWB%20v7_2.pdf.
+Bluetooth is connected to |bluetooth-uart| interface.
 The Bluetooth device needs to be set up manually:
 
 .. code-block:: console

--- a/source/conf.py
+++ b/source/conf.py
@@ -288,6 +288,14 @@ latex_documents = [
         False,
     ),
     (
+        'bsp/imx9/imx93/pd24.2.1',
+        'imx93-pd24.2.1.tex',
+        'i.MX 93 BSP Manual PD24.2.1',
+        'PHYTEC Messtechnik GmbH',
+        'manual',
+        False,
+    ),
+    (
         'yocto/kirkstone',
         'kirkstone.tex',
         'Yocto Reference Manual Kirkstone',


### PR DESCRIPTION
Update documentation for the i.MX93 PD24.2.1 release.

Changelog:
- update component version (Linux, U-Boot, Yocto, etc.)
- update line references in device-tree URL links
- rename SoM option extension overlays (unified with i.MX91)
- add phyboard-nash rev 1616.2
- improve WLAN/BT chapter for both boards (Segin uses PEB-WLBT-05, Nash uses PEB-WLBT-07)
- add mlan0 interface name note for PEB-WLBT-07 wireless adapter
- drop PEB-WLBT-05 specifics in general wireless-network.rsti chapter
- update CAN-FD chapter due to BSP changes
- update GPIO chapter due to BSP changes (libgpiod v2 was already part of previous release, so fix it now)
- update EEPROM chapter due to libgpiod v2 changes
- drop "BOOT/bootenv.txt" in favor of "/boot/bootenv.txt" in display.rsti chapter
