### PR TITLE
BSPYOCTOIMX93-488 bsp: imx9: imx93: Include USB OTG chapter

### DIFF
--- a/source/bsp/imx9/imx93/head.rst
+++ b/source/bsp/imx9/imx93/head.rst
@@ -584,6 +584,8 @@ DT representation for USB Host:
 or
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L185`
 
+.. include:: /bsp/peripherals/usb-otg.rsti
+
 RS232/RS485
 -----------
 

--- a/source/bsp/imx9/imx93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx93/pd24.1.0.rst
@@ -939,6 +939,8 @@ Linux/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt.
 DT representation for USB Host:
 :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.36_2.1.0-phy1#n190`
 
+.. include:: /bsp/peripherals/usb-otg.rsti
+
 CAN FD
 ------
 

--- a/source/bsp/imx9/imx93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx93/pd24.1.1.rst
@@ -985,6 +985,8 @@ DT representation for USB Host:
 :imx-dt:`imx93-phyboard-segin.dts?h=v6.1.55_2.2.0-phy3#n190` or
 :imx-dt:`imx93-phyboard-nash.dts?h=v6.1.55_2.2.0-phy3#n180`
 
+.. include:: /bsp/peripherals/usb-otg.rsti
+
 RS232/RS485
 -----------
 

--- a/source/bsp/imx9/imx93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx93/pd24.2.0.rst
@@ -619,6 +619,8 @@ DT representation for USB Host:
 or
 :linux-phytec-imx:`blob/v6.6.23-2.0.0-phy8/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L181`
 
+.. include:: /bsp/peripherals/usb-otg.rsti
+
 RS232/RS485
 -----------
 

--- a/source/bsp/imx9/imx93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx93/pd24.2.1.rst
@@ -575,6 +575,8 @@ DT representation for USB Host:
 or
 :linux-phytec-imx:`blob/v6.6.52-2.2.0-phy9/arch/arm64/boot/dts/freescale/imx93-phyboard-nash.dts#L185`
 
+.. include:: /bsp/peripherals/usb-otg.rsti
+
 RS232/RS485
 -----------
 


### PR DESCRIPTION
Include the missing generic PHYTEC USB OTG chapter also for i.MX93, as it also supports it.


