### PR TITLE
bsp: imx9: imx95-fpsc: Add eeprom read/write example

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -475,6 +475,8 @@ And on the |sbc| carrier board:
 Device Tree Reference for Carrier Board:
 :linux-phytec-imx:`tree/v6.12.34-2.1.0-phy9/arch/arm64/boot/dts/freescale/imx95-phyflex-libra-rdk.dts#L339`
 
+.. include:: /bsp/imx-common/peripherals/eeprom.rsti
+
 .. include:: /bsp/peripherals/rtc.rsti
 
 DT representation for I²C RTCs:


### PR DESCRIPTION
Include explanations how to read  and write to an i2c eeprom in U-Boot and linux.