### PR TITLE
github: workflows: build: Remove preview deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,17 +22,3 @@ jobs:
         tox -e intl
     - name: Build PDF Documentation
       run: tox -e pdf
-    - name: Deploy Preview
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: build/html
-        destination_dir: 'previews/${{ github.event.number }}'
-    - name: Create status check with preview link
-      run: |
-        PREVIEW_URL="https://phytec.github.io/doc-bsp-yocto/previews/${{ github.event.number }}"
-        PAYLOAD=$(echo '{}' | jq --arg name 'Click on details for a Doc Preview' --arg url "${PREVIEW_URL}" '{"name": $name, "head_sha": "${{ github.event.pull_request.head.sha }}", "details_url": $url, "status": "completed", "conclusion": "success", "output": {"title": $name, "summary": "Preview available at the link below. PRs that have been merged in the meantime trigger a deploy action that will delete existing previews. Re-run the build action if the link does not work.", "text": $url}}')
-        curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-             -H "Content-Type: application/json" \
-             -X POST -d "${PAYLOAD}" \
-             "https://api.github.com/repos/${{ github.repository }}/check-runs"


### PR DESCRIPTION
Previously, the gh-branch would be littered with content from pull-requests and display wrong or outdated content in our official documentation. Remove the preview that is being deployed to the gh-pages branch. Previewing should be done locally. This workflow should just check whether pull-requests build.