### PR TITLE
BSPIMX95-230: i.MX95 ethernet update and more

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -182,7 +182,7 @@ substitutions are used.
 
 
 Internal vs. external Links
-..............
+...........................
 
 When linking to internal (doc-bsp-yocto) documents or chapters,
 cross-references must be used. Referencing via external links is not allowed as

--- a/source/bsp/imx8/imx8mm/pd25.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.1.rst
@@ -306,46 +306,7 @@ After saving the changes, follow the remaining steps from |ref-build-uboot|.
 
 .. include:: /bsp/imx-common/development/format_sd-card.rsti
 
-.. include:: /bsp/development/ampliphy-boot.rsti
-   :end-before: .. ampliphy-boot-supported-bootscripts-marker
-
-.. code-block::
-
-   mmc_boot
-   mmc_boot_fit
-   net_boot_fit
-
-.. include:: /bsp/development/ampliphy-boot.rsti
-   :start-after: .. ampliphy-boot-supported-bootscripts-marker
-
-For the |kit|, the default values are defined in the U-Boot devicetree
-(e.g. arch/arm/dts/|dt-carrierboard|-u-boot.dtsi):
-
-.. code-block::
-
-   bootstd {
-           bootph-verify;
-           compatible = "u-boot,boot-std";
-
-           filename-prefixes = "/", "/boot/";
-           bootdev-order = "mmc2", "mmc1", "ethernet";
-
-           rauc {
-                   compatible = "u-boot,distro-rauc";
-           };
-
-           script {
-                   compatible = "u-boot,script";
-           };
-   };
-
-The filename-prefixes property describes the paths that will be searched for
-the bootscripts. In this case this is the root of the partition as well as the
-boot folder. The bootdev-order property sets the default value for the
-boot_targets variable. The supported bootmeths will also be named. In this case
-the script and rauc bootmethods are supported.
-
-.. include:: /bsp/development/fitImages.rsti
+.. include:: /bsp/imx8/development/legacy_boot_deprecated.rsti
 
 .. +---------------------------------------------------------------------------+
 ..                               DEVICE TREE
@@ -375,7 +336,7 @@ the script and rauc bootmethods are supported.
    imx8mm-phycore-rpmsg.dtbo
 
 .. _imx8mm-dt-overlays:
-.. include:: /bsp/dt-overlays-ampliphy-boot.rsti
+.. include:: ../../dt-overlays.rsti
 
 .. +---------------------------------------------------------------------------+
 ..                        ACCESSING PERIPHERALS

--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -379,9 +379,9 @@ The device tree representation for UART1 pinmuxing:
 Ethernet
 --------
 
-|sbc|-|soc| provides three ethernet interfaces. A gigabit Ethernet is provided
+|sbc|-|soc| provides three ethernet interfaces. Gigabit Ethernet is provided
 by our module and board. Additionally there is a 10Gbit Ethernet. Currently
-only the one Gigabit Ethernet ports are supported (Ethernet1 and Ethernet2).
+only the Gigabit Ethernet ports are supported (Ethernet1 and Ethernet2).
 
 .. include:: /bsp/peripherals/network.rsti
 


### PR DESCRIPTION
Started of with a small ethernet chapter update for i.MX95 but the found also other stuff looking into the documentation:
- Rewording of Ethernet Chapter for i.MX95
- Remove ampliphy-boot documentation for i.MX8MM PD25.1.1 as it is not available there
- Small fix in CONTRIBUTING.rst