### PR TITLE
CI: fix linkcheck by ignoring one affected URL temporarily

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -371,7 +371,10 @@ latex_documents = [
 
 # -- Linkcheck options ----------------------------------------------------
 
-linkcheck_ignore = ["https://github.com/phytec/doc-bsp-yocto"]
+linkcheck_ignore = [
+    "https://github.com/phytec/doc-bsp-yocto",
+    "https://opencv.org/",
+]
 
 linkcheck_timeout = 60
 linkcheck_workers = 10


### PR DESCRIPTION
Certify revoked deprecated certificates in their collection. It seems that this change revealed an issue with the Snowflake connector which is probably used by opencv.org. Snowflake will release an update on 30.04.2025 and later on it may be updated on the opencv.org website. For now we have to switch to the last certify version.

Ignore opencv.org until the issues are fixed.

Replaces #295 