### PR TITLE
BSPIMX8M-4160: intial prep for PD24.1.1 BSP documentation

### DIFF
--- a/source/bsp/imx8/imx8mp/imx8mp.rst
+++ b/source/bsp/imx8/imx8mp/imx8mp.rst
@@ -22,6 +22,16 @@ Mainline HEAD
 
    mainline-head
 
+BSP-Yocto-NXP-i.MX8MP-PD24.1.1
+==============================
+
+.. toctree::
+   :caption: Table of Contents
+   :numbered:
+   :maxdepth: 2
+
+   pd24.1.1_nxp
+
 BSP-Yocto-NXP-i.MX8MP-PD24.1.0
 ==============================
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -16,9 +16,6 @@
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
 .. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.1_nxp.pdf
 
-.. IMX8(MP) specific
-.. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2024.04-2.2.2-phy7#n177
-
 .. General Substitutions
 .. |kit| replace:: **phyCORE-i.MX8M Plus Kit**
 .. |kit-ram-size| replace:: 2GiB

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -1,0 +1,634 @@
+.. Download links
+.. |dlpage-bsp| replace:: our BSP
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD24.1.0
+.. |dlpage-bsp-link| replace:: |dlpage-bsp|_
+.. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-8m-plus/#downloads
+.. |dl-server| replace:: BSP downloads
+.. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/
+.. |dl-server-link| replace:: |dl-server|_
+.. |dl-sdk| replace:: SDK downloads
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/sdk/ampliphy-vendor-xwayland/
+.. |dl-sdk-link| replace:: |dl-sdk|_
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
+.. |link-bsp-images| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/
+.. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.0_nxp.pdf
+
+.. IMX8(MP) specific
+.. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2024.04-2.0.0-phy7#n177
+
+.. General Substitutions
+.. |kit| replace:: **phyCORE-i.MX8M Plus Kit**
+.. |kit-ram-size| replace:: 2GiB
+.. |sbc| replace:: phyBOARD-Pollux
+.. |soc| replace:: i.MX 8M Plus
+.. |socfamily| replace:: i.MX 8
+.. |som| replace:: phyCORE-|soc|
+.. |debug-uart| replace:: ttymxc0
+.. |serial-uart| replace:: ttymxc1
+.. |bluetooth-uart| replace:: UART3
+.. |expansion-connector| replace:: X6
+.. |netboot-script| replace:: boot.scr.uimg
+.. |can0-interface| replace:: can0
+.. |can-network-file| replace:: can0.network
+
+.. Linux Kernel
+.. |kernel-defconfig| replace:: imx8_phytec_defconfig
+.. |kernel-primary-ethernet| replace:: eth0
+.. |kernel-recipe-path| replace:: meta-phytec/recipes-kernel/linux/linux-phytec-imx_*.bb
+.. |kernel-repo-name| replace:: linux-phytec-imx
+.. |kernel-repo-url| replace:: https://github.com/phytec/linux-phytec-imx
+.. |kernel-socname| replace:: imx8mp
+.. |kernel-tag| replace:: v6.6.23-2.0.0-phy10
+.. |emmcdev| replace:: mmcblk2
+.. |led-names| replace:: red:user1, green:user2 and blue:user3
+.. |led-example| replace:: red\\:user1
+
+.. Bootloader
+.. |u-boot-defconfig| replace:: phycore-imx8mp_defconfig
+.. |bootloader-offset| replace:: 32
+.. |bootloader-offset-boot-part| replace:: 0
+.. |u-boot-mmc-flash-offset| replace:: 0x40
+.. |u-boot-emmc-devno| replace:: 2
+.. |u-boot-recipe-path| replace:: meta-phytec/recipes-bsp/u-boot/u-boot-imx_*.bb
+.. |u-boot-repo-name| replace:: u-boot-imx
+.. |u-boot-repo-url| replace:: git://git.phytec.de/u-boot-imx
+.. |emmcdev-uboot| replace:: mmc 2
+.. |sdcarddev-uboot| replace:: mmc 1
+
+.. IMX8(MP) specific
+.. |u-boot-socname-config| replace:: PHYCORE_IMX8MP
+.. |u-boot-tag| replace:: v2024.04_2.0.0-phy7
+
+.. RAUC
+.. |rauc-manual| replace:: L-1006e.A6 RAUC Update & Device Management Manual
+.. _rauc-manual: https://www.phytec.de/cdocuments/?doc=F4DiM
+
+.. Devicetree
+.. |dt-carrierboard| replace:: imx8mp-phyboard-pollux-rdk
+.. |dt-som| replace:: imx8mp-phycore-som
+.. |dtbo-rpmsg| replace:: conf-imx8mp-phycore-rpmsg.dtbo
+.. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-10.dtbo
+
+.. IMX8(MP) specific
+.. |dt-somnetwork| replace:: :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L50`
+
+.. Yocto
+.. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
+.. |yocto-bsp-name| replace:: BSP-Yocto-IMX8MP
+.. _yocto-bsp-name: `dl-server`_
+.. |yocto-codename| replace:: Scarthgap
+.. |yocto-distro| replace:: ampliphy-vendor-xwayland
+.. |yocto-imagename| replace:: phytec-qt6demo-image
+.. |yocto-imageext| replace:: rootfs.wic.xz
+.. |yocto-machinename| replace:: phyboard-pollux-imx8mp-3
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD24.1.0
+.. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
+.. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD24.1.y
+.. |yocto-ref-manual| replace:: :ref:`Yocto Reference Manual (scarthgap) <yocto-man-scarthgap>`
+.. |yocto-ref-manual-kernel-and-bootloader-conf| replace:: :ref:`Yocto Reference Manual <yocto-man-scarthgap-kernel-and-bootloader-conf>`
+.. |yocto-sdk-rev| replace::  5.0.x
+.. |yocto-sdk-a-core| replace:: cortexa53-crypto
+
+.. Ref Substitutions
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd24.1.0_nxp-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd24.1.0_nxp-images>`
+.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd24.1.0_nxp-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd24.1.0_nxp-device-tree>`
+.. |ref-supported-hardware| replace:: :ref:`Supported Hardware <imx8mp-pd24.1.0_nxp-supported-hardware>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx8mp-pd24.1.0_nxp-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd24.1.0_nxp-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd24.1.0_nxp-development>`
+.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd24.1.0_nxp-components>`
+.. |ref-build-uboot| replace:: :ref:`Build U-Boot <imx8mp-pd24.1.0_nxp-development-build-uboot>`
+.. |ref-format-sd| replace:: :ref:`Resizing ext4 Root Filesystem  <imx8mp-pd24.1.0_nxp-format-sd>`
+
+.. IMX8(MP) specific
+.. |gpu-model| replace:: Vivante GC7000UL
+.. |sbc-network| replace::
+   The device tree set up for EQOS Ethernet IP core where the PHY is populated
+   on the |sbc| can be found here:
+   :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L179`.
+.. |pollux-fan-note| replace::
+   Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
+   to GPIO fan due to availability. The PWM fan will not be supported
+   anymore and will not function with the new release.
+
+.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd24.1.0_nxp-components>`
+.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd24.1.0_nxp-components>`
+.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd24.1.0_nxp-components>`
+.. |ubootexternalenv| replace:: U-boot External Environment subsection of the
+   :ref:`device tree overlay section <imx8mp-pd24.1.0_nxp-ubootexternalenv>`
+.. |lvds-display-adapters| replace:: PEB-AV-10
+.. |weston-hdmi-mode| replace:: preferred
+
+.. M-Core specific
+.. |mcore| replace:: M7 Core
+.. |mcore-zephyr-docs| replace:: https://docs.zephyrproject.org/latest/boards/phytec/mimx8mp_phyboard_pollux/doc/index.html
+.. |mcore-jtag-dev| replace:: MIMX8ML8_M7
+.. |mcore-sdk-version| replace:: 2.13.0
+
+.. Powerkey specific
+.. |powerkey-driver| replace:: snvs_pwrkey
+.. |systemd-logind-conf-path-powerkey| replace:: ``/etc/systemd/logind.conf``
+.. |powerkey-input-dev| replace:: 30370000.snvs\:snvs-powerkey
+.. |powerkey-keycode-property| replace:: linux,keycode
+
+.. only:: html
+
+   Documentation in pdf format: `Download <static-pdf-dl_>`_
+
+The table below shows the Compatible BSPs for this manual:
+
+==================== ================ ================ ================= ==========
+Compatible BSPs      BSP Release Type Yocto Version    BSP Release Date  BSP Status
+
+==================== ================ ================ ================= ==========
+|yocto-manifestname| Major            |yocto-codename| 2024/11/06        Released
+==================== ================ ================ ================= ==========
+
+.. include:: ../../intro.rsti
+
+.. _imx8mp-pd24.1.0_nxp-supported-hardware:
+
+Supported Hardware
+------------------
+
+On our web page, you can see all supported Machines with the available Article
+Numbers for this release: |yocto-manifestname| `download <dlpage-bsp_>`_.
+
+If you choose a specific **Machine Name** in the section **Supported Machines**,
+you can see which **Article Numbers** are available under this machine and also
+a short description of the hardware information. In case you only have
+the **Article Number** of your hardware, you can leave the **Machine
+Name** drop-down menu empty and only choose your **Article Number**. Now it
+should show you the necessary **Machine Name** for your specific hardware
+
+.. _imx8mp-pd24.1.0_nxp-components:
+.. include:: components.rsti
+
+.. +---------------------------------------------------------------------------+
+.. Getting Started
+.. +---------------------------------------------------------------------------+
+
+.. _imx8mp-pd24.1.0_nxp-getting-started:
+.. include:: /bsp/getting-started.rsti
+
+First Start-up
+--------------
+
+*  To boot from an SD card, the |ref-bootswitch| needs to be set to the
+   following position:
+
+   .. image:: /bsp/images/dipswitch-4-1000.svg
+      :scale: 400%
+
+*  Insert the SD card
+*  Connect the target and the host with **micro USB** on |ref-debugusbconnector|
+   debug USB
+*  Power up the board
+
+.. +---------------------------------------------------------------------------+
+.. Building the BSP
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/building-bsp.rsti
+
+.. _imx8mp-pd24.1.0_nxp-images:
+
+*  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
+   Bootloader image!
+*  **oftree**: Default kernel device tree
+*  **u-boot-spl.bin**: Secondary program loader (SPL)
+*  **bl31-imx8mp.bin**: ARM Trusted Firmware binary
+*  **lpddr4_pmu_train_2d_dmem_202006.bin,
+   lpddr4_pmu_train_2d_imem_202006.bin**: DDR PHY firmware images
+*  **imx-boot**: Bootloader build by imx-mkimage which includes SPL, U-Boot, ARM
+   Trusted Firmware and DDR firmware. This is the final bootloader image which
+   is bootable.
+*  **fitImage**: Linux kernel FIT image
+*  **fitImage-its\*.its**
+*  **Image**: Linux kernel image
+*  **Image.config**: Kernel configuration
+*  **imx8mp-phyboard-pollux-rdk*.dtb**: Kernel device tree file
+*  **imx8mp-phy*.dtbo**: Kernel device tree overlay files
+*  **phytec-qt6demo-image\*.tar.gz**: Root file system
+*  **phytec-qt6demo-image\*.rootfs.wic.xz**: compressed SD card image
+
+.. +---------------------------------------------------------------------------+
+.. INSTALLING THE OS
+.. +---------------------------------------------------------------------------+
+
+Installing the OS
+=================
+
+Bootmode Switch (S3)
+--------------------
+
+.. tip::
+
+   Hardware revision baseboard: 1552.2
+
+The |sbc| features a boot switch with four individually switchable ports to
+select the |som| default bootsource.
+
+.. _imx8mp-pd24.1.0_nxp-bootswitch:
+.. include:: bootmode-switch.rsti
+
+.. include:: /bsp/imx-common/installing-os.rsti
+
+.. include:: ../efi.rsti
+.. include:: /bsp/installing-distro-efi.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVELOPMENT
+.. +---------------------------------------------------------------------------+
+
+.. _imx8mp-pd24.1.0_nxp-development:
+
+Development
+===========
+
+Starting with this release, the boot behaviour in U-Boot changes. Before, kernel
+and device tree came as separate blobs. Now, both will be included in a single
+FIT image blob. Further, the logic for booting the PHYTEC ampliphy distributions
+is moved to a boot script which itself is part of a separate FIT image blob.
+To revert to the old style of booting, you may do
+
+.. code-block:: console
+
+   run legacyboot
+
+.. note::
+
+   This way of booting is deprecated and will be removed in the next release.
+   By default, booting via this command will return an error as kernel and
+   device tree are missing in the boot partition.
+
+.. include:: ../../imx-common/development/standalone_build_preface.rsti
+
+.. warning::
+   Using the SDK on older host distributions (e.g., Ubuntu 20.04 LTS) with Scarthgap NXP-based BSPs
+   can cause issues when building U-Boot or Linux kernel tools for host use. If you encounter an
+   "undefined reference" error, a workaround is to prepend the host's binutils to the PATH.
+
+   .. code-block:: console
+
+      host$ export PATH=/usr/bin:$PATH
+
+   Run this after sourcing the SDK *environment-setup* file.
+
+   Note, SDK issue has not been observed on newer distributions, such as Ubuntu 22.04, which appear to work
+   without requiring any modifications.
+
+.. _imx8mp-pd24.1.0_nxp-development-build-uboot:
+.. include:: ../../imx-common/development/standalone_build_u-boot_binman.rsti
+.. include:: development/uboot-standalone-fixed-ram-config.rsti
+.. include:: /bsp/imx-common/development/standalone_build_kernel_fit.rsti
+.. include:: ../../imx-common/development/uuu.rsti
+
+.. include:: /bsp/development/host_network_setup.rsti
+
+.. warning::
+
+   Using netboot with standard boot and static IPs does not work yet in this
+   release. Standardboot will always use dhcp.
+
+.. include:: /bsp/imx-common/development/netboot_fit.rsti
+   :end-before: .. network-settings-on-target-marker
+
+Set the bootenv.txt for Netboot
+...............................
+
+Create a bootenv.txt file in your tftp directory and write the following variables into it.
+
+.. code-block::
+
+   nfsroot=/srv/nfs
+   overlays=<overlayconfignames>
+
+<overlayconfignames> has to be replaced with the devicetree overlay config names that you want to use.
+Separate the config names by hashtag. For example:
+
+.. code-block::
+
+   overlays=conf-example-overlay1.dtbo#conf-example-overlay2.dtbo
+
+.. Tip::
+
+   All supported devicetree overlays are in the |ref-dt| chapter. Or can be printed with:
+
+   .. code-block::
+
+      host:~$ dumpimage -l fitImage
+
+.. include:: /bsp/imx-common/development/netboot_fit.rsti
+   :start-after: .. network-settings-on-target-marker
+
+.. include:: /bsp/imx-common/development/development_manifests.rsti
+
+.. include:: /bsp/imx-common/development/master_manifest.rsti
+
+.. _imx8mp-pd24.1.0_nxp-format-sd:
+
+.. include:: /bsp/imx-common/development/format_sd-card.rsti
+
+.. include:: /bsp/imx8/development/legacy_boot_deprecated.rsti
+
+.. +---------------------------------------------------------------------------+
+.. DEVICE TREE
+.. +---------------------------------------------------------------------------+
+
+.. _imx8mp-pd24.1.0_nxp-device-tree:
+.. include:: /bsp/device-tree.rsti
+
+.. code-block::
+   :substitutions:
+
+   imx8mp-isi-csi1.dtbo
+   imx8mp-isi-csi2.dtbo
+   imx8mp-isp-csi1.dtbo
+   imx8mp-isp-csi2.dtbo
+   |dtbo-peb-av-10|
+   imx8mp-phyboard-pollux-peb-wlbt-05.dtbo
+   imx8mp-phycore-no-eth.dtbo
+   imx8mp-phycore-no-rtc.dtbo
+   imx8mp-phycore-no-spiflash.dtbo
+   imx8mp-phycore-rpmsg.dtbo
+   imx8mp-vm016-csi1.dtbo
+   imx8mp-vm016-csi1-fpdlink.dtbo
+   imx8mp-vm016-csi2.dtbo
+   imx8mp-vm016-csi2-fpdlink.dtbo
+   imx8mp-vm017-csi1.dtbo
+   imx8mp-vm017-csi1-fpdlink.dtbo
+   imx8mp-vm017-csi2.dtbo
+   imx8mp-vm017-csi2-fpdlink.dtbo
+
+.. _imx8mp-pd24.1.0_nxp-ubootexternalenv:
+.. include:: ../../dt-overlays.rsti
+
+.. +---------------------------------------------------------------------------+
+.. ACCESSING PERIPHERALS
+.. +---------------------------------------------------------------------------+
+
+.. include:: /bsp/peripherals/introduction.rsti
+
+.. include:: /bsp/imx-common/peripherals/pin-muxing.rsti
+
+The following is an example of the pin muxing of the UART1 device in
+|dt-carrierboard|.dts:
+
+.. code-block::
+
+   pinctrl_uart1: uart1grp {
+           fsl,pins = <
+                   MX8MP_IOMUXC_UART1_RXD_UART1_DCE_RX     0x140
+                   MX8MP_IOMUXC_UART1_TXD_UART1_DCE_TX     0x140
+           >;
+   };
+
+The first part of the string MX8MP_IOMUXC_UART1_RXD_UART1_DCE_RX names the pad
+(in this example UART1_RXD). The second part of the string (UART1_DCE_RX) is the
+desired muxing option for this pad. The pad setting value (hex value on the
+right) defines different modes of the pad, for example, if internal pull
+resistors are activated or not. In this case, the internal resistors are
+disabled.
+
+The device tree representation for UART1 pinmuxing:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L373`
+
+RS232/RS485
+-----------
+
+The |som| supports up to 4 UART units. On the |sbc|, TTL level signals
+of UART1 (the standard console) and UART4 are routed to Silicon Labs CP2105 UART
+to USB converter expansion. This USB is brought out at Micro-USB connector X1.
+UART3 is at X6 (Expansion Connector) at TTL level. UART2 is connected to a
+multi-protocol transceiver for RS-232 and RS-485, available at pin header
+connector |ref-serial| at the RS-232 level, or at the RS-485 level. The
+configuration of the multi-protocol transceiver is done by jumpers |ref-jp3| and
+|ref-jp4| on the baseboard. For more information about the correct setup please
+refer to the |som|/|sbc| Hardware Manual section UARTs.
+
+We use the same device tree node for RS-232 and RS-485. RS-485 mode can be
+enabled with ioctl TIOCSRS485. Also, full-duplex support is also configured
+using ioctls. Have a look at our small example application rs485test, which is
+also included in the BSP. The jumpers |ref-jp3| and |ref-jp4| need to be set
+correctly.
+
+.. include:: /bsp/peripherals/rs232.rsti
+.. include:: /bsp/peripherals/rs485.rsti
+.. include:: /bsp/peripherals/rs485-halfduplex.rsti
+.. include:: /bsp/peripherals/rs485-fullduplex.rsti
+
+The device tree representation for RS232 and RS485:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L412`
+
+.. _imx8mp-pd24.1.0_nxp-network:
+
+Ethernet
+--------
+
+|sbc|-|soc| provides two ethernet interfaces. A gigabit Ethernet is provided by
+our module and board.
+
+.. warning::
+
+   The naming convention of the Ethernet interfaces in the hardware (ethernet0
+   and ethernet1) do not align with the network interfaces (eth0 and eth1) in
+   Linux. So, be aware of these differences:
+
+   | ethernet1 = eth0
+   | ethernet0 = eth1
+
+.. include:: /bsp/peripherals/network.rsti
+
+.. include:: wireless-network.rsti
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :end-before: .. bluetooth_chapter_start_label
+
+Bluetooth is supported on |sbc| with the PEB-WLBT-05 expansion card. How this
+can be activated is described in the WLAN/Bluetooth section.
+
+.. include:: ../../peripherals/wireless-network.rsti
+   :start-after: .. bluetooth_chapter_start_label
+
+.. note::
+
+   If the connection fails with the error message: "Failed to connect:
+   org.bluez.Error.Failed" try restarting PulseAudio with:
+
+   .. code-block:: console
+
+      target:~$ pulseaudio --start
+
+.. include:: /bsp/imx-common/peripherals/sd-card.rsti
+
+DT configuration for the MMC (SD card slot) interface can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L422`
+
+DT configuration for the eMMC interface can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L214`
+
+.. include:: emmc.rsti
+
+.. include:: ../peripherals/spi-master.rsti
+
+The definition of the SPI master node in the device tree can be found here:
+
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L76`
+
+.. include:: /bsp/imx-common/peripherals/gpios.rsti
+
+.. include:: /bsp/peripherals/leds.rsti
+
+Device tree configuration for the User I/O configuration can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L255`
+
+.. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
+
+General I²C1 bus configuration (e.g. |dt-som|.dtsi):
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L113`
+
+General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L239`
+
+EEPROM
+------
+
+On the |som| there is an i2c EEPROM flash populated. It has two addresses. The
+main EEPROM space (bus: I2C-0 address: 0x51) can be accessed via the sysfs
+interface in Linux. The first 256 bytes of the main EEPROM and the ID-page
+(bus: I2C-0 address: 0x59) are used for board detection and must not be
+overwritten. Therefore the ID-page can not be accessed via the sysfs interface.
+Overwriting reserved spaces will result in boot issues.
+
+.. note::
+
+   If you deleted reserved EEPROM spaces, please contact our support!
+
+.. include:: ../peripherals/eeprom.rsti
+
+DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
+found in our PHYTEC git:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
+
+.. include:: ../../peripherals/rtc.rsti
+
+DT representation for I²C RTCs:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L208`
+
+USB Host Controller
+-------------------
+
+The USB controller of the |soc| SoC provides a low-cost connectivity solution
+for numerous consumer portable devices by providing a mechanism for data
+transfer between USB devices with a line/bus speed of up to 4 Gbit/s (SuperSpeed
+'SS'). The USB subsystem has two independent USB controller cores. Both cores
+are capable of acting as a USB peripheral device or a USB host. Each is
+connected to a USB 3.0 PHY.
+
+.. include:: /bsp/peripherals/usb-host.rsti
+
+DT representation for USB Host:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L380`
+
+CAN FD
+------
+
+The |sbc| has two flexCAN interfaces supporting CAN FD. They are supported by
+the Linux standard CAN framework which builds upon then the Linux network
+layer.
+Using this framework, the CAN interfaces behave like an ordinary Linux network
+device, with some additional features special to CAN. More information can be
+found in the Linux Kernel
+documentation: https://www.kernel.org/doc/html/latest/networking/can.html
+
+.. include:: /bsp/peripherals/canfd.rsti
+
+Device Tree CAN configuration of |dt-carrierboard|.dts:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L203`
+
+.. include:: /bsp/peripherals/pcie.rsti
+
+Device Tree PCIe configuration of |dt-carrierboard|.dts:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L345`
+
+Audio
+-----
+
+Playback devices supported for |sbc| are HDMI and the TI TLV320AIC3007 audio
+codec on the PEB-AV-10 connector. On the AV-Connector there is a 3.5mm headset
+jack with OMTP-standard and an 8-pin header. The 8-pin header contains a mono
+speaker, headphones, and line in signals.
+
+.. note::
+
+   Using the PEB-AV-10 connector for display output along HDMI as audio output
+   is not supported. The audio output device must match the video output device.
+
+.. include:: /bsp/peripherals/audio.rsti
+
+Device Tree Audio configuration:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L58`
+
+.. include:: /bsp/peripherals/video.rsti
+
+.. include:: display.rsti
+   :end-before: .. supported-display-interfaces-marker-start
+
+The |sbc| supports up to 3 different display outputs. Two can be used
+simultaneously. The following table shows the required extensions and devicetree
+overlays for the different interfaces.
+
+========= ======================== ======================================
+Interface Expansion                devicetree overlay
+========= ======================== ======================================
+HDMI      |sbc|                    no overlay needed (enabled by default)
+LVDS0     PEB-AV-10                |dtbo-peb-av-10|
+                                   (loaded by default)
+LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
+========= ======================== ======================================
+
+.. include:: display.rsti
+   :start-after: .. supported-display-interfaces-marker-end
+   :end-before: .. no-peb-av-12-marker
+
+.. include:: /bsp/qt6.rsti
+
+.. include:: /bsp/imx-common/peripherals/display.rsti
+
+Device tree description of LVDS-1 and HDMI can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L294`
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L218`
+
+The device tree of LVDS-0 on PEB-AV-10 can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L133`
+
+.. include:: /bsp/peripherals/gpu.rsti
+
+.. include:: ../peripherals/pm.rsti
+
+.. include:: ../peripherals/tm.rsti
+
+The device tree description of GPIO Fan can be found here:
+:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L35`
+
+.. include:: /bsp/peripherals/watchdog.rsti
+
+.. include:: /bsp/imx-common/peripherals/power-key.rsti
+
+.. include:: ../peripherals/npu.rsti
+
+.. include:: ../peripherals/isp.rsti
+
+.. include:: ../peripherals/ocotp-ctrl.rsti
+
+.. +---------------------------------------------------------------------------+
+.. i.MX 8M Plus M7 Core
+.. +---------------------------------------------------------------------------+
+
+.. include:: ../mcu.rsti

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -1,23 +1,23 @@
 .. Download links
 .. |dlpage-bsp| replace:: our BSP
-.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD24.1.0
+.. _dlpage-bsp: https://www.phytec.de/bsp-download/?bsp=BSP-Yocto-NXP-i.MX8MP-PD24.1.1
 .. |dlpage-bsp-link| replace:: |dlpage-bsp|_
 .. |dlpage-product| replace:: https://www.phytec.de/produkte/system-on-modules/phycore-imx-8m-plus/#downloads
 .. |dl-server| replace:: BSP downloads
 .. _dl-server: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/
 .. |dl-server-link| replace:: |dl-server|_
 .. |dl-sdk| replace:: SDK downloads
-.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/sdk/ampliphy-vendor-xwayland/
+.. _dl-sdk: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.1/sdk/ampliphy-vendor/
 .. |dl-sdk-link| replace:: |dl-sdk|_
-.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.wic.xz
-.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
-.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/imx-boot-tools/
-.. |link-bsp-images| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.0/images/ampliphy-vendor-xwayland/phyboard-pollux-imx8mp-3/
+.. |link-image| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.1/images/ampliphy-vendor/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.wic.xz
+.. |link-partup-package| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.1/images/ampliphy-vendor/phyboard-pollux-imx8mp-3/phytec-qt6demo-image-phyboard-pollux-imx8mp-3.rootfs.partup
+.. |link-boot-tools| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.1/images/ampliphy-vendor/phyboard-pollux-imx8mp-3/imx-boot-tools/
+.. |link-bsp-images| replace:: https://download.phytec.de/Software/Linux/BSP-Yocto-i.MX8MP/BSP-Yocto-NXP-i.MX8MP-PD24.1.1/images/ampliphy-vendor/phyboard-pollux-imx8mp-3/
 .. _releasenotes: https://git.phytec.de/phy2octo/tree/releasenotes?h=imx8mp
-.. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.0_nxp.pdf
+.. _`static-pdf-dl`: ../../../_static/imx8mp-pd24.1.1_nxp.pdf
 
 .. IMX8(MP) specific
-.. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2024.04-2.0.0-phy7#n177
+.. _overlaycallback: https://git.phytec.de/u-boot-imx/tree/board/phytec/phycore_imx8mp/phycore-imx8mp.c?h=v2024.04-2.2.2-phy7#n177
 
 .. General Substitutions
 .. |kit| replace:: **phyCORE-i.MX8M Plus Kit**
@@ -41,7 +41,7 @@
 .. |kernel-repo-name| replace:: linux-phytec-imx
 .. |kernel-repo-url| replace:: https://github.com/phytec/linux-phytec-imx
 .. |kernel-socname| replace:: imx8mp
-.. |kernel-tag| replace:: v6.6.23-2.0.0-phy10
+.. |kernel-tag| replace:: v6.6.52-2.2.2-phyx
 .. |emmcdev| replace:: mmcblk2
 .. |led-names| replace:: red:user1, green:user2 and blue:user3
 .. |led-example| replace:: red\\:user1
@@ -60,7 +60,7 @@
 
 .. IMX8(MP) specific
 .. |u-boot-socname-config| replace:: PHYCORE_IMX8MP
-.. |u-boot-tag| replace:: v2024.04_2.0.0-phy7
+.. |u-boot-tag| replace:: v2024.04_2.2.2-phyx
 
 .. RAUC
 .. |rauc-manual| replace:: L-1006e.A6 RAUC Update & Device Management Manual
@@ -73,18 +73,18 @@
 .. |dtbo-peb-av-10| replace:: imx8mp-phyboard-pollux-peb-av-10.dtbo
 
 .. IMX8(MP) specific
-.. |dt-somnetwork| replace:: :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L50`
+.. |dt-somnetwork| replace:: :linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L50`
 
 .. Yocto
 .. |yocto-bootenv-link| replace:: :yocto-bootenv:`scarthgap`
 .. |yocto-bsp-name| replace:: BSP-Yocto-IMX8MP
 .. _yocto-bsp-name: `dl-server`_
 .. |yocto-codename| replace:: Scarthgap
-.. |yocto-distro| replace:: ampliphy-vendor-xwayland
+.. |yocto-distro| replace:: ampliphy-vendor
 .. |yocto-imagename| replace:: phytec-qt6demo-image
 .. |yocto-imageext| replace:: rootfs.wic.xz
 .. |yocto-machinename| replace:: phyboard-pollux-imx8mp-3
-.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD24.1.0
+.. |yocto-manifestname| replace:: BSP-Yocto-NXP-i.MX8MP-PD24.1.1
 .. |yocto-manifestname-master| replace:: BSP-Yocto-Ampliphy-i.MX8MP-master
 .. |yocto-manifestname-y| replace:: BSP-Yocto-NXP-i.MX8MP-PD24.1.y
 .. |yocto-ref-manual| replace:: :ref:`Yocto Reference Manual (scarthgap) <yocto-man-scarthgap>`
@@ -93,34 +93,34 @@
 .. |yocto-sdk-a-core| replace:: cortexa53-crypto
 
 .. Ref Substitutions
-.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd24.1.0_nxp-bootswitch>`
-.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd24.1.0_nxp-images>`
-.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd24.1.0_nxp-components>`
-.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd24.1.0_nxp-device-tree>`
-.. |ref-supported-hardware| replace:: :ref:`Supported Hardware <imx8mp-pd24.1.0_nxp-supported-hardware>`
-.. |ref-getting-started| replace:: :ref:`Getting Started <imx8mp-pd24.1.0_nxp-getting-started>`
-.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd24.1.0_nxp-network>`
-.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd24.1.0_nxp-development>`
-.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd24.1.0_nxp-components>`
-.. |ref-build-uboot| replace:: :ref:`Build U-Boot <imx8mp-pd24.1.0_nxp-development-build-uboot>`
-.. |ref-format-sd| replace:: :ref:`Resizing ext4 Root Filesystem  <imx8mp-pd24.1.0_nxp-format-sd>`
+.. |ref-bootswitch| replace:: :ref:`bootmode switch (S3) <imx8mp-pd24.1.1_nxp-bootswitch>`
+.. |ref-bsp-images| replace:: :ref:`BSP Images <imx8mp-pd24.1.1_nxp-images>`
+.. |ref-debugusbconnector| replace:: :ref:`(X1) <imx8mp-pd24.1.1_nxp-components>`
+.. |ref-dt| replace:: :ref:`device tree <imx8mp-pd24.1.1_nxp-device-tree>`
+.. |ref-supported-hardware| replace:: :ref:`Supported Hardware <imx8mp-pd24.1.1_nxp-supported-hardware>`
+.. |ref-getting-started| replace:: :ref:`Getting Started <imx8mp-pd24.1.1_nxp-getting-started>`
+.. |ref-network| replace:: :ref:`Network Environment Customization <imx8mp-pd24.1.1_nxp-network>`
+.. |ref-setup-network-host| replace:: :ref:`Setup Network Host <imx8mp-pd24.1.1_nxp-development>`
+.. |ref-usb-otg| replace:: :ref:`X5 (upper connector) <imx8mp-pd24.1.1_nxp-components>`
+.. |ref-build-uboot| replace:: :ref:`Build U-Boot <imx8mp-pd24.1.1_nxp-development-build-uboot>`
+.. |ref-format-sd| replace:: :ref:`Resizing ext4 Root Filesystem  <imx8mp-pd24.1.1_nxp-format-sd>`
 
 .. IMX8(MP) specific
 .. |gpu-model| replace:: Vivante GC7000UL
 .. |sbc-network| replace::
    The device tree set up for EQOS Ethernet IP core where the PHY is populated
    on the |sbc| can be found here:
-   :linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L179`.
+   :linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L179`.
 .. |pollux-fan-note| replace::
    Starting with BSP-Yocto-i.MX8MP-PD22.1.1 we have to switch from PWM fan
    to GPIO fan due to availability. The PWM fan will not be supported
    anymore and will not function with the new release.
 
-.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd24.1.0_nxp-components>`
-.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd24.1.0_nxp-components>`
-.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd24.1.0_nxp-components>`
+.. |ref-serial| replace:: :ref:`X2 <imx8mp-pd24.1.1_nxp-components>`
+.. |ref-jp3| replace:: :ref:`JP3 <imx8mp-pd24.1.1_nxp-components>`
+.. |ref-jp4| replace:: :ref:`JP4 <imx8mp-pd24.1.1_nxp-components>`
 .. |ubootexternalenv| replace:: U-boot External Environment subsection of the
-   :ref:`device tree overlay section <imx8mp-pd24.1.0_nxp-ubootexternalenv>`
+   :ref:`device tree overlay section <imx8mp-pd24.1.1_nxp-ubootexternalenv>`
 .. |lvds-display-adapters| replace:: PEB-AV-10
 .. |weston-hdmi-mode| replace:: preferred
 
@@ -142,16 +142,16 @@
 
 The table below shows the Compatible BSPs for this manual:
 
-==================== ================ ================ ================= ==========
+==================== ================ ================ ================= ===========
 Compatible BSPs      BSP Release Type Yocto Version    BSP Release Date  BSP Status
 
-==================== ================ ================ ================= ==========
-|yocto-manifestname| Major            |yocto-codename| 2024/11/06        Released
-==================== ================ ================ ================= ==========
+==================== ================ ================ ================= ===========
+|yocto-manifestname| Minor            |yocto-codename| 2026/06/XX        in progress
+==================== ================ ================ ================= ===========
 
 .. include:: ../../intro.rsti
 
-.. _imx8mp-pd24.1.0_nxp-supported-hardware:
+.. _imx8mp-pd24.1.1_nxp-supported-hardware:
 
 Supported Hardware
 ------------------
@@ -166,14 +166,14 @@ the **Article Number** of your hardware, you can leave the **Machine
 Name** drop-down menu empty and only choose your **Article Number**. Now it
 should show you the necessary **Machine Name** for your specific hardware
 
-.. _imx8mp-pd24.1.0_nxp-components:
+.. _imx8mp-pd24.1.1_nxp-components:
 .. include:: components.rsti
 
 .. +---------------------------------------------------------------------------+
 .. Getting Started
 .. +---------------------------------------------------------------------------+
 
-.. _imx8mp-pd24.1.0_nxp-getting-started:
+.. _imx8mp-pd24.1.1_nxp-getting-started:
 .. include:: /bsp/getting-started.rsti
 
 First Start-up
@@ -196,7 +196,7 @@ First Start-up
 
 .. include:: /bsp/building-bsp.rsti
 
-.. _imx8mp-pd24.1.0_nxp-images:
+.. _imx8mp-pd24.1.1_nxp-images:
 
 *  **u-boot.bin**: Binary compiled U-boot bootloader (U-Boot). Not the final
    Bootloader image!
@@ -234,7 +234,7 @@ Bootmode Switch (S3)
 The |sbc| features a boot switch with four individually switchable ports to
 select the |som| default bootsource.
 
-.. _imx8mp-pd24.1.0_nxp-bootswitch:
+.. _imx8mp-pd24.1.1_nxp-bootswitch:
 .. include:: bootmode-switch.rsti
 
 .. include:: /bsp/imx-common/installing-os.rsti
@@ -246,7 +246,7 @@ select the |som| default bootsource.
 .. DEVELOPMENT
 .. +---------------------------------------------------------------------------+
 
-.. _imx8mp-pd24.1.0_nxp-development:
+.. _imx8mp-pd24.1.1_nxp-development:
 
 Development
 ===========
@@ -283,7 +283,7 @@ To revert to the old style of booting, you may do
    Note, SDK issue has not been observed on newer distributions, such as Ubuntu 22.04, which appear to work
    without requiring any modifications.
 
-.. _imx8mp-pd24.1.0_nxp-development-build-uboot:
+.. _imx8mp-pd24.1.1_nxp-development-build-uboot:
 .. include:: ../../imx-common/development/standalone_build_u-boot_binman.rsti
 .. include:: development/uboot-standalone-fixed-ram-config.rsti
 .. include:: /bsp/imx-common/development/standalone_build_kernel_fit.rsti
@@ -331,7 +331,7 @@ Separate the config names by hashtag. For example:
 
 .. include:: /bsp/imx-common/development/master_manifest.rsti
 
-.. _imx8mp-pd24.1.0_nxp-format-sd:
+.. _imx8mp-pd24.1.1_nxp-format-sd:
 
 .. include:: /bsp/imx-common/development/format_sd-card.rsti
 
@@ -341,7 +341,7 @@ Separate the config names by hashtag. For example:
 .. DEVICE TREE
 .. +---------------------------------------------------------------------------+
 
-.. _imx8mp-pd24.1.0_nxp-device-tree:
+.. _imx8mp-pd24.1.1_nxp-device-tree:
 .. include:: /bsp/device-tree.rsti
 
 .. code-block::
@@ -366,7 +366,7 @@ Separate the config names by hashtag. For example:
    imx8mp-vm017-csi2.dtbo
    imx8mp-vm017-csi2-fpdlink.dtbo
 
-.. _imx8mp-pd24.1.0_nxp-ubootexternalenv:
+.. _imx8mp-pd24.1.1_nxp-ubootexternalenv:
 .. include:: ../../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
@@ -397,7 +397,7 @@ resistors are activated or not. In this case, the internal resistors are
 disabled.
 
 The device tree representation for UART1 pinmuxing:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L373`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L373`
 
 RS232/RS485
 -----------
@@ -424,9 +424,9 @@ correctly.
 .. include:: /bsp/peripherals/rs485-fullduplex.rsti
 
 The device tree representation for RS232 and RS485:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L412`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L412`
 
-.. _imx8mp-pd24.1.0_nxp-network:
+.. _imx8mp-pd24.1.1_nxp-network:
 
 Ethernet
 --------
@@ -468,10 +468,10 @@ can be activated is described in the WLAN/Bluetooth section.
 .. include:: /bsp/imx-common/peripherals/sd-card.rsti
 
 DT configuration for the MMC (SD card slot) interface can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L422`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L422`
 
 DT configuration for the eMMC interface can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L214`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L214`
 
 .. include:: emmc.rsti
 
@@ -479,22 +479,22 @@ DT configuration for the eMMC interface can be found here:
 
 The definition of the SPI master node in the device tree can be found here:
 
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L76`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L76`
 
 .. include:: /bsp/imx-common/peripherals/gpios.rsti
 
 .. include:: /bsp/peripherals/leds.rsti
 
 Device tree configuration for the User I/O configuration can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L255`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L255`
 
 .. include:: /bsp/imx-common/peripherals/i2c-bus.rsti
 
 General I²C1 bus configuration (e.g. |dt-som|.dtsi):
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L113`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L113`
 
 General I²C2 bus configuration (e.g. |dt-carrierboard|.dts)
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L239`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L239`
 
 EEPROM
 ------
@@ -514,12 +514,12 @@ Overwriting reserved spaces will result in boot issues.
 
 DT representation, e.g. in |som| file imx8mp-phycore-som.dtsi can be
 found in our PHYTEC git:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L201`
 
 .. include:: ../../peripherals/rtc.rsti
 
 DT representation for I²C RTCs:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L208`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phycore-som.dtsi#L208`
 
 USB Host Controller
 -------------------
@@ -534,7 +534,7 @@ connected to a USB 3.0 PHY.
 .. include:: /bsp/peripherals/usb-host.rsti
 
 DT representation for USB Host:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L380`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L380`
 
 CAN FD
 ------
@@ -550,12 +550,12 @@ documentation: https://www.kernel.org/doc/html/latest/networking/can.html
 .. include:: /bsp/peripherals/canfd.rsti
 
 Device Tree CAN configuration of |dt-carrierboard|.dts:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L203`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L203`
 
 .. include:: /bsp/peripherals/pcie.rsti
 
 Device Tree PCIe configuration of |dt-carrierboard|.dts:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L345`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L345`
 
 Audio
 -----
@@ -573,7 +573,7 @@ speaker, headphones, and line in signals.
 .. include:: /bsp/peripherals/audio.rsti
 
 Device Tree Audio configuration:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L58`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L58`
 
 .. include:: /bsp/peripherals/video.rsti
 
@@ -602,11 +602,11 @@ LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
 .. include:: /bsp/imx-common/peripherals/display.rsti
 
 Device tree description of LVDS-1 and HDMI can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L294`
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L218`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L294`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L218`
 
 The device tree of LVDS-0 on PEB-AV-10 can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L133`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-peb-av-10.dtso#L133`
 
 .. include:: /bsp/peripherals/gpu.rsti
 
@@ -615,7 +615,7 @@ The device tree of LVDS-0 on PEB-AV-10 can be found here:
 .. include:: ../peripherals/tm.rsti
 
 The device tree description of GPIO Fan can be found here:
-:linux-phytec-imx:`tree/v6.6.23-2.0.0-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L35`
+:linux-phytec-imx:`tree/v6.6.52-2.2.2-phy10/arch/arm64/boot/dts/freescale/imx8mp-phyboard-pollux-rdk.dts#L35`
 
 .. include:: /bsp/peripherals/watchdog.rsti
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -163,6 +163,14 @@ latex_documents = [
         False,
     ),
     (
+        'bsp/imx8/imx8mp/pd24.1.1_nxp',
+        'imx8mp-pd24.1.1_nxp.tex',
+        'i.MX 8M Plus BSP Manual PD24.1.1 NXP DRAFT',
+        'PHYTEC Messtechnik GmbH',
+        'manual',
+        False,
+    ),
+    (
         'bsp/imx8/imx8mp/pd24.1.0_nxp',
         'imx8mp-pd24.1.0_nxp.tex',
         'phyCORE-i.MX 8M Plus BSP Manual PD24.1.0 NXP',

--- a/source/conf.py
+++ b/source/conf.py
@@ -165,7 +165,7 @@ latex_documents = [
     (
         'bsp/imx8/imx8mp/pd24.1.1_nxp',
         'imx8mp-pd24.1.1_nxp.tex',
-        'i.MX 8M Plus BSP Manual PD24.1.1 NXP DRAFT',
+        'phyCORE-i.MX 8M Plus BSP Manual PD24.1.1 NXP',
         'PHYTEC Messtechnik GmbH',
         'manual',
         False,


### PR DESCRIPTION
This PR creates a new release manual (copy from pd24.1.0) for an upcoming minor release and sets basic known parameters.