### PR TITLE
sphinx: static: css: Improved navbar section visibility

### DIFF
--- a/source/sphinx/static/css/phytec-theme.css
+++ b/source/sphinx/static/css/phytec-theme.css
@@ -32,6 +32,18 @@
     --yellow: #f1bf00;
 }
 
+a {
+    color: var(--teal3);
+}
+
+a:hover {
+    color: var(--teal2);
+}
+
+a:visited {
+    color: var(--purple);
+}
+
 .wy-menu-vertical header,
 .wy-menu-vertical p.caption {
     color: var(--teal3);


### PR DESCRIPTION
Slightly brighten the text of the navbar sections to improve the contrast and readability. Also change the Languages and Version button at the bottom to the same color.

The background of the search bar would shine through at the rounded corners of its border. Remove the border and clip the background.

Use PHYTEC-specific colors for links in the content to match our theme.
<img width="600" height="602" alt="css-improved-link-vis" src="https://github.com/user-attachments/assets/e7d0e737-b60f-42e2-9e40-cfa6dc63a74f" />
