### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{rst,rsti}]
+indent_size = 3
+indent_style = space
+spelling_language = en-US


### PR DESCRIPTION
Add an EditorConfig file for uniformly configuring common editor settings. This should prevent some common formatting errors for contributors.