### PR TITLE
bsp: imx95: use "new" link to i.MX Graphics User's Guide

### DIFF
--- a/source/bsp/imx9/imx95/peripherals/gpu.rsti
+++ b/source/bsp/imx9/imx95/peripherals/gpu.rsti
@@ -3,7 +3,7 @@ GPU
 ---
 
 i.MX95 FPSC has MALI GPU G310. As recommended by NXP in the
-`i.MX Graphics User's Guide <https://www.nxp.com/docs/en/user-guide/IMX_GRAPHICS_USERS_GUIDE.pdf#page=84>`_,
+`i.MX Graphics User's Guide <https://www.nxp.com/docs/en/user-guide/UG10159.pdf#page=84>`_,
 when running benchmarks, set the /etc/environment on the target with the variable "WESTON_FORCE_RENDERER=1"
 and restart Weston with "systemctl".
 


### PR DESCRIPTION
NXP apparently changed their naming scheme of the user guides and thus changed the link to their pdf on their website.
Adjust accordingly.
The link may be found via the
"Embedded Linux for i.MX Applications Processors" page.

resolves #326 