### PR TITLE
tox: silence linkcheck

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:linkcheck]
 commands =
-    sphinx-build -b linkcheck source build/linkcheck -j auto
+    sphinx-build -b linkcheck source build/linkcheck -j auto -q
 
 [testenv:spellcheck]
 deps =


### PR DESCRIPTION
Its hard to find the broken links in the long list. Quite changes the output to e.g.

tox -e linkcheck
linkcheck: commands[0]> sphinx-build -b linkcheck source build/linkcheck -j auto -q /home/jremmet/git/doc-bsp-yocto/source/bsp/imx8/imx8mm/head.rst:149: WARNING: broken link: https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.47.0 (403 Client Error: Forbidden for url: https://e2fsprogs.sourceforge.net/e2fsprogs-release.html) /home/jremmet/git/doc-bsp-yocto/source/bsp/imx8/imx8mm/head.rst:4: WARNING: broken link: https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/imx-processors/140261/1/UUU.pdf (500 Server Error: Internal Server Error for url: https://community.nxp.com:443/t5/errors/FilterErrorHandlerPage) linkcheck: exit 1 (54.43 seconds) /home/jremmet/git/doc-bsp-yocto> sphinx-build -b linkcheck source build/linkcheck -j auto -q pid=80050
  linkcheck: FAIL code 1 (54.50=setup[0.07]+cmd[54.43] seconds)
  evaluation failed :( (54.56 seconds)