### PR TITLE
imx9: imx95: peripherals: add and update gpu section

### DIFF
--- a/source/bsp/imx9/imx95/alpha1.rst
+++ b/source/bsp/imx9/imx95/alpha1.rst
@@ -431,6 +431,8 @@ Device tree description of LVDS-0 can be found here:
 
 .. include:: /bsp/imx9/imx95/peripherals/tm.rsti
 
+.. include:: /bsp/imx9/imx95/peripherals/gpu.rsti
+
 .. include:: /bsp/peripherals/watchdog.rsti
 
 .. +---------------------------------------------------------------------------+

--- a/source/bsp/imx9/imx95/head.rst
+++ b/source/bsp/imx9/imx95/head.rst
@@ -431,6 +431,8 @@ Device tree description of LVDS-0 can be found here:
 
 .. include:: /bsp/imx9/imx95/peripherals/tm.rsti
 
+.. include:: /bsp/imx9/imx95/peripherals/gpu.rsti
+
 .. include:: /bsp/peripherals/watchdog.rsti
 
 .. +---------------------------------------------------------------------------+

--- a/source/bsp/imx9/imx95/peripherals/gpu.rsti
+++ b/source/bsp/imx9/imx95/peripherals/gpu.rsti
@@ -1,0 +1,12 @@
+
+GPU
+---
+
+i.MX95 FPSC has MALI GPU G310. As recommended by NXP in the
+`i.MX Graphics User's Guide <https://www.nxp.com/docs/en/user-guide/IMX_GRAPHICS_USERS_GUIDE.pdf#page=84>`_,
+when running benchmarks, set the /etc/environment on the target with the variable "WESTON_FORCE_RENDERER=1"
+and restart Weston with "systemctl".
+
+This variable disables the use of hardware planes for compositing except for cursors.
+This avoids tearing and framerate drops caused by the lack of atomic Kernel Mode Setting
+support, ensuring more stable and consistent benchmark results.


### PR DESCRIPTION
When running benchmark tests on MALI G310 GPU of i.MX95 FPSC WESTON_FORCE_RENDERER is enabled and sourced in /etc/environment on the target.

Ref: https://www.nxp.com/docs/en/user-guide/IMX_GRAPHICS_USERS_GUIDE.pdf