### PR TITLE
i.MX8MP: Update display chapter

### DIFF
--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -87,7 +87,7 @@ Dual Display
    together.
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
-have to be set to the:
+need to be configured as follows:
 
 .. code-block::
    :substitutions:

--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -18,16 +18,24 @@ LVDS1     |sbc| AC200              imx8mp-phyboard-pollux-etml1010g3dra.dtbo
                                    (disabled if PEB-AV-10 display overlay is used)
 ========= ======================== ======================================
 
+The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-10).
+
+To select a different LVDS interface or display, edit ``/boot/overlays.txt`` and
+update the ``fit_overlay_conf`` entry with the appropriate overlay from the table
+above. The ``fit_overlay_conf`` value must reference the FIT overlay configuration
+name, which uses the ``conf-`` prefix.
+
+.. code-block::
+
+   fit_overlay_conf=conf-imx8mp-phyboard-pollux-etml1010g3dra.dtbo
+
+Device tree configurations can be added as a ``#``-separated list but adding two LVDS
+related overlays at a time will not work. Changes will have an effect after reboot.
+
 .. note::
 
    *  When changing Weston output, make sure to match the audio output as well.
    *  LVDS0 (PEB-AV-10) and LVDS1 (onboard) can not be used at the same time.
-
-HDMI is always enabled in the devicetree. The other interfaces can be enabled
-with Device Tree Overlay.
-
-The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-010). We support a
-10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
 
 .. note::
 
@@ -38,7 +46,7 @@ The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-010). We support a
 Weston Configuration
 ....................
 
-In order to get an output from Weston on the correct display, it still needs to
+In order to get an output from Weston on the correct display, it also needs to
 be configured correctly. This will be done at ``/etc/xdg/weston/weston.ini``.
 
 Single Display
@@ -59,9 +67,6 @@ In our BSP, the default Weston output is set to HDMI.
 
 When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
 the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
-If you want to use LVDS channel 1 (cables connected directly to the
-phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
-Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 .. code-block::
 
@@ -78,7 +83,7 @@ Dual Display
 
 .. note::
 
-   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
+   For dual display output you can not use LVDS1 (onboard) and HDMI
    together.
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes

--- a/source/bsp/imx8/imx8mp/display.rsti
+++ b/source/bsp/imx8/imx8mp/display.rsti
@@ -1,9 +1,7 @@
 Display
 -------
 
-.. supported-display-interfaces-marker-start
-
-The |sbc| supports up to 4 different display outputs. Three can be used
+The |sbc| supports up to 3 different display outputs. Two can be used
 simultaneously. The following table shows the required extensions and devicetree
 overlays for the different interfaces.
 
@@ -11,13 +9,14 @@ overlays for the different interfaces.
 Interface Expansion                devicetree overlay
 ========= ======================== ======================================
 HDMI      |sbc|                    no overlay needed (enabled by default)
-LVDS0     PEB-AV-10                |dtbo-peb-av-10|
+LVDS0     PEB-AV-10 AC209          imx8mp-phyboard-pollux-peb-av-10-ph128800t006.dtbo
                                    (loaded by default)
-LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
-MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo
+LVDS0     PEB-AV-10 AC200          imx8mp-phyboard-pollux-peb-av-10-etml1010g3dra.dtbo
+LVDS1     |sbc| AC209              imx8mp-phyboard-pollux-ph128800t006.dtbo
+                                   (disabled if PEB-AV-10 display overlay is used)
+LVDS1     |sbc| AC200              imx8mp-phyboard-pollux-etml1010g3dra.dtbo
+                                   (disabled if PEB-AV-10 display overlay is used)
 ========= ======================== ======================================
-
-.. supported-display-interfaces-marker-end
 
 .. note::
 
@@ -94,41 +93,4 @@ have to be set to the:
 
    [output]
    name=LVDS-1
-   mode=current
-
-.. no-peb-av-12-marker
-
-For dual display at LVDS0 (PEB-AV-010) and MIPI (PEB-AV-012), both dtbos need to
-be loaded at the bootenv.txt and the weston.ini should look like this:
-
-.. code-block::
-   :substitutions:
-
-   [output]
-   name=HDMI-A-1
-   mode=off
-
-   [output]
-   name=LVDS-1
-   mode=current
-
-Triple Display
-~~~~~~~~~~~~~~
-
-Three outputs: HDMI, LVDS-1 (PEB-AV-10), and LVDS-2 (PEB-AV-12). Remember to
-load both dtbos for LVDS interfaces.
-
-.. code-block::
-   :substitutions:
-
-   [output]
-   name=HDMI-A-1
-   mode=|weston-hdmi-mode|
-
-   [output]
-   name=LVDS-1
-   mode=current
-
-   [output]
-   name=LVDS-2
    mode=current

--- a/source/bsp/imx8/imx8mp/head.rst
+++ b/source/bsp/imx8/imx8mp/head.rst
@@ -573,28 +573,6 @@ Device Tree Audio configuration:
 .. include:: /bsp/peripherals/video.rsti
 
 .. include:: display.rsti
-   :end-before: .. supported-display-interfaces-marker-start
-
-The |sbc| supports up to 3 different display outputs. Two can be used
-simultaneously. The following table shows the required extensions and devicetree
-overlays for the different interfaces.
-
-========= ======================== ======================================
-Interface Expansion                devicetree overlay
-========= ======================== ======================================
-HDMI      |sbc|                    no overlay needed (enabled by default)
-LVDS0     PEB-AV-10 AC209          imx8mp-phyboard-pollux-peb-av-10-ph128800t006.dtbo
-                                   (loaded by default)
-LVDS0     PEB-AV-10 AC200          imx8mp-phyboard-pollux-peb-av-10-etml1010g3dra.dtbo
-LVDS1     |sbc| AC209              imx8mp-phyboard-pollux-ph128800t006.dtbo
-                                   (disabled if PEB-AV-10 display overlay is used)
-LVDS1     |sbc| AC200              imx8mp-phyboard-pollux-etml1010g3dra.dtbo
-                                   (disabled if PEB-AV-10 display overlay is used)
-========= ======================== ======================================
-
-.. include:: display.rsti
-   :start-after: .. supported-display-interfaces-marker-end
-   :end-before: .. no-peb-av-12-marker
 
 .. include:: /bsp/qt6.rsti
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -1768,7 +1768,134 @@ Device Tree Audio configuration:
 
 .. include:: /bsp/peripherals/video.rsti
 
-.. include:: display.rsti
+Display
+-------
+
+The |sbc| supports up to 4 different display outputs. Three can be used
+simultaneously. The following table shows the required extensions and devicetree
+overlays for the different interfaces.
+
+========= ======================== ======================================
+Interface Expansion                devicetree overlay
+========= ======================== ======================================
+HDMI      |sbc|                    no overlay needed (enabled by default)
+LVDS0     PEB-AV-10                |dtbo-peb-av-10|
+                                   (loaded by default)
+LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
+MIPI      PEB-AV-12 (MIPI to LVDS) imx8mp-phyboard-pollux-peb-av-012.dtbo
+========= ======================== ======================================
+
+.. note::
+
+   *  When changing Weston output, make sure to match the audio output as well.
+   *  LVDS0 (PEB-AV-10) and LVDS1 (onboard) can not be used at the same time.
+
+HDMI is always enabled in the devicetree. The other interfaces can be enabled
+with Device Tree Overlay.
+
+The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-10). We support a
+10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
+
+.. note::
+
+   The current display driver limits the pixel clock for a display connected to
+   LVDS to 74.25 MHz (or a divider of it). If this does not fit your display
+   requirements, please contact Support for further help.
+
+Weston Configuration
+....................
+
+In order to get an output from Weston on the correct display, it still needs to
+be configured correctly. This will be done at ``/etc/xdg/weston/weston.ini``.
+
+Single Display
+~~~~~~~~~~~~~~
+
+In our BSP, the default Weston output is set to HDMI.
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=off
+
+When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
+the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
+If you want to use LVDS channel 1 (cables connected directly to the
+phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
+
+.. code-block::
+
+   [output]
+   name=HDMI-A-1
+   mode=off
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+Dual Display
+~~~~~~~~~~~~
+
+.. note::
+
+   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
+   together.
+
+For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
+have to be set to the:
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+For dual display at LVDS0 (PEB-AV-10) and MIPI (PEB-AV-012), both dtbos need to
+be loaded at the bootenv.txt and the weston.ini should look like this:
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=off
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+Triple Display
+~~~~~~~~~~~~~~
+
+Three outputs: HDMI, LVDS-1 (PEB-AV-10), and LVDS-2 (PEB-AV-12). Remember to
+load both dtbos for LVDS interfaces.
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+   [output]
+   name=LVDS-2
+   mode=current
 
 .. include:: /bsp/qt6.rsti
 

--- a/source/bsp/imx8/imx8mp/pd23.1.0.rst
+++ b/source/bsp/imx8/imx8mp/pd23.1.0.rst
@@ -1827,7 +1827,7 @@ In our BSP, the default Weston output is set to HDMI.
 When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
 the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
 If you want to use LVDS channel 1 (cables connected directly to the
-phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+phyBOARD-Pollux, not to PEB-AV-10 expansion board), no overlay should be loaded.
 Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 .. code-block::
@@ -1849,7 +1849,7 @@ Dual Display
    together.
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
-have to be set to the:
+need to be configured as follows:
 
 .. code-block::
    :substitutions:
@@ -1863,7 +1863,7 @@ have to be set to the:
    mode=current
 
 For dual display at LVDS0 (PEB-AV-10) and MIPI (PEB-AV-012), both dtbos need to
-be loaded at the bootenv.txt and the weston.ini should look like this:
+be configured in bootenv.txt and the weston.ini should look like this:
 
 .. code-block::
    :substitutions:

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -645,7 +645,7 @@ In our BSP, the default Weston output is set to HDMI.
 When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
 the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
 If you want to use LVDS channel 1 (cables connected directly to the
-phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+phyBOARD-Pollux, not to PEB-AV-10 expansion board), no overlay should be loaded.
 Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 .. code-block::
@@ -667,7 +667,7 @@ Dual Display
    together.
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
-have to be set to the:
+need to be configured as follows:
 
 .. code-block::
    :substitutions:

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -587,8 +587,8 @@ Device Tree Audio configuration:
 
 .. include:: /bsp/peripherals/video.rsti
 
-.. include:: display.rsti
-   :end-before: .. supported-display-interfaces-marker-start
+Display
+-------
 
 The |sbc| supports up to 3 different display outputs. Two can be used
 simultaneously. The following table shows the required extensions and devicetree
@@ -603,9 +603,82 @@ LVDS0     PEB-AV-10                |dtbo-peb-av-10|
 LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
 ========= ======================== ======================================
 
-.. include:: display.rsti
-   :start-after: .. supported-display-interfaces-marker-end
-   :end-before: .. no-peb-av-12-marker
+.. note::
+
+   *  When changing Weston output, make sure to match the audio output as well.
+   *  LVDS0 (PEB-AV-10) and LVDS1 (onboard) can not be used at the same time.
+
+HDMI is always enabled in the devicetree. The other interfaces can be enabled
+with Device Tree Overlay.
+
+The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-10). We support a
+10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
+
+.. note::
+
+   The current display driver limits the pixel clock for a display connected to
+   LVDS to 74.25 MHz (or a divider of it). If this does not fit your display
+   requirements, please contact Support for further help.
+
+Weston Configuration
+....................
+
+In order to get an output from Weston on the correct display, it still needs to
+be configured correctly. This will be done at ``/etc/xdg/weston/weston.ini``.
+
+Single Display
+~~~~~~~~~~~~~~
+
+In our BSP, the default Weston output is set to HDMI.
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=off
+
+When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
+the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
+If you want to use LVDS channel 1 (cables connected directly to the
+phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
+
+.. code-block::
+
+   [output]
+   name=HDMI-A-1
+   mode=off
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+Dual Display
+~~~~~~~~~~~~
+
+.. note::
+
+   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
+   together.
+
+For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
+have to be set to the:
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=current
 
 .. include:: /bsp/qt6.rsti
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -632,7 +632,7 @@ In our BSP, the default Weston output is set to HDMI.
 When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
 the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
 If you want to use LVDS channel 1 (cables connected directly to the
-phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+phyBOARD-Pollux, not to PEB-AV-10 expansion board), no overlay should be loaded.
 Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
 
 .. code-block::
@@ -654,7 +654,7 @@ Dual Display
    together.
 
 For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
-have to be set to the:
+need to be configured as follows:
 
 .. code-block::
    :substitutions:

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -574,8 +574,8 @@ Device Tree Audio configuration:
 
 .. include:: /bsp/peripherals/video.rsti
 
-.. include:: display.rsti
-   :end-before: .. supported-display-interfaces-marker-start
+Display
+-------
 
 The |sbc| supports up to 3 different display outputs. Two can be used
 simultaneously. The following table shows the required extensions and devicetree
@@ -590,9 +590,82 @@ LVDS0     PEB-AV-10                |dtbo-peb-av-10|
 LVDS1     |sbc|                    disabled if PEB-AV-10 overlay is used
 ========= ======================== ======================================
 
-.. include:: display.rsti
-   :start-after: .. supported-display-interfaces-marker-end
-   :end-before: .. no-peb-av-12-marker
+.. note::
+
+   *  When changing Weston output, make sure to match the audio output as well.
+   *  LVDS0 (PEB-AV-10) and LVDS1 (onboard) can not be used at the same time.
+
+HDMI is always enabled in the devicetree. The other interfaces can be enabled
+with Device Tree Overlay.
+
+The default-enabled Interfaces are HDMI and LVDS0 (PEB-AV-10). We support a
+10'' edt,etml1010g0dka display for the |lvds-display-adapters|.
+
+.. note::
+
+   The current display driver limits the pixel clock for a display connected to
+   LVDS to 74.25 MHz (or a divider of it). If this does not fit your display
+   requirements, please contact Support for further help.
+
+Weston Configuration
+....................
+
+In order to get an output from Weston on the correct display, it still needs to
+be configured correctly. This will be done at ``/etc/xdg/weston/weston.ini``.
+
+Single Display
+~~~~~~~~~~~~~~
+
+In our BSP, the default Weston output is set to HDMI.
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=off
+
+When using the LVDS channel 0 (PEB-AV-10) or the LVDS channel 1 as output, set
+the output mode to ``off`` for HDMI-A-1 and for LVDS-1 to ``current``.
+If you want to use LVDS channel 1 (cables connected directly to the
+phyBOARD-Pollux, not to PEB-AV-10 expansion board) then you need to load no overlay.
+Remove the imx8mp-phyboard-pollux-peb-av-xxx.dtbo from bootenv.txt.
+
+.. code-block::
+
+   [output]
+   name=HDMI-A-1
+   mode=off
+
+   [output]
+   name=LVDS-1
+   mode=current
+
+Dual Display
+~~~~~~~~~~~~
+
+.. note::
+
+   For dual and triple display output you can not use LVDS1 (onboard) and HDMI
+   together.
+
+For dual display in dual view mode at HDMI and LVDS0 (PEB-AV-10), both modes
+have to be set to the:
+
+.. code-block::
+   :substitutions:
+
+   [output]
+   name=HDMI-A-1
+   mode=|weston-hdmi-mode|
+
+   [output]
+   name=LVDS-1
+   mode=current
 
 .. include:: /bsp/qt6.rsti
 

--- a/source/bsp/imx8/imx8mp/pd26.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd26.1.0_nxp.rst
@@ -560,28 +560,6 @@ Device Tree Audio configuration:
 .. include:: /bsp/peripherals/video.rsti
 
 .. include:: display.rsti
-   :end-before: .. supported-display-interfaces-marker-start
-
-The |sbc| supports up to 3 different display outputs. Two can be used
-simultaneously. The following table shows the required extensions and devicetree
-overlays for the different interfaces.
-
-========= ======================== ======================================
-Interface Expansion                devicetree overlay
-========= ======================== ======================================
-HDMI      |sbc|                    no overlay needed (enabled by default)
-LVDS0     PEB-AV-10 AC209          imx8mp-phyboard-pollux-peb-av-10-ph128800t006.dtbo
-                                   (loaded by default)
-LVDS0     PEB-AV-10 AC200          imx8mp-phyboard-pollux-peb-av-10-etml1010g3dra.dtbo
-LVDS1     |sbc| AC209              imx8mp-phyboard-pollux-ph128800t006.dtbo
-                                   (disabled if PEB-AV-10 display overlay is used)
-LVDS1     |sbc| AC200              imx8mp-phyboard-pollux-etml1010g3dra.dtbo
-                                   (disabled if PEB-AV-10 display overlay is used)
-========= ======================== ======================================
-
-.. include:: display.rsti
-   :start-after: .. supported-display-interfaces-marker-end
-   :end-before: .. no-peb-av-12-marker
 
 .. include:: /bsp/qt6.rsti
 


### PR DESCRIPTION
- Dissolve display chapter from old BSPs
- Update the display chapter according to the changes done in head and pd26.1.0
- Update the device tree overlay display handling. This was wrong for the pollux on board display