### PR TITLE
source: sphinx: static: Properly wrap text in tables

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -113,6 +113,7 @@ templates_path = ['sphinx/templates']
 
 html_css_files = [
     'css/phytec-theme.css',
+    'css/table-wrap-text.css',
 ]
 
 pygments_style = 'bw'

--- a/source/sphinx/static/css/table-wrap-text.css
+++ b/source/sphinx/static/css/table-wrap-text.css
@@ -1,0 +1,4 @@
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    white-space: normal;
+}


### PR DESCRIPTION
Properly wrap text in tables to fit the content. Break at whitespaces.

This is an ongoing issue with the ReadTheDocs theme: https://github.com/readthedocs/sphinx_rtd_theme/issues/1505