### PR TITLE
imx-common: network: more detail on how to configure dynamic IP in linux

### DIFF
--- a/source/bsp/imx-common/peripherals/network.rsti
+++ b/source/bsp/imx-common/peripherals/network.rsti
@@ -4,12 +4,20 @@ the systemd-networkd daemon. The relevant configuration files can be found on
 the target in ``/lib/systemd/network/`` as well as the BSP in
 ``meta-ampliphy/recipes-core/systemd/systemd-conf``.
 
-IP addresses can be configured within \*.network files. The default IP address
-and netmask for eth0 is:
+IP addresses can be configured within \*.network files. The interfaces are
+configured to static IP as default. The default IP address and netmask for eth0
+is:
 
 .. code-block::
 
    eth0: 192.168.3.11/24
+
+To configure eth0 to dynamic IP over DHCP, go to
+``/lib/systemd/network/\*-eth0.network`` and delete the line:
+
+.. code-block::
+
+   Address=192.168.3.11/24
 
 The DT Ethernet setup might be split into two files depending on your hardware
 configuration: the module DT and the board-specific DT. The device tree set up


### PR DESCRIPTION
Add a more detailed description on how to configure network interfaces to use dynamic IP addresses in linux.