### PR TITLE
bsp: {imx8,imx9}: Restore accidentally removed NXP EULA note

### DIFF
--- a/source/bsp/imx8/imx8mm/head.rst
+++ b/source/bsp/imx8/imx8mm/head.rst
@@ -178,6 +178,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mm-head-images:
 

--- a/source/bsp/imx8/imx8mm/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd22.1.1.rst
@@ -263,6 +263,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mm-pd22.1.1-images:
 

--- a/source/bsp/imx8/imx8mm/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd23.1.0.rst
@@ -361,6 +361,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mm-pd23.1.0-images:
 

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -179,6 +179,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mm-pd25.1.0-images:
 

--- a/source/bsp/imx8/imx8mm/pd25.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.1.rst
@@ -179,6 +179,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mm-pd25.1.1-images:
 

--- a/source/bsp/imx8/imx8mn/head.rst
+++ b/source/bsp/imx8/imx8mn/head.rst
@@ -165,6 +165,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mn-head-images:
 

--- a/source/bsp/imx8/imx8mn/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mn/pd22.1.1.rst
@@ -254,6 +254,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mn-pd22.1.1-images:
 

--- a/source/bsp/imx8/imx8mn/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mn/pd23.1.0.rst
@@ -352,6 +352,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mn-pd23.1.0-images:
 

--- a/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
@@ -186,6 +186,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-fpsc-alpha1-images:
 

--- a/source/bsp/imx8/imx8mp-fpsc/head.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/head.rst
@@ -188,6 +188,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-fpsc-head-images:
 

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -190,6 +190,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-head-images:
 

--- a/source/bsp/imx8/imx8mp/mainline-head.rst
+++ b/source/bsp/imx8/imx8mp/mainline-head.rst
@@ -171,6 +171,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-mainline-head-images:
 

--- a/source/bsp/imx8/imx8mp/pd22.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.1.rst
@@ -276,6 +276,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd22.1.1-images:
 

--- a/source/bsp/imx8/imx8mp/pd22.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd22.1.2.rst
@@ -275,6 +275,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd22.1.2-images:
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -377,6 +377,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd23.1.0-images:
 

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -195,6 +195,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd24.1.0_nxp-images:
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1.rst
@@ -363,6 +363,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd24.1.1-images:
 

--- a/source/bsp/imx8/imx8mp/pd24.1.2.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.2.rst
@@ -171,6 +171,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx8mp-pd24.1.2-images:
 

--- a/source/bsp/imx9/imx91-93/head.rst
+++ b/source/bsp/imx9/imx91-93/head.rst
@@ -221,6 +221,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-head-images:
 

--- a/source/bsp/imx9/imx91-93/pd24.1.0.rst
+++ b/source/bsp/imx9/imx91-93/pd24.1.0.rst
@@ -169,6 +169,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-pd24.1.0-images:
 

--- a/source/bsp/imx9/imx91-93/pd24.1.1.rst
+++ b/source/bsp/imx9/imx91-93/pd24.1.1.rst
@@ -177,6 +177,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-PD24.1.1-images:
 

--- a/source/bsp/imx9/imx91-93/pd24.2.0.rst
+++ b/source/bsp/imx9/imx91-93/pd24.2.0.rst
@@ -179,6 +179,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-PD24.2.0-images:
 

--- a/source/bsp/imx9/imx91-93/pd24.2.1.rst
+++ b/source/bsp/imx9/imx91-93/pd24.2.1.rst
@@ -182,6 +182,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-PD24.2.1-images:
 

--- a/source/bsp/imx9/imx91-93/pd24.2.2.rst
+++ b/source/bsp/imx9/imx91-93/pd24.2.2.rst
@@ -211,6 +211,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-PD24.2.2-images:
 

--- a/source/bsp/imx9/imx91-93/pd26.1.0.rst
+++ b/source/bsp/imx9/imx91-93/pd26.1.0.rst
@@ -221,6 +221,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx93-PD26.1.0-images:
 

--- a/source/bsp/imx9/imx95-fpsc/alpha1.rst
+++ b/source/bsp/imx9/imx95-fpsc/alpha1.rst
@@ -177,6 +177,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx95-fpsc-alpha1-images:
 

--- a/source/bsp/imx9/imx95-fpsc/alpha2.rst
+++ b/source/bsp/imx9/imx95-fpsc/alpha2.rst
@@ -177,6 +177,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx95-fpsc-alpha2-images:
 

--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -177,6 +177,19 @@ First Start-up
 .. +---------------------------------------------------------------------------+
 
 .. include:: /bsp/building-bsp.rsti
+   :end-before: .. nxp-eula-marker
+*  Open the main configuration file and accept the GPU and VPU binary license
+   agreements. Do this by uncommenting the corresponding line, as below.
+
+   .. code-block:: console
+
+      host:~/yocto/build$ vim conf/local.conf
+      # Uncomment to accept NXP EULA
+      # EULA can be found under ../sources/meta-freescale/EULA
+      ACCEPT_FSL_EULA = "1"
+
+.. include:: /bsp/building-bsp.rsti
+   :start-after: .. nxp-eula-marker
 
 .. _imx95-fpsc-head-images:
 


### PR DESCRIPTION
Commit 8aea814c11aefb0a97753aa4481d6e061d3cc199 tried to move NXP EULA note from the general documentation file to NXP specific documentations. But the commit just removed the EULA note.

Restore the NXP EULA note for the NXP based vendor releases.