### PR TITLE
bsp: imx8mp-fpsc: imx95-fpsc: fix EEPROM chapter

### DIFF
--- a/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
@@ -486,11 +486,14 @@ carrier board:
 
 On the |som| SoM:
 
-*  Board Detection EEPROM (write-protected)
+*  SoM Detection EEPROM (write-protected)
+
    *  Bus: I2C-0
    *  Address: 0x51
-   *  Purpose: Factory configuration for board identification
+   *  Purpose: Factory configuration for SoM identification
+
 *  User EEPROM
+
    *  Bus: I2C-0
    *  Address: 0x50
    *  Purpose: Available for user applications
@@ -501,6 +504,7 @@ Device Tree Reference for SoM EEPROMs:
 And on the |sbc| carrier board:
 
 *  Board Detection EEPROM
+
    *  Bus: I2C-1
    *  Address: 0x51
    *  Purpose: Reserved for carrier board identification

--- a/source/bsp/imx8/imx8mp-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/head.rst
@@ -487,11 +487,14 @@ carrier board:
 
 On the |som| SoM:
 
-*  Board Detection EEPROM (write-protected)
+*  SoM Detection EEPROM (write-protected)
+
    *  Bus: I2C-0
    *  Address: 0x51
-   *  Purpose: Factory configuration for board identification
+   *  Purpose: Factory configuration for SoM identification
+
 *  User EEPROM
+
    *  Bus: I2C-0
    *  Address: 0x50
    *  Purpose: Available for user applications
@@ -502,6 +505,7 @@ Device Tree Reference for SoM EEPROMs:
 And on the |sbc| carrier board:
 
 *  Board Detection EEPROM
+
    *  Bus: I2C-1
    *  Address: 0x51
    *  Purpose: Reserved for carrier board identification

--- a/source/bsp/imx9/imx95-fpsc/alpha1.rst
+++ b/source/bsp/imx9/imx95-fpsc/alpha1.rst
@@ -404,12 +404,14 @@ carrier board:
 
 On the |som| SoM:
 
-*  Board Detection EEPROM (write-protected)
+*  SoM Detection EEPROM (write-protected)
+
    *  Bus: I2C-0
    *  Address: 0x51
-   *  Purpose: Factory configuration for board identification
+   *  Purpose: Factory configuration for SoM identification
 
 *  User EEPROM
+
    *  Bus: I2C-0
    *  Address: 0x50
    *  Purpose: Available for user applications
@@ -420,6 +422,7 @@ Device Tree Reference for SoM EEPROMs:
 And on the |sbc| carrier board:
 
 *  Board Detection EEPROM
+
    *  Bus: I2C-4
    *  Address: 0x51
    *  Purpose: Reserved for carrier board identification

--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -400,12 +400,14 @@ carrier board:
 
 On the |som| SoM:
 
-*  Board Detection EEPROM (write-protected)
+*  SoM Detection EEPROM (write-protected)
+
    *  Bus: I2C-0
    *  Address: 0x51
-   *  Purpose: Factory configuration for board identification
+   *  Purpose: Factory configuration for SoM identification
 
 *  User EEPROM
+
    *  Bus: I2C-0
    *  Address: 0x50
    *  Purpose: Available for user applications
@@ -416,6 +418,7 @@ Device Tree Reference for SoM EEPROMs:
 And on the |sbc| carrier board:
 
 *  Board Detection EEPROM
+
    *  Bus: I2C-4
    *  Address: 0x51
    *  Purpose: Reserved for carrier board identification


### PR DESCRIPTION
Fix styling for EEPROM chapter. And specify, that factory EEPROM on SoM is only for SoM detection not for (carrier) board detection.