### PR TITLE
bsp: imx95: head: add note about backlight brightness 0 not working

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -513,6 +513,12 @@ DT representation for USB Host:
 
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
+.. note::
+
+   On current hardware (1618.2) the backlight brightness 0 will not turn off the
+   backlight enable. Therefore the backlight will be set to max brightness on
+   brightness level 0.
+
 Device tree description of LVDS-1 can be found here:
 :linux-phytec-imx:`tree/v6.6.52-2.2.0-phy13/arch/arm64/boot/dts/freescale/imx95-libra-rdk-fpsc-lvds.dtsi#L35`
 


### PR DESCRIPTION
Add note that backlight brightness level 0 does not turn off the backlight, but sets it to max brightness instead.