### PR TITLE
bsp: imx9: Remove SBC mention from tpm.rsti

### DIFF
--- a/source/bsp/peripherals/tpm.rsti
+++ b/source/bsp/peripherals/tpm.rsti
@@ -1,8 +1,15 @@
 TPM
 ---
 
-The |sbc| is equipped with a Trusted Platform Module (TPM)
+Some carrier boards/SOMs are equipped with a Trusted Platform Module (TPM)
 that provides hardware-based security functions.
+
+.. note::
+
+  To check if TPM is supported on your hardware, refer to the hardware manual
+  for your carrier board/SOM on the download page: |dlpage-product|.
+  Alternatively, check whether a TPM device file (``/dev/tpm*``)
+  exists on your target system.
 
 Here are some useful examples to work with the TPM
 


### PR DESCRIPTION
The documentation for imx91-93 states, that phyBOARD-Segin/Nash i.MX 91/93 is equipped with a TPM. This is not true, as Segin has no such module. The change is to remove the |sbc| mention and add a note to the user, to check their hardware specs.

Before the change (imx91-93):
<img width="714" height="167" alt="grafik" src="https://github.com/user-attachments/assets/4b6331f4-55d2-45e5-aecd-e0d0375b98dc" />

After this PR:
<img width="714" height="333" alt="grafik" src="https://github.com/user-attachments/assets/0c4e8be8-b598-41ed-91c4-2f397c873fc1" />