### PR TITLE
source: bsp: imx-common: Replace uboot-mkimage with mkimage

### DIFF
--- a/source/bsp/imx-common/development/standalone_build_kernel_fit.rsti
+++ b/source/bsp/imx-common/development/standalone_build_kernel_fit.rsti
@@ -100,7 +100,7 @@ image and create the final fitImage with mkimage.
 
    host:~/|kernel-repo-name|$ cp /path/to/yocto/deploydir/fitimage-its*.its .
                      && ln -s arch/arm64/boot/Image.gz linux.bin
-                     && uboot-mkimage -f fitImage-its*.its fitImage
+                     && mkimage -f fitImage-its*.its fitImage
 
 
 Copy FIT image and kernel modules to SD card


### PR DESCRIPTION
To be consistent and allow for using system-wide installed tools, only use mkimage instead of uboot-mkimage. With the SDK, mkimage links to uboot-mkimage and most other Linux distros use just mkimage, when installed.

Fixes #401 