### PR TITLE
BSPIMX95-246 Make e.MMC dev for installing-os configurable

### DIFF
--- a/source/bsp/imx-common/installing-os.rsti
+++ b/source/bsp/imx-common/installing-os.rsti
@@ -46,7 +46,7 @@ to the e.MMC of your device:
 .. code-block:: console
    :substitutions:
 
-   host:~$ scp /srv/tftp/|yocto-imagename|-|yocto-machinename|.rootfs.wic.* root@192.168.3.11:/tmp && ssh root@192.168.3.11 "bmaptool copy /tmp/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/mmcblk2"
+   host:~$ scp /srv/tftp/|yocto-imagename|-|yocto-machinename|.rootfs.wic.* root@192.168.3.11:/tmp && ssh root@192.168.3.11 "bmaptool copy /tmp/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/|emmcdev|"
 
 Flash e.MMC via Network in Linux on Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,7 +64,7 @@ the target with a one-line command:
 .. code-block:: console
    :substitutions:
 
-   target:~$ scp <USER>@192.168.3.10:/srv/tftp/|yocto-imagename|-|yocto-machinename|.rootfs.wic.* /tmp && bmaptool copy /tmp/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/mmcblk2
+   target:~$ scp <USER>@192.168.3.10:/srv/tftp/|yocto-imagename|-|yocto-machinename|.rootfs.wic.* /tmp && bmaptool copy /tmp/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/|emmcdev|
 
 Flash e.MMC from Network in U-Boot on Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,7 +213,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
    .. code-block:: console
       :substitutions:
 
-      target:~$ bmaptool copy /mnt/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/mmcblk2
+      target:~$ bmaptool copy /mnt/|yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/|emmcdev|
 
 *  After a complete write, your board can boot from e.MMC.
 
@@ -300,7 +300,7 @@ image saved on the SD card.
    .. code-block:: console
       :substitutions:
 
-      target:~$ partup install |yocto-imagename|-|yocto-machinename|.rootfs.partup /dev/mmcblk2
+      target:~$ partup install |yocto-imagename|-|yocto-machinename|.rootfs.partup /dev/|emmcdev|
 
    Flashing the partup package has the advantage of using the full capacity of
    the e.MMC device, adjusting partitions accordingly.
@@ -312,7 +312,7 @@ image saved on the SD card.
       .. code-block:: console
          :substitutions:
 
-         target:~$ bmaptool copy |yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/mmcblk2
+         target:~$ bmaptool copy |yocto-imagename|-|yocto-machinename|.|yocto-imageext| /dev/|emmcdev|
 
       Keep in mind that the root partition does not make use of the full space when
       flashing with ``bmaptool``.

--- a/source/bsp/imx-common/installing-os.rsti
+++ b/source/bsp/imx-common/installing-os.rsti
@@ -139,14 +139,15 @@ Load your image via network to RAM:
 Write the image to the e.MMC:
 
 .. code-block::
+   :substitutions:
 
-   u-boot=> mmc dev 2
+   u-boot=> mmc dev |u-boot-emmc-devno|
    switch to partitions #0, OK
-   mmc2(part 0) is current device
+   mmc|u-boot-emmc-devno|(part 0) is current device
    u-boot=> setexpr nblk ${filesize} / 0x200
    u-boot=> mmc write ${loadaddr} 0x0 ${nblk}
 
-   MMC write: dev # 2, block # 0, count 1780942 ... 1780942 blocks written: OK
+   MMC write: dev # |u-boot-emmc-devno|, block # 0, count 1780942 ... 1780942 blocks written: OK
 
 Flash e.MMC U-Boot image via Network from running U-Boot
 ........................................................
@@ -165,7 +166,7 @@ Load image over tftp into RAM and then write it to e.MMC:
 
    u-boot=> tftp ${loadaddr} imx-boot
    u-boot=> setexpr nblk ${filesize} / 0x200
-   u-boot=> mmc dev 2
+   u-boot=> mmc dev |u-boot-emmc-devno|
    u-boot=> mmc write ${loadaddr} |u-boot-mmc-flash-offset| ${nblk}
 
 .. hint::
@@ -208,7 +209,7 @@ need a complete image saved on the USB stick and a bootable WIC image. (e.g.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the |som| e.MMC (MMC device 2 without partition):
+*  Write the image to the |som| e.MMC (MMC device |u-boot-emmc-devno| without partition):
 
    .. code-block:: console
       :substitutions:
@@ -253,14 +254,15 @@ Load your image from the USB device to RAM:
 Write the image to the e.MMC:
 
 .. code-block::
+   :substitutions:
 
-   u-boot=> mmc dev 2
+   u-boot=> mmc dev |u-boot-emmc-devno|
    switch to partitions #0, OK
-   mmc2(part 0) is current device
+   mmc|u-boot-emmc-devno|(part 0) is current device
    u-boot=> setexpr nblk ${filesize} / 0x200
    u-boot=> mmc write 0x58000000 0x0 ${nblk}
 
-   MMC write: dev # 2, block # 0, count 1024000 ... 1024000 blocks written: OK
+   MMC write: dev # |u-boot-emmc-devno|, block # 0, count 1024000 ... 1024000 blocks written: OK
    u-boot=> boot
 
 .. flash-emmc-from-sdcard-marker
@@ -294,7 +296,7 @@ image saved on the SD card.
       |yocto-imagename|-|yocto-machinename|.|yocto-imageext|
       |yocto-imagename|-|yocto-machinename|.rootfs.wic.bmap
 
-*  Write the image to the |som| e.MMC (MMC device 2 **without**
+*  Write the image to the |som| e.MMC (MMC device |u-boot-emmc-devno| **without**
    partition) using `partup`_:
 
    .. code-block:: console
@@ -351,24 +353,26 @@ Flash e.MMC from SD card in U-Boot on Target
 *  Switch the mmc dev to e.MMC:
 
    .. code-block::
+      :substitutions:
 
       u-boot=> mmc list
       FSL_SDHC: 1 (SD)
-      FSL_SDHC: 2 (eMMC)
-      u-boot=> mmc dev 2
+      FSL_SDHC: |u-boot-emmc-devno| (eMMC)
+      u-boot=> mmc dev |u-boot-emmc-devno|
       switch to partitions #0, OK
-      mmc2(part 0) is current device
+      mmc|u-boot-emmc-devno|(part 0) is current device
 
 *  Flash your WIC image (for example |yocto-imagename|.rootfs.wic)
    from the SD card to e.MMC. This will partition the card and copy imx-boot,
    Image, dtb, dtbo, and root file system to e.MMC.
 
    .. code-block::
+      :substitutions:
 
       u-boot=> setexpr nblk ${filesize} / 0x200
       u-boot=> mmc write ${loadaddr} 0x0 ${nblk}
 
-      MMC write: dev # 2, block # 0, count 1780942 ... 1780942 blocks written: OK
+      MMC write: dev # |u-boot-emmc-devno|, block # 0, count 1780942 ... 1780942 blocks written: OK
 
 *  Power off the board and change the |ref-bootswitch| to e.MMC.
 


### PR DESCRIPTION
In the installing os chapter the e.MMC device is hardcoded to 2. 
This does not fit for i.MX95. 
So use the existing substitutions to make it configurable.