### PR TITLE
sphinx: static: css: Same color for visited links

### DIFF
--- a/source/sphinx/static/css/phytec-theme.css
+++ b/source/sphinx/static/css/phytec-theme.css
@@ -52,7 +52,19 @@ a:visited {
     letter-spacing: 0.75px;
 }
 
+.wy-menu a {
+    color: var(--gray2);
+}
+
 .wy-menu a:hover {
+    color: var(--white);
+}
+
+.wy-menu a:visited {
+    color: var(--gray2);
+}
+
+.wy-menu a:visited:hover {
     color: var(--white);
 }
 


### PR DESCRIPTION
Use the same color in the navigation bar on left for visited links. Previously, purple was used, but the resulting contrast on dark gray was bad.