### PR TITLE
BSPIMX8M-4056 bsp: rs485: add note about signal polarity

### DIFF
--- a/source/bsp/peripherals/rs485-halfduplex.rsti
+++ b/source/bsp/peripherals/rs485-halfduplex.rsti
@@ -5,6 +5,10 @@ For half-duplex mode your connection setup should look like this:
 
 .. image:: ./images/RS485_halfduplex_connection.png
 
+.. note::
+
+   Note that TX+ corresponds to signal A and TX- corresponds to signal B.
+
 Which function is on which pin is described in the hardware manual.
 
 For half-duplex mode you can set the ioctls manually like this:


### PR DESCRIPTION
To help users with connecting signal correctly, add a mapping note from signal name to polarity.
In some of our schematics signal names (i.e. A and B) are used and some schematics use polarity signals. The mapping helps in easily translating from one scheme to the other (also relevant for e.g. USB to RS485/422 cables).