### PR TITLE
source: bsp: imx95-fpsc: head: add wireless-network

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -336,6 +336,7 @@ only the script method is supported.
 .. code-block::
    :substitutions:
 
+   imx95-phyflex-libra-rdk-bluetooth-88w8987.dtbo
    imx95-phyflex-libra-rdk-lvds-ph128800t006-zhc01.dtbo
    imx95-phyflex-libra-rdk-neoisp.dtbo
    imx95-phyflex-libra-rdk-vm016-csi1.dtbo
@@ -356,6 +357,7 @@ only the script method is supported.
    imx95-phyflex-libra-rdk-vm020-csi2.dtbo
    imx95-phyflex-libra-rdk-vm020-fpdlink-port0-csi2.dtbo
    imx95-phyflex-libra-rdk-vm020-fpdlink-port1-csi2.dtbo
+   imx95-phyflex-fpsc-g-som-temperature.dtbo
 
 .. _imx95-fpsc-head-ubootexternalenv:
 .. include:: /bsp/dt-overlays-ampliphy-boot.rsti
@@ -400,6 +402,10 @@ by our module and board. Additionally there is a 10Gbit Ethernet. Currently
 only the one Gigabit Ethernet ports are supported (ETH0 and ETH1).
 
 .. include:: /bsp/imx-common/peripherals/network.rsti
+
+.. include:: wireless-network.rsti
+
+.. include:: ../../peripherals/wireless-network.rsti
 
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 

--- a/source/bsp/imx9/imx95-fpsc/wireless-network.rsti
+++ b/source/bsp/imx9/imx95-fpsc/wireless-network.rsti
@@ -1,0 +1,37 @@
+WLAN/Bluetooth
+--------------
+
+WLAN and Bluetooth on the |sbc| are provided by the M.2 ublox MAYA-W271-00B
+expansion card. This module supports 2,4 and 5 GHz bandwidth and can be run
+in several modes, like client mode and Access Point (AP).
+More information about the module can be found at
+https://www.u-blox.com/en/product/maya-w2-series
+
+To use the bluetooth connection, the overlay needs to be activated first,
+otherwise the UART connection isn't configured as needed.
+
+.. code-block:: console
+
+   target:~$ vi /boot/bootenv.txt
+
+Afterwards the bootenv.txt file should look like this (it can also contain
+other devicetree overlays!):
+
+.. code-block::
+
+   fit_overlay_conf=conf-imx95-phyflex-libra-rdk-bluetooth-88w8987.dtbo
+
+The changes will be applied after a reboot:
+
+.. code-block:: console
+
+   target:~$ reboot
+
+For further information about devicetree overlays, read the |ref-dt| chapter.
+
+.. note::
+   The following WLAN chapter assumes wireless network interface name is
+   ``wlan0``. However with MAYA-W271-00B adapter the name of the WLAN
+   interface is actually ``mlan0``. Thus when using commands to configure
+   wireless network, substitute ``wlan0`` with ``mlan0`` when using
+   MAYA-W271-00B.


### PR DESCRIPTION
Based on the M.2  MAYA-W271-00B sdio wlan card.
Also add temperature overlays while on it.