### PR TITLE
editorconfig: move max_line_length to rst files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,10 +6,10 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 80
 trim_trailing_whitespace = true
 
 [*.{rst,rsti}]
 indent_size = 3
 indent_style = space
+max_line_length = 80
 spelling_language = en-US


### PR DESCRIPTION
max_line_length being set to 80 for all filetypes did what it was supposed to, but led to some unexpected behaviour. That is, for e.g. the gitcommit filetype, 80 was set as line length as well. Keep it at default (which should be 72 if following the official guidelines) and only enforce for rst files. If other filetypes should enforce the 80 character limit in the future, they should be added specifically .