### PR TITLE
Wip/jremmet/libra imx8 uart

### DIFF
--- a/source/bsp/imx8/imx8mp-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/head.rst
@@ -26,8 +26,8 @@
 .. |socfamily| replace:: i.MX 8
 .. |som| replace:: phyCORE-|soc| FPSC
 .. |debug-uart| replace:: ttymxc3
-.. |serial-uart| replace:: ttymxc2
-.. |bluetooth-uart| replace:: UART3
+.. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART1
 .. |expansion-connector| replace:: X6
 .. |netboot-script| replace:: net_boot_fit.scr.uimg
 .. |can0-interface| replace:: fcan1

--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -25,7 +25,7 @@
 .. |som| replace:: phyFLEX-|soc| FPSC
 .. |debug-uart| replace:: ttyLP3
 .. |serial-uart| replace:: ttyLP1
-.. |bluetooth-uart| replace:: UART3
+.. |bluetooth-uart| replace:: UART1
 .. |expansion-connector| replace:: X56
 .. |netboot-script| replace:: net_boot_fit.scr.uimg
 .. |can0-interface| replace:: fcan1


### PR DESCRIPTION
bsp: imx95-fpsc: head: fix bluetooth-uart
    
    will be connected to UART1
    
 bsp: imx8mp-fpsc: head: fix uart name
    
    We now use the fpsc standard alias.