### PR TITLE
CI: fix linkcheck by downgrading certify

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,3 +4,4 @@ Sphinx-Substitution-Extensions==2025.2.19
 sphinx-intl==2.3.1
 sphinx-sitemap==2.6.0
 sphinx-autobuild==2024.10.3
+certifi==2025.1.31


### PR DESCRIPTION
Certify revoked deprecated certificates in their collection. It seems that this change revealed an issue with the Snowflake connector which is probably used by opencv.org. Snowflake will release an update on 30.04.2025 and later on it may be updated on the opencv.org website. For now we have to switch to the last certify version.

More information to the underlaying issue: 

- `https://github.com/certifi/python-certifi/issues/349`

- https://status.snowflake.com/incidents/txclg2cyzq32#:~:text=Customers%20hosted%20in%20AWS%20regions%20may,the%20certifi%20library%20to%20version%202025.4.26