### PR TITLE
bsp: imx8mp display: improve LVDS section

### DIFF
--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -58,8 +58,11 @@ In our BSP, the default Weston output is set to HDMI.
    name=LVDS-1
    mode=off
 
-When using the LVDS0 (PEB-AV-10) as output, set the output mode to off for
-HDMI-A-1 and for LVDS-1 to current.
+When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
+the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
+If you want to use LVDS channel 1 (cables connected directly to the
+phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 .. code-block::
 
@@ -70,9 +73,6 @@ HDMI-A-1 and for LVDS-1 to current.
    [output]
    name=LVDS-1
    mode=current
-
-If you want to use LVDS1 (onboard) then you need to load no overlay. Remove the
-imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 Dual Display
 ~~~~~~~~~~~~


### PR DESCRIPTION
The i.MX 8M Plus has a single LVDS controller with 2 separate channels. These are routed to different connectors for the phyBOARD-Pollux, where one set of connectors in on the board itself and the other set is on an expansion board (PEB-AV-10), which needs to be connected to the phyBOARD-Pollux. The limitation is that both channels may not be used for different displays at the same time, but the single display section did not explain this very well. Explain that
1. Software does not differentiate between the channel
2. The device tree needs to match the physical connections