### PR TITLE
sphinx: static: css: Change mobile navbar color

### DIFF
--- a/source/sphinx/static/css/phytec-theme.css
+++ b/source/sphinx/static/css/phytec-theme.css
@@ -40,6 +40,7 @@
     letter-spacing: 0.75px;
 }
 
-.wy-side-nav-search {
+.wy-side-nav-search,
+.wy-nav-top {
     background-color: var(--teal4);
 }


### PR DESCRIPTION
Change the navbar color showing up for smaller screens, like mobile devices, to match the teal used for the regular navbar.

Before: 
![Screen Shot 2025-05-21 at 09 50 37](https://github.com/user-attachments/assets/74ce489e-182f-4bd7-bf94-cf968e7088ff)

After: 
![Screen Shot 2025-05-21 at 09 50 41](https://github.com/user-attachments/assets/ffee1795-3db2-42e3-ad87-d4a7a6c0efab)
