### PR TITLE
use phyCORE-|soc| as |som|  generally 

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Mini
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MM
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -227,7 +227,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mm-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -466,7 +466,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx8mm-phycore-som.dtsi#L278`
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -305,7 +305,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mm-pd22.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -545,7 +545,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2boot0; mmcblk2boot1)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -644,7 +644,7 @@ the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic).
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition):
 
    .. code-block:: console
@@ -681,7 +681,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1132,7 +1132,7 @@ Device Tree Structure
 *  *Board.dts* - include the carrier board and module dtsi files. There may also
    be some hardware configuration nodes enabled on the carrier board or the
    module (i.e. the Board .dts shows the special characteristics of the board
-   configuration). For example, there are phyCORE-|soc| SOMs which may or may not
+   configuration). For example, there are |som| SOMs which may or may not
    have a MIPI DSI to LVDS converter mounted. The converter is enabled (if
    available) in the Board .dts and not in the Module .dtsi
 
@@ -1406,7 +1406,7 @@ DT configuration for the eMMC interface can be found here:
 eMMC Devices
 ------------
 
-PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+PHYTEC modules like |som| is populated with an eMMC memory chip as the
 main storage. eMMC devices contain raw MLC memory cells combined with a memory
 controller that handles ECC and wear leveling. They are connected via an SD/MMC
 interface to the |soc| and are represented as block devices in the Linux kernel
@@ -1531,7 +1531,7 @@ There are two different Reliable Write options:
    partition table (see the previous section).
 
 The first Reliable Write option is mostly already enabled on the eMMCs mounted
-on the phyCORE-|soc| SoMs. To check this on the running target:
+on the |som| SoMs. To check this on the running target:
 
 .. code-block:: console
    :substitutions:
@@ -1989,7 +1989,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mm-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n271`
 
@@ -2059,7 +2059,7 @@ Device Tree CAN configuration of imx8mm-phyboard-polis.dtsi:
 PCIe
 ----
 
-The phyCORE-|soc| has one Mini-PCIe slot. In general, PCIe autodetects new
+The |som| has one Mini-PCIe slot. In general, PCIe autodetects new
 devices on the bus. After connecting the device and booting up the system, you
 can use the command lspci to see all PCIe devices recognized.
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -20,7 +20,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Mini
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MM
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |expansion-connector| replace:: X8

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -401,7 +401,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mm-pd23.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -658,7 +658,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -747,7 +747,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -798,7 +798,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1571,7 +1571,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mm-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n311`
 

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -20,7 +20,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Mini
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MM
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Mini
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MM
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -227,7 +227,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mm-pd25.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -466,7 +466,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx8mm-phycore-som.dtsi#L278`
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -213,7 +213,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mn-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -414,7 +414,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n259`
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Nano
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MN
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -21,7 +21,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Nano
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MN
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -298,7 +298,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mn-pd22.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -538,7 +538,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2boot0; mmcblk2boot1)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -637,7 +637,7 @@ the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic).
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition):
 
    .. code-block:: console
@@ -674,7 +674,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1120,7 +1120,7 @@ Device Tree Structure
 *  *Board.dts* - include the carrier board and module dtsi files. There may also
    be some hardware configuration nodes enabled on the carrier board or the
    module (i.e. the Board .dts shows the special characteristics of the board
-   configuration). For example, there are phyCORE-|soc| SOMs which may or may not
+   configuration). For example, there are |som| SOMs which may or may not
    have a MIPI DSI to LVDS converter mounted. The converter is enabled (if
    available) in the Board .dts and not in the Module .dtsi
 
@@ -1395,7 +1395,7 @@ DT configuration for the eMMC interface can be found here:
 eMMC Devices
 ------------
 
-PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+PHYTEC modules like |som| is populated with an eMMC memory chip as the
 main storage. eMMC devices contain raw MLC memory cells combined with a memory
 controller that handles ECC and wear leveling. They are connected via an SD/MMC
 interface to the |soc| and are represented as block devices in the Linux kernel
@@ -1520,7 +1520,7 @@ There are two different Reliable Write options:
    partition table (see the previous section).
 
 The first Reliable Write option is mostly already enabled on the eMMCs mounted
-on the phyCORE-|soc| SoMs. To check this on the running target:
+on the |som| SoMs. To check this on the running target:
 
 .. code-block:: console
    :substitutions:
@@ -1978,7 +1978,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n248`
 

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -21,7 +21,7 @@
 .. |sbc| replace:: phyBOARD-Polis
 .. |soc| replace:: i.MX 8M Nano
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MN
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc2
 .. |serial-uart| replace:: ttymxc0
 .. |bluetooth-uart| replace:: UART2

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -392,7 +392,7 @@ Bootmode Switch (S1)
 --------------------
 
 The |sbc| features a boot switch with six individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mn-pd23.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -649,7 +649,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -738,7 +738,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -789,7 +789,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1551,7 +1551,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file |dt-som|.dtsi can be
+DT representation, e.g. in |som| file |dt-som|.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mn-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n259`
 

--- a/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: Libra
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP-FPSC
+.. |som| replace:: phyCORE-|soc| FPSC
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
@@ -237,7 +237,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-libra-fpsc-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -371,7 +371,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -379,7 +379,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -484,7 +484,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
 

--- a/source/bsp/imx8/imx8mp/development/uboot-standalone-fixed-ram-config.rsti
+++ b/source/bsp/imx8/imx8mp/development/uboot-standalone-fixed-ram-config.rsti
@@ -1,7 +1,7 @@
 Build U-Boot With a Fixed RAM Size and Frequency
 ................................................
 
-Starting with PD23.1.0 NXP or PD24.1.2 mainline release, the phyCORE-|soc| SoMs
+Starting with PD23.1.0 NXP or PD24.1.2 mainline release, the |som| SoMs
 with revision 1549.3 and newer also support 2GHz RAM timings. These will be
 enabled for supported boards automatically, but they can also be enabled or
 disabled manually.

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -237,7 +237,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -372,7 +372,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -380,7 +380,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -485,7 +485,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -18,7 +18,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |expansion-connector| replace:: X6

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -222,7 +222,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-mainline-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -462,7 +462,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -550,7 +550,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -912,7 +912,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -920,7 +920,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1027,7 +1027,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L169`
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -313,7 +313,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd22.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -553,7 +553,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2boot0; mmcblk2boot1)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -653,7 +653,7 @@ the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic).
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition):
 
    .. code-block:: console
@@ -690,7 +690,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1141,7 +1141,7 @@ Device Tree Structure
 *  *Board.dts* - include the carrier board and module dtsi files. There may also
    be some hardware configuration nodes enabled on the carrier board or the
    module (i.e. the Board .dts shows the special characteristics of the board
-   configuration). For example, there are phyCORE-|soc| SOMs which may or may not
+   configuration). For example, there are |som| SOMs which may or may not
    have a MIPI DSI to LVDS converter mounted. The converter is enabled (if
    available) in the Board .dts and not in the Module .dtsi
 
@@ -1220,7 +1220,7 @@ disabled.
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -1228,7 +1228,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1474,7 +1474,7 @@ DT configuration for the eMMC interface can be found here:
 eMMC Devices
 ------------
 
-PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+PHYTEC modules like |som| is populated with an eMMC memory chip as the
 main storage. eMMC devices contain raw MLC memory cells combined with a memory
 controller that handles ECC and wear leveling. They are connected via an SD/MMC
 interface to the |soc| and are represented as block devices in the Linux kernel
@@ -1599,7 +1599,7 @@ There are two different Reliable Write options:
    partition table (see the previous section).
 
 The first Reliable Write option is mostly already enabled on the eMMCs mounted
-on the phyCORE-|soc| SoMs. To check this on the running target:
+on the |som| SoMs. To check this on the running target:
 
 .. code-block:: console
    :substitutions:
@@ -2047,7 +2047,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy17#n201`
 
@@ -2090,7 +2090,7 @@ Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi:
 PCIe
 ----
 
-The phyCORE-|soc| has one Mini-PCIe slot. In general, PCIe autodetects new
+The |som| has one Mini-PCIe slot. In general, PCIe autodetects new
 devices on the bus. After connecting the device and booting up the system, you
 can use the command lspci to see all PCIe devices recognized.
 
@@ -2479,8 +2479,8 @@ NPU
 ---
 
 The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an accelerator
-for artificial intelligence operations. Refer to our latest phyCORE-|soc| AI Kit
-Guide on the phyCORE-|soc| download section to get information about the
+for artificial intelligence operations. Refer to our latest |som| AI Kit
+Guide on the |som| download section to get information about the
 NPU: `L-1015e.A0 phyCORE-i.MX 8M Plus AI Kit Guide
 <https://www.phytec.de/cdocuments/?doc=ZQBhDw>`_
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -20,7 +20,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -312,7 +312,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd22.1.2-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -552,7 +552,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2boot0; mmcblk2boot1)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -652,7 +652,7 @@ the SD card (e.g. |yocto-imagename|-|yocto-machinename|.wic).
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition):
 
    .. code-block:: console
@@ -689,7 +689,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1165,7 +1165,7 @@ Device Tree Structure
 *  *Board.dts* - include the carrier board and module dtsi files. There may also
    be some hardware configuration nodes enabled on the carrier board or the
    module (i.e. the Board .dts shows the special characteristics of the board
-   configuration). For example, there are phyCORE-|soc| SOMs which may or may not
+   configuration). For example, there are |som| SOMs which may or may not
    have a MIPI DSI to LVDS converter mounted. The converter is enabled (if
    available) in the Board .dts and not in the Module .dtsi
 
@@ -1244,7 +1244,7 @@ disabled.
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -1252,7 +1252,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1495,7 +1495,7 @@ DT configuration for the eMMC interface can be found here:
 eMMC Devices
 ------------
 
-PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+PHYTEC modules like |som| is populated with an eMMC memory chip as the
 main storage. eMMC devices contain raw MLC memory cells combined with a memory
 controller that handles ECC and wear leveling. They are connected via an SD/MMC
 interface to the |soc| and are represented as block devices in the Linux kernel
@@ -1620,7 +1620,7 @@ There are two different Reliable Write options:
    partition table (see the previous section).
 
 The first Reliable Write option is mostly already enabled on the eMMCs mounted
-on the phyCORE-|soc| SoMs. To check this on the running target:
+on the |som| SoMs. To check this on the running target:
 
 .. code-block:: console
    :substitutions:
@@ -2068,7 +2068,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.10.72_2.2.0-phy18#n201`
 
@@ -2111,7 +2111,7 @@ Device Tree CAN configuration of imx8mp-phyboard-pollux.dtsi:
 PCIe
 ----
 
-The phyCORE-|soc| has one Mini-PCIe slot. In general, PCIe autodetects new
+The |som| has one Mini-PCIe slot. In general, PCIe autodetects new
 devices on the bus. After connecting the device and booting up the system, you
 can use the command lspci to see all PCIe devices recognized.
 
@@ -2500,8 +2500,8 @@ NPU
 ---
 
 The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an accelerator
-for artificial intelligence operations. Refer to our latest phyCORE-|soc| AI Kit
-Guide on the phyCORE-|soc| download section to get information about the
+for artificial intelligence operations. Refer to our latest |som| AI Kit
+Guide on the |som| download section to get information about the
 NPU: `L-1015e.A0 phyCORE-i.MX 8M Plus AI Kit Guide
 <https://www.phytec.de/cdocuments/?doc=ZQBhDw>`_
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -19,7 +19,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -411,7 +411,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd23.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -668,7 +668,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -757,7 +757,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.wic
       |yocto-imagename|-|yocto-machinename|.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -808,7 +808,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 
@@ -1090,7 +1090,7 @@ Execute and power up the board:
 .. _imx8mp-pd23.1.0-development-build-uboot:
 .. include:: /bsp/imx-common/development/standalone_build_u-boot_binman.rsti
 
-Starting with PD23.1.0 release, the phyCORE-|soc| SoMs with revision 1549.3 and
+Starting with PD23.1.0 release, the |som| SoMs with revision 1549.3 and
 newer also support 2GHz RAM timings. These will be enabled for supported boards
 automatically, but they can also be enabled or disabled manually.
 
@@ -1240,7 +1240,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -1248,7 +1248,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1635,7 +1635,7 @@ hardware introspection from the ID area to the normal area.
 
    If you deleted both EEPROM spaces, please contact our support!
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :imx-dt:`imx8mp-phycore-som.dtsi?h=v5.15.71_2.2.2-phy3#n199`
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -20,7 +20,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -22,7 +22,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -237,7 +237,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd24.1.0_nxp-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -372,7 +372,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -380,7 +380,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -485,7 +485,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -18,7 +18,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |expansion-connector| replace:: X6

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -407,7 +407,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd24.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -649,7 +649,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2boot0; mmcblk2boot1)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -754,7 +754,7 @@ image saved on the SD card.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (mmcblk2\ **boot0**; mmcblk2\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -1127,7 +1127,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -1135,7 +1135,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1240,7 +1240,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L169`
 

--- a/source/bsp/imx8/imx8mp/pd24.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.2.rst
@@ -18,7 +18,7 @@
 .. |sbc| replace:: phyBOARD-Pollux
 .. |soc| replace:: i.MX 8M Plus
 .. |socfamily| replace:: i.MX 8
-.. |som| replace:: phyCORE-i.MX8MP
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttymxc0
 .. |serial-uart| replace:: ttymxc1
 .. |expansion-connector| replace:: X6

--- a/source/bsp/imx8/imx8mp/pd24.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.2.rst
@@ -222,7 +222,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1552.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx8mp-pd24.1.2-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -462,7 +462,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -550,7 +550,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -912,7 +912,7 @@ The device tree representation for UART1 pinmuxing:
 RS232/RS485
 -----------
 
-The phyCORE-|soc| supports up to 4 UART units. On the |sbc|, TTL level signals
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
 of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
 to USB converter expansion. This USB is brought out at Micro-USB connector X1.
 UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
@@ -920,7 +920,7 @@ multi-protocol transceiver for RS-232 and RS-485, available at pin header
 connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
 configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
 |ref-jp4| on the baseboard. For more information about the correct setup please
-refer to the phyCORE-|soc|/|sbc| Hardware Manual section UARTs.
+refer to the |som|/|sbc| Hardware Manual section UARTs.
 
 We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
 enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
@@ -1027,7 +1027,7 @@ Overwriting reserved spaces will result in boot issues.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file imx8mp-phycore-som.dtsi can be
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
 :linux-phytec:`blob/v6.6.21-phy1/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L169`
 

--- a/source/bsp/imx8/installing-os.rsti
+++ b/source/bsp/imx8/installing-os.rsti
@@ -220,7 +220,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 without partition):
+*  Write the image to the |som| eMMC (MMC device 2 without partition):
 
    .. code-block:: console
       :substitutions:
@@ -299,7 +299,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the phyCORE-|soc| eMMC (MMC device 2 **without**
+*  Write the image to the |som| eMMC (MMC device 2 **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -398,7 +398,7 @@ Flash SPI NOR Flash from Network
 
 The SPI NOR can contain the bootloader and environment to boot from. The arm64
 kernel can not decompress itself, the image size extends the SPI NOR flash
-populated on the phyCORE-|soc|.
+populated on the |som|.
 
 .. tip::
 

--- a/source/bsp/imx8/peripherals/npu.rsti
+++ b/source/bsp/imx8/peripherals/npu.rsti
@@ -2,8 +2,8 @@ NPU
 ---
 
 The |soc| SoC contains a Neural Processing Unit up to 2.3 TOPS as an accelerator
-for artificial intelligence operations. Refer to our latest phyCORE-|soc| AI Kit
-Guide on the phyCORE-|soc| download section to get information about the
+for artificial intelligence operations. Refer to our latest |som| AI Kit
+Guide on the |som| download section to get information about the
 NPU: `L-1015e.A1 phyCORE-i.MX 8M Plus AI Kit Guide
 <https://www.phytec.de/cdocuments/?doc=9oB5Hg>`_
 

--- a/source/bsp/imx8/peripherals/spi-master.rsti
+++ b/source/bsp/imx8/peripherals/spi-master.rsti
@@ -13,7 +13,7 @@ than one device on each channel is possible.
 SPI NOR Flash
 .............
 
-phyCORE-|soc| is equipped with a QSPI NOR Flash which connects to the |soc|'s
+|som| is equipped with a QSPI NOR Flash which connects to the |soc|'s
 FlexSPI interface. The QSPI NOR Flash is suitable for booting. Please see
 different sections for flashing and bootmode setup. Due to limited space on the
 SPI NOR Flash, only the bootloader is stored inside. By default, the kernel,

--- a/source/bsp/imx9/imx93/head.rst
+++ b/source/bsp/imx9/imx93/head.rst
@@ -19,7 +19,7 @@
 .. |sbc-nash| replace:: phyBOARD-Nash i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX93
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP0
 .. |serial-uart| replace:: ttyLP6
 .. |bluetooth-uart| replace:: UART5

--- a/source/bsp/imx9/imx93/head.rst
+++ b/source/bsp/imx9/imx93/head.rst
@@ -236,7 +236,7 @@ Bootmode Switch (S3)
    *  |sbc-nash|: 1616.0, 1616.1, 1616.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx93-head-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -521,7 +521,7 @@ detection.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+DT representation, e.g. in |som| file can be found in our PHYTEC git:
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
 
 .. include:: ../../peripherals/rtc.rsti

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -17,7 +17,7 @@
 .. |sbc| replace:: phyBOARD-Segin i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX93
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP0
 .. |expansion-connector| replace:: X16
 

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -223,7 +223,7 @@ Bootmode Switch (S3)
    Hardware revision baseboard: 1472.5
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx93-pd24.1.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -292,7 +292,7 @@ saved on the SD card.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without**
+*  Write the image to the |som| eMMC (/dev/|emmcdev| **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -474,7 +474,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without partition):
+*  Write the image to the |som| eMMC (/dev/|emmcdev| without partition):
 
    .. code-block:: console
       :substitutions:
@@ -908,7 +908,7 @@ The hardware introspection data is pre-written on the EEPROM data spaces. If
 you have accidentally deleted or overwritten the HW data, you could contact our
 support!
 
-DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+DT representation, e.g. in |som| file can be found in our PHYTEC git:
 :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.36_2.1.0-phy1#n173`
 
 .. include:: ../../peripherals/rtc.rsti

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -17,7 +17,7 @@
 .. |sbc| replace:: phyBOARD-Segin/Nash i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX93
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP0
 .. |serial-uart| replace:: ttyLP6
 .. |expansion-connector| replace:: X16

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -233,7 +233,7 @@ Bootmode Switch (S3)
    *  phyBOARD-Nash-i.MX 93: 1616.0
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx93-PD24.1.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -302,7 +302,7 @@ saved on the SD card.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without**
+*  Write the image to the |som| eMMC (/dev/|emmcdev| **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -484,7 +484,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without partition):
+*  Write the image to the |som| eMMC (/dev/|emmcdev| without partition):
 
    .. code-block:: console
       :substitutions:
@@ -952,7 +952,7 @@ The hardware introspection data is pre-written on the EEPROM data spaces. If
 you have accidentally deleted or overwritten the HW data, you could contact our
 support!
 
-DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+DT representation, e.g. in |som| file can be found in our PHYTEC git:
 :imx-dt:`imx93-phycore-som.dtsi?h=v6.1.55_2.2.0-phy3#n172`
 
 .. include:: ../../peripherals/rtc.rsti

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -235,7 +235,7 @@ Bootmode Switch (S3)
    *  |sbc-nash|: 1616.0, 1616.1
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx93-PD24.2.0-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -565,7 +565,7 @@ detection.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+DT representation, e.g. in |som| file can be found in our PHYTEC git:
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
 
 .. include:: ../../peripherals/rtc.rsti

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -19,7 +19,7 @@
 .. |sbc-nash| replace:: phyBOARD-Nash i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX93
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP0
 .. |serial-uart| replace:: ttyLP6
 .. |expansion-connector| replace:: X16

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -19,7 +19,7 @@
 .. |sbc-nash| replace:: phyBOARD-Nash i.MX 93
 .. |soc| replace:: i.MX 93
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX93
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP0
 .. |serial-uart| replace:: ttyLP6
 .. |bluetooth-uart| replace:: UART5

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -236,7 +236,7 @@ Bootmode Switch (S3)
    *  |sbc-nash|: 1616.0, 1616.1, 1616.2
 
 The |sbc| features a boot switch with four individually switchable ports to
-select the phyCORE-|soc| default bootsource.
+select the |som| default bootsource.
 
 .. _imx93-PD24.2.1-bootswitch:
 .. include:: bootmode-switch.rsti
@@ -521,7 +521,7 @@ detection.
 
 .. include:: ../peripherals/eeprom.rsti
 
-DT representation, e.g. in phyCORE-|soc| file can be found in our PHYTEC git:
+DT representation, e.g. in |som| file can be found in our PHYTEC git:
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phycore-som.dtsi#L172`
 
 .. include:: ../../peripherals/rtc.rsti

--- a/source/bsp/imx9/imx95/alpha1.rst
+++ b/source/bsp/imx9/imx95/alpha1.rst
@@ -19,7 +19,7 @@
 .. |sbc| replace:: Libra FPSC
 .. |soc| replace:: i.MX 95
 .. |socfamily| replace:: i.MX 9
-.. |som| replace:: phyCORE-i.MX95 FPSC
+.. |som| replace:: phyCORE-|soc|
 .. |debug-uart| replace:: ttyLP6
 .. |serial-uart| replace:: ttyLP7
 .. |bluetooth-uart| replace:: UART3

--- a/source/bsp/imx9/installing-os.rsti
+++ b/source/bsp/imx9/installing-os.rsti
@@ -62,7 +62,7 @@ saved on the SD card.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| **without**
+*  Write the image to the |som| eMMC (/dev/|emmcdev| **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -244,7 +244,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
 
 *  The eMMC device can be recognized by the fact that it contains two boot
    partitions: (|emmcdev|\ **boot0**; |emmcdev|\ **boot1**)
-*  Write the image to the phyCORE-|soc| eMMC (/dev/|emmcdev| without partition):
+*  Write the image to the |som| eMMC (/dev/|emmcdev| without partition):
 
    .. code-block:: console
       :substitutions:

--- a/source/bsp/peripherals/emmc.rsti
+++ b/source/bsp/peripherals/emmc.rsti
@@ -1,7 +1,7 @@
 eMMC Devices
 ------------
 
-PHYTEC modules like phyCORE-|soc| is populated with an eMMC memory chip as the
+PHYTEC modules like |som| is populated with an eMMC memory chip as the
 main storage. eMMC devices contain raw Multi-Level Cells (MLC) or Triple-Level
 Cells (TLC) combined with a memory controller that handles ECC and wear
 leveling. They are connected via an SD/MMC interface to the |soc| and are
@@ -137,7 +137,7 @@ There are two different Reliable Write options:
    partition table (see the previous section).
 
 The first Reliable Write option is mostly already enabled on the eMMCs mounted
-on the phyCORE-|soc| SoMs. To check this on the running target:
+on the |som| SoMs. To check this on the running target:
 
 .. code-block:: console
    :substitutions:

--- a/source/bsp/peripherals/introduction.rsti
+++ b/source/bsp/peripherals/introduction.rsti
@@ -2,7 +2,7 @@ Accessing Peripherals
 =====================
 
 To find out which boards and modules are supported by the release of PHYTEC's
-phyCORE-|soc| BSP described herein, visit |dlpage-bsp|_ web page and click
+|som| BSP described herein, visit |dlpage-bsp|_ web page and click
 the corresponding BSP release in the download section. Here you can find all
 hardware supported in the columns "Hardware Article Number" and the correct
 machine name in the corresponding cell under "Machine Name".

--- a/source/bsp/peripherals/pcie.rsti
+++ b/source/bsp/peripherals/pcie.rsti
@@ -1,7 +1,7 @@
 PCIe
 ----
 
-The phyCORE-|soc| has one Mini-PCIe slot. In general, PCIe autodetects new
+The |som| has one Mini-PCIe slot. In general, PCIe autodetects new
 devices on the bus. After connecting the device and booting up the system, you
 can use the command lspci to see all PCIe devices recognized.
 

--- a/source/bsp/template.rst
+++ b/source/bsp/template.rst
@@ -41,7 +41,7 @@
 .. |soc| replace::
 .. Name of the family of SoCs this SoC is part of; e.g. i.MX 8
 .. |socfamily| replace::
-.. Name of the PHYTEC System on Module
+.. Name of the PHYTEC System on Module; e.g. phyCORE-|soc|
 .. |som| replace::
 .. debug uart on the board; Example: ttymxc0
 .. |debug-uart| replace::


### PR DESCRIPTION
We already have a term for the Module. This also helps us with phyCORE-i.MX8MP-FPSC or any non phyCORE doc in future.

Changes generated with
find source/bsp/  -type f | xargs sed -i 's/phyCORE-|soc|/|som|/g'


```
 git grep "|som| replace::"
source/bsp/imx8/imx8mm/head.rst:25:.. |som| replace:: phyCORE-i.MX8MM
source/bsp/imx8/imx8mm/pd22.1.1.rst:23:.. |som| replace:: phyCORE-i.MX8MM
source/bsp/imx8/imx8mm/pd23.1.0.rst:23:.. |som| replace:: phyCORE-i.MX8MM
source/bsp/imx8/imx8mm/pd25.1.0.rst:25:.. |som| replace:: phyCORE-i.MX8MM
source/bsp/imx8/imx8mn/head.rst:25:.. |som| replace:: phyCORE-i.MX8MN
source/bsp/imx8/imx8mn/pd22.1.1.rst:24:.. |som| replace:: phyCORE-i.MX8MN
source/bsp/imx8/imx8mn/pd23.1.0.rst:24:.. |som| replace:: phyCORE-i.MX8MN
source/bsp/imx8/imx8mp-libra-fpsc/head.rst:25:.. |som| replace:: phyCORE-i.MX8MP-FPSC
source/bsp/imx8/imx8mp/head.rst:25:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/mainline-head.rst:21:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd22.1.1.rst:23:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd22.1.2.rst:22:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd23.1.0.rst:23:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst:25:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd24.1.1.rst:21:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx8/imx8mp/pd24.1.2.rst:21:.. |som| replace:: phyCORE-i.MX8MP
source/bsp/imx9/imx93/pd24.1.0.rst:20:.. |som| replace:: phyCORE-i.MX93
source/bsp/imx9/imx93/pd24.1.1.rst:20:.. |som| replace:: phyCORE-i.MX93
source/bsp/imx9/imx93/pd24.2.0.rst:22:.. |som| replace:: phyCORE-i.MX93
source/bsp/imx9/imx93/pd24.2.1.rst:22:.. |som| replace:: phyCORE-i.MX93
source/bsp/imx9/imx95/alpha1.rst:22:.. |som| replace:: phyCORE-i.MX95 FPSC
```

**With this PR all occurence of |som| will change from the short form
like phyCORE-i.MX8MM to the format used on our website 
phyCORE-i.MX 8M Mini**

