### PR TITLE
bsp: imx8: spi-master: update

### DIFF
--- a/source/bsp/imx8/peripherals/spi-master.rsti
+++ b/source/bsp/imx8/peripherals/spi-master.rsti
@@ -31,6 +31,7 @@ in the BSP is set to:
 
 .. code-block::
 
+   u-boot=> printenv mtdparts
    mtdparts=30bb0000.spi:3840k(u-boot),128k(env),128k(env_redund),-(none)
 
 This is a bootloader environment variable that is defined here and can be
@@ -42,54 +43,7 @@ for a partition, run on the target:
 .. code-block:: console
    :substitutions:
 
-   root@|yocto-machinename|:~$ mtdinfo --all
-   Count of MTD devices:           4
-   Present MTD devices:            mtd0, mtd1, mtd2, mtd3
-   Sysfs interface supported:      yes
-
-   mtd0
-   Name:                           u-boot
-   Type:                           nor
-   Eraseblock size:                65536 bytes, 64.0 KiB
-   Amount of eraseblocks:          60 (3932160 bytes, 3.7 MiB)
-   Minimum input/output unit size: 1 byte
-   Sub-page size:                  1 byte
-   Character device major/minor:   90:0
-   Bad blocks are allowed:         false
-   Device is writable:             true
-
-   mtd1
-   Name:                           env
-   Type:                           nor
-   Eraseblock size:                65536 bytes, 64.0 KiB
-   Amount of eraseblocks:          2 (131072 bytes, 128.0 KiB)
-   Minimum input/output unit size: 1 byte
-   Sub-page size:                  1 byte
-   Character device major/minor:   90:2
-   Bad blocks are allowed:         false
-   Device is writable:             true
-
-   mtd2
-   Name:                           env_redund
-   Type:                           nor
-   Eraseblock size:                65536 bytes, 64.0 KiB
-   Amount of eraseblocks:          2 (131072 bytes, 128.0 KiB)
-   Minimum input/output unit size: 1 byte
-   Sub-page size:                  1 byte
-   Character device major/minor:   90:4
-   Bad blocks are allowed:         false
-   Device is writable:             true
-
-   mtd3
-   Name:                           none
-   Type:                           nor
-   Eraseblock size:                65536 bytes, 64.0 KiB
-   Amount of eraseblocks:          448 (29360128 bytes, 28.0 MiB)
-   Minimum input/output unit size: 1 byte
-   Sub-page size:                  1 byte
-   Character device major/minor:   90:6
-   Bad blocks are allowed:         false
-   Device is writable:             true
+   target:~$ mtdinfo --all
 
 It lists all MTD devices and the corresponding partition names. The flash node
 is defined inside of the SPI master node in the module DTS. The SPI node


### PR DESCRIPTION
Do not list the complete output of mtdparts --all command in Linux, as it will be different for different devices and releases. For upstream we have 4 partitions for downstream we have an additional mtd device that includes the whole spi nor flash. Also the size of the flash will be different. Some SoMs have 64 MiB Flash. Use newer linux console style that is used everywhere else in documentation. List U-Boot command for printing mtdparts env variable.