### PR TITLE
imx93: add enabling jtag section

### DIFF
--- a/source/bsp/imx9/imx93/head.rst
+++ b/source/bsp/imx9/imx93/head.rst
@@ -390,6 +390,18 @@ Execute and power up the board:
 
 .. include:: ../../imx-common/development/format_sd-card.rsti
 
+Enabling JTAG Debug Interface
+-----------------------------
+
+The |soc| has a JTAG debug interface which can be used to debug software running
+on the SoC. The JTAG interface is routed through the pinmux and is not enabled
+by default. To enable the JTAG interface, please add this overlay to your
+```bootenv.txt``` file:
+
+.. code-block::
+
+   imx93-phyboard-nash-jtag.dtbo
+
 .. +---------------------------------------------------------------------------+
 .. DEVICE TREE
 .. +---------------------------------------------------------------------------+


### PR DESCRIPTION
JTAG isn't muxed by default on i.MX93.

This PR adds a section describing the need to enable it by devicetree overlay, because otherwise it does not work.