### PR TITLE
bsp: imx95: add xxd to required host tools for mkimage

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/development/standalone_build_u-boot_imxmkimage.rsti
+++ b/source/bsp/imx9/imx95-fpsc/development/standalone_build_u-boot_imxmkimage.rsti
@@ -46,6 +46,12 @@ Build the bootloader
 Build the imx-boot binary with imx-mkimage
 ..........................................
 
+``xxd`` is required for compiling the boot container.
+
+.. code-block:: console
+
+   host:~$ sudo apt install xxd
+
 Clone the repository
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
imx-mkimage has a dependency on xxd for imx95 (and fspi). Add info on the dependency and how to install xxd.