### PR TITLE
imx95: alpha1: add new powertip display

### DIFF
--- a/source/bsp/imx9/imx95/alpha1.rst
+++ b/source/bsp/imx9/imx95/alpha1.rst
@@ -407,7 +407,7 @@ Device Tree Audio configuration:
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 Device tree description of LVDS-0 can be found here:
-:linux-phytec-imx:`tree/v6.6.52-2.2.0-phy10/arch/arm64/boot/dts/freescale/imx95-libra-rdk-fpsc-lvds.dtso#L14`
+:linux-phytec-imx:`tree/v6.6.52-2.2.0-phy10/arch/arm64/boot/dts/freescale/`
 
 The device tree of LVDS-1 on PEB-AV-10 can be found here:
 :linux-phytec-imx:`tree/v6.6.52-2.2.0-phy10/arch/arm64/boot/dts/freescale/`

--- a/source/bsp/imx9/imx95/display.rsti
+++ b/source/bsp/imx9/imx95/display.rsti
@@ -6,12 +6,16 @@ Display
 The |sbc| supports up to 3 different display outputs. The following table shows
 the required extensions and devicetree overlays for the different interfaces.
 The PEB-AV-20 is not supported yet.
+For the alpha release, we have included overlays for two different LVDS displays.
+These displays are ``edt,etml1010g3dra`` or ``powertip,ph128800t006-zhc01``.
+The name can be found on the back of the display.
 
 ========= ======================== ======================================
 Interface Expansion                devicetree overlay
 ========= ======================== ======================================
 LVDS1     PEB-AV-10                |dtbo-peb-av-10|
-LVDS0     |sbc|                    imx95-libra-rdk-fpsc-lvds.dtso
+LVDS0     |sbc|                    imx95-libra-rdk-fpsc-lvds-etml1010g3dra.dtbo
+                                   imx95-libra-rdk-fpsc-lvds-ph128800t006-zhc01.dtbo
 MIPI      PEB-AV-20
 ========= ======================== ======================================
 
@@ -22,8 +26,7 @@ MIPI      PEB-AV-20
    *  When changing Weston output, make sure to match the audio output as well.
    *  LVDS0 (PEB-AV-10) and LVDS1 (onboard)can not be used at the same time.
 
-The default-enabled Interface is LVDS0 (onboard LVDS). We support a
-10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
+The default interface is LVDS0 (onboard LVDS).
 
 .. note::
 


### PR DESCRIPTION
For the alpha release of the imx95-libra we will include two overlays for two different displays. The current edt etml1010g3dra display and the new powertip ph128800t006-zhc01 display.