### PR TITLE
bsp: jtag: Add hints for user

### DIFF
--- a/source/bsp/peripherals/jtag.rsti
+++ b/source/bsp/peripherals/jtag.rsti
@@ -28,7 +28,13 @@ Connect to target
 Boot the target into U-Boot and run ``JLinkExe``. On the host, connect
 to the target using the ``connect`` command. When prompted to enter the device,
 either type in the device directly or type in ``?`` to get a Popup window, to
-list and search all devices and select the correct one.
+list and search all devices and select the correct one. You will most likely
+find the exact model of the device printed on the SoC.
+
+.. hint::
+
+   For USB-C cables with E-Marker chip, connection to the probe will not work.
+   See `<https://kb.segger.com/USB-C_-_Connection_Issue>`_
 
 .. code-block:: console
    :substitutions:


### PR DESCRIPTION
Add a hint to USB-C cable connection problems with segger JLink debuggers.
Also add where to (likely) find the exact device model description when prompted to enter target device.