### PR TITLE
tox: sphinx-build: stop updating while editing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 # Build and monitor for changes. Host the html documentation at localhost at a free port.
 [testenv:html]
 commands =
-    sphinx-autobuild -E -W --keep-going -b html source build/html -j auto --port 0
+    sphinx-autobuild -E -W --keep-going -b html source build/html -j auto --port 0 --ignore "*.swp"
 
 [testenv:pdf]
 allowlist_externals =


### PR DESCRIPTION
If you open a file with vim, a temporary *.swp is created. This trogger the build while editing. Because it is not directly used, this build is pointless.
Wait till we save the file to trigger the build by ignoring *.swp files.