### PR TITLE
bsp:imx95: quickstart-alpha1: Add SoC revision warning

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/quickstart-alpha1.rst
+++ b/source/bsp/imx9/imx95-fpsc/quickstart-alpha1.rst
@@ -96,6 +96,11 @@ Included in the Kit
 -  2.54 10P to DB9P Female (WF072)
 -  2 x 2.54 10P to DB9P Male (WF228)
 
+.. warning::
+   The PD-05032-ALPHA.A0 Alpha1 Kit includes the i.MX95 CPU revision A1.
+   This CPU revision will not be software compatible with future NXP BSP
+   releases, as new releases will only support i.MX95 CPU revision B0.
+
 Components
 ----------
 


### PR DESCRIPTION
Add a warning to mark that this Alpha1 i.MX95 kit will not be supported in future BSPs.