### PR TITLE
BSPIMX8M-3630: bsp: imx8mp-libra-fpsc: fix led names

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -37,6 +37,8 @@
 .. |kernel-socname| replace:: imx8mm
 .. |kernel-tag| replace:: v6.6.52-2.2.0-phy9
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 33
@@ -105,7 +107,6 @@
 .. |pollux-fan-note| replace:: Only GPIO fan supported.
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
    :ref:`device tree overlay section <imx8mm-head-ubootexternalenv>`
-
 
 .. M-Core specific
 .. |mcore| replace:: M4 Core

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -35,6 +35,8 @@
 .. |kernel-socname| replace:: imx8mm
 .. |kernel-tag| replace:: v5.15.71_2.2.2-phy3
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 33

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -37,6 +37,8 @@
 .. |kernel-socname| replace:: imx8mm
 .. |kernel-tag| replace:: v6.6.52-2.2.0-phy9
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 33

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -36,6 +36,8 @@
 .. |kernel-socname| replace:: imx8mn
 .. |kernel-tag| replace:: v5.15.71_2.2.2-phy3
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 32

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -35,6 +35,8 @@
 .. |kernel-socname| replace:: imx8mn
 .. |kernel-tag| replace:: v5.15.71_2.2.2-phy3
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 32

--- a/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-libra-fpsc/head.rst
@@ -37,6 +37,8 @@
 .. |kernel-socname| replace:: imx8mp-fpsc
 .. |kernel-tag| replace:: v6.6.23-2.0.0-phy10
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: red:user1, green:user2 and blue:user3
+.. |led-example| replace:: red\\:user1
 
 .. Bootloader
 .. |u-boot-defconfig| replace:: imx8mp-libra_defconfig
@@ -436,7 +438,7 @@ The definition of the SPI master node in the device tree can be found here:
 .. include:: /bsp/peripherals/leds.rsti
 
 Device tree configuration for the User I/O configuration can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L255`
+:linux-phytec-imx:`tree/v6.6.52-2.2.0-phy16/arch/arm64/boot/dts/freescale/imx8mp-libra-rdk-fpsc.dts#L165`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -37,6 +37,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v6.6.23-2.0.0-phy10
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: red:user1, green:user2 and blue:user3
+.. |led-example| replace:: red\\:user1
 
 .. Bootloader
 .. |u-boot-defconfig| replace:: phycore-imx8mp_defconfig

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -32,6 +32,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v6.6.21-phy1
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |u-boot-defconfig| replace:: phycore-imx8mp_defconfig

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -35,6 +35,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v5.15.71_2.2.2-phy3
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 32

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -37,6 +37,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v6.6.23-2.0.0-phy10
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: red:user1, green:user2 and blue:user3
+.. |led-example| replace:: red\\:user1
 
 .. Bootloader
 .. |u-boot-defconfig| replace:: phycore-imx8mp_defconfig

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -32,6 +32,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v6.6.21-phy1
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |bootloader-offset| replace:: 32

--- a/source/bsp/imx8/imx8mp/pd24.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.2.rst
@@ -32,6 +32,8 @@
 .. |kernel-socname| replace:: imx8mp
 .. |kernel-tag| replace:: v6.6.21-phy1
 .. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: led-0, led-1 and led-2
+.. |led-example| replace:: led-1
 
 .. Bootloader
 .. |u-boot-defconfig| replace:: phycore-imx8mp_defconfig

--- a/source/bsp/peripherals/leds.rsti
+++ b/source/bsp/peripherals/leds.rsti
@@ -19,16 +19,18 @@ To get all available LEDs, type:
    target:~$ ls /sys/class/leds
    led-1@  led-2@  led-3@  mmc1::@  mmc2::@
 
-Here the LEDs blue-mmc, green-heartbeat, and red-emmc are on the |sbc|.
+The |sbc| provides the following LED indicators: |led-names|.
 
 *  To toggle the LEDs ON:
 
    .. code-block:: console
+      :substitutions:
 
-      target:~$ echo 255 > /sys/class/leds/led-1/brightness
+      target:~$ echo 255 > /sys/class/leds/|led-example|/brightness
 
 *  To toggle OFF:
 
    .. code-block:: console
+      :substitutions:
 
-      target:~$ echo 0 > /sys/class/leds/led-1/brightness
+      target:~$ echo 0 > /sys/class/leds/|led-example|/brightness

--- a/source/bsp/template.rst
+++ b/source/bsp/template.rst
@@ -56,6 +56,10 @@
 .. |kernel-tag| replace::
 .. File name for the e.MMC device. Example: mmcblk0
 .. |emmcdev| replace::
+.. enumeration of led names in sysfs Example: led-0, led-1 and led-2
+.. |led-names| replace::
+.. led names in sysfs for the usage example Example: led-1
+.. |led-example| replace::
 
 .. U-boot
 .. Offset (in kiB) on block device to write bootloader to. SoC ROM code loads


### PR DESCRIPTION
we still use the default text:
Here the LEDs blue-mmc, green-heartbeat, and red-emmc are on the |sbc|

make the names here and in the example configure able. Checked the names from the linked device trees to set the values for other platforms.