### PR TITLE
linkcheck: add some urls to ignore list

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -374,6 +374,13 @@ latex_documents = [
 linkcheck_ignore = [
     "https://github.com/phytec/doc-bsp-yocto",
     "https://opencv.org/",
+    # Github rate limiting
+    "https://github.com/phytec/linux-phytec-imx",
+    "https://github.com/phytec/linux-phytec",
+    # Client Error 403: Forbidden
+    "https://unix.stackexchange.com/",
+    # Timeout with linkcheck
+    "https://www.jedec.org/standards-documents/technology-focus-areas/flash-memory-ssds-ufs-emmc/e-mmc"
 ]
 
 linkcheck_timeout = 60


### PR DESCRIPTION
Github.com imposes rate limits after around 10 checks or so. It seems that this rate limit only counts for source file links, but not for general projects. For now we can ignore those files and instead manually checking those links from time-to-time with high wait times to not run into the rate-limit.

unix.stackexchange.com and jedec.org show other errors but the pages generally work. This is likely also recent measures to mitigate the impact of AI crawler.

Note:
This is a fix to make the linkcheck work reliably for other links. The situation seems to change rapidly with multiple websites recently and we may need to find other solutions for a linkcheck. First I would like to make the linkcheck work again (even if that means ignoring some domains). Then we can observe the behavior in the next weeks and adapt.