### PR TITLE
BSPIMX8M-3617 imx8: imx95: add comment about static IPs for netboot

### DIFF
--- a/source/bsp/imx-common/development/host_network_setup.rsti
+++ b/source/bsp/imx-common/development/host_network_setup.rsti
@@ -150,3 +150,15 @@ When you boot/restart your host PC and don't have the network interface, as
 specified in the kea-dhcp4 config, already active the kea-dhcp4-server will
 fail to start. Make sure to start/restart the systemd service when you connect
 the interface.
+
+.. note::
+
+   DHCP server setup is only needed when using dynamic IP addresses. For our
+   vendor BSPs, static IP addresses are used by default.
+
+   .. code-block::
+
+      u-boot=> env print ip_dyn
+      ip_dyn=no
+
+   To use dynamic IP addresses for netboot, ``ip_dyn`` needs to be set to ``yes``.

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -284,6 +284,12 @@ To revert to the old style of booting, you may do
 .. include:: /bsp/imx-common/development/uuu.rsti
 
 .. include:: /bsp/imx-common/development/host_network_setup.rsti
+
+.. warning::
+
+   Using netboot with standardboot and static IPs does not work yet in this
+   release. Standardboot will always use dhcp.
+
 .. include:: /bsp/imx-common/development/netboot_fit.rsti
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -295,6 +295,12 @@ To revert to the old style of booting, you may do
 .. include:: ../../imx-common/development/uuu.rsti
 
 .. include:: /bsp/imx-common/development/host_network_setup.rsti
+
+.. warning::
+
+   Using netboot with standardboot and static IPs does not work yet in this
+   release. Standardboot will always use dhcp.
+
 .. include:: /bsp/imx-common/development/netboot_fit.rsti
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti

--- a/source/bsp/imx9/imx95/alpha1.rst
+++ b/source/bsp/imx9/imx95/alpha1.rst
@@ -277,6 +277,12 @@ You can build the SDK yourself with Yocto:
    :end-before: .. uuu-flash-emmc-marker
 
 .. include:: /bsp/imx-common/development/host_network_setup.rsti
+
+.. warning::
+
+   Using netboot with standardboot and static IPs does not work yet in this
+   release. Standardboot will always use dhcp.
+
 .. include:: /bsp/imx-common/development/netboot_fit.rsti
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti


### PR DESCRIPTION
For our vendor BSPs we are using static IPs by default. Now netboot with standardboot and static IPs are also possible and used as default. DHCP server setup is only needed when using dynamic IPs. Add a comment for that.