### PR TITLE
bsp: imx8: mcu: Fix the remoteproc docu section

### DIFF
--- a/source/bsp/imx8/mcu.rsti
+++ b/source/bsp/imx8/mcu.rsti
@@ -175,7 +175,7 @@ adding |dtbo-rpmsg|:
 
 Restart the target and execute in U-Boot::
 
-   u-boot=> run prepare_mcore
+   u-boot=> setenv optargs clk-imx8mp.mcore_booted
 
 Firmware .elf files for the |mcore| can be found under /lib/firmware.
 To load the firmware, type:


### PR DESCRIPTION
To enable the mcore clock, the bootarg variable prepare_mcore is replaced with the optargs. so fixed in the remoteproc section of documentation.