### PR TITLE
bsp: imx(95): add GoPoint ML Benchmark demo

### DIFF
--- a/source/bsp/imx-common/GoPoint/ML_Benchmark.rsti
+++ b/source/bsp/imx-common/GoPoint/ML_Benchmark.rsti
@@ -1,0 +1,85 @@
+ML Benchmark
+------------
+
+   ML Benchmark tool allows to easily compare the performance of TensorFlow Lite
+   models running on CPU (Cortex-A) and NPU, without the need to type in any
+   command.
+
+   -- NXP [ml_benchmark]_
+
+Note that NXP supplies instructions to run the demo as well. For completeness,
+references will be supplied.
+
+Prerequisites
+.............
+
+To be able to run the ML Benchmark demo application, you will need the
+following:
+
+1. Yocto Project setup with the PHYTEC BSP being built
+2. Ethernet cable, board connected to the internet
+3. Display for any of the supported SoCs PHYTEC SBCs
+4. Console connection to the SBC from host PC
+
+Yocto Project
+~~~~~~~~~~~~~
+
+Modifications in the Yocto Project are necessary as PHYTEC BSPs do not have the
+GoPoint suite included by default.
+Add the following to your local.conf::
+
+   IMAGE_INSTALL:append = " packagegroup-imx-gopoint packagegroup-imx-ml"
+
+Adding this causes the gopoint scripts/ui and the backend ml libraries to be
+installed, respectively.
+Build the phytec-qt6demo-image::
+
+   bitbake phytec-qt6demo-image
+
+and flash the Image to the board.
+
+Ethernet
+~~~~~~~~
+
+Connect an Ethernet cable to the SBC or make otherwise sure that the SBC has
+access to the internet. Otherwise the demo application is unable to download a
+ml model and fails.
+
+Display
+~~~~~~~
+
+Connect the Display accompanying the PHYTEC SBC to the SBC. You may also use
+your own display, however different hardware and/or software may be required.
+The results for this demo are put out as a graphical UI and when weston is
+unable to start the demo will not start, either.
+
+.. note::
+
+   The accompanying display supports touch. In that case no mouse is necessary.
+   When not using a touch display, a mouse is necessary as you need to click on
+   gui elements.
+
+Console
+~~~~~~~
+
+Connect a USB cable from your host PC to the respective port of the SBC.
+
+Running the demo
+................
+
+Boot the board. Ensure the display is working. When using your own display,
+ensure you have the correct dtbo applied and weston starts.
+Connect to the SBC via debug console and execute::
+
+   gopoint tui
+
+This will prompt you for a selection of different demos.
+Use the arrow keys to select the ML Benchmark demo and press Enter.
+On the display, a TFLite Benchmarking box should appear.
+The bottom text within the box should say ``Models are ready for inference``.
+Click/press on ``RUN BENCHMARKS!``.
+Sometimes the box may disappear, rerun the ML Benchmark in the terminal.
+NXP explains this and other issues here [ml_benchmark]_.
+
+.. [ml_benchmark] https://github.com/nxp-imx-support/nxp-demo-experience-demos-list/tree/lf-6.6.52_2.2.0/scripts/machine_learning/ml_benchmark#ml-benchmark-tool.
+

--- a/source/bsp/imx-common/GoPoint/introduction.rsti
+++ b/source/bsp/imx-common/GoPoint/introduction.rsti
@@ -1,0 +1,27 @@
+..
+   GoPoint is only available for NXP vendor releases as NXP has override Syntax
+   in Yocto for nxp-bsp.
+   This file shall only be included in vendor BSP manuals.
+
+
+NXP GoPoint demo suite
+======================
+
+NXP provides demos for their EVK SBCs.
+They are bundled in a demo suite called GoPoint.
+It is advertised as
+
+   "GoPoint for i.MX Applications Processors is for users who are interested in
+   showcasing the various features and capabilities of NXP provided SoCs. The
+   demos included in this application are meant to be easy to run for users of
+   all skill levels, making complex use cases accessible to anyone. Users need
+   some knowledge when setting up equipment on Evaluation Kits (EVKs), such as
+   changing Device Tree Blob (DTB) files."
+
+   -- GoPoint for i.MX Applications Processors User Guide [GPNTUG]_
+
+Since most of the demos require different accessory hardware to be connected to
+the SBC to function properly, the list of required hardware will be presented
+within each demo section.
+
+.. [GPNTUG] https://www.nxp.com/design/design-center/software/i-mx-developer-resources/gopoint-for-i-mx-applications-processors:GOPOINT

--- a/source/bsp/imx9/imx95/alpha1.rst
+++ b/source/bsp/imx9/imx95/alpha1.rst
@@ -421,3 +421,11 @@ The device tree of LVDS-1 on PEB-AV-10 can be found here:
    :end-before: .. tm-gpio-fan-marker
 
 .. include:: /bsp/peripherals/watchdog.rsti
+
+.. +---------------------------------------------------------------------------+
+.. | NXP Demos                                                                 |
+.. +---------------------------------------------------------------------------+
+
+.. include:: ../../imx-common/GoPoint/introduction.rsti
+
+.. include:: ../../imx-common/GoPoint/ML_Benchmark.rsti


### PR DESCRIPTION
Add a section to imx(95) for instructions on how to run a NPU demo using the NXP GoPoint demo suite.