### PR TITLE
Wip/bhahn/imx95 usb

### DIFF
--- a/source/bsp/imx9/imx95-fpsc/head.rst
+++ b/source/bsp/imx9/imx95-fpsc/head.rst
@@ -505,22 +505,29 @@ DT representation for I²C RTCs:
 And the additions on the carrierboard:
 :linux-phytec-imx:`tree/v6.18.20-2.0.0-phy/arch/arm64/boot/dts/freescale/imx95-phyflex-libra-rdk.dts#L436`
 
-USB Host Controller
--------------------
+USB
+---
 
-The USB controller of the |soc| SoC provides a low-cost connectivity solution
-for numerous consumer portable devices by providing a mechanism for data
-transfer between USB devices with a line/bus speed of up to 4 Gbit/s (SuperSpeed
-'SS'). The USB subsystem has two independent USB controller cores. Both cores
-are capable of acting as a USB peripheral device or a USB host. Each is
-connected to a USB 3.0 PHY.
+The |kit| has two USB 2.0 type A ports (X16) that are configured as USB host
+interface and one USB-C 3.0 DRP (Dual Role Port) (X18) that can act
+as device or host. In Linux, the USB-C port will switch the role automatically
+depending on what is plugged into the port. In U-Boot, the port will be
+initialized as device or as host depending on the command that is used.
+
+DT representation for USB-A Host Ports:
+:linux-phytec-imx:`tree/v6.18.20-2.0.0-phy/arch/arm64/boot/dts/freescale/imx95-phyflex-libra-rdk.dts#L538`
+
+DT representation for USB-C DRP:
+:linux-phytec-imx:`tree/v6.18.20-2.0.0-phy/arch/arm64/boot/dts/freescale/imx95-phyflex-libra-rdk.dts#L538`
+
+USB-Host
+........
 
 .. include:: /bsp/peripherals/usb-host.rsti
 
-DT representation for USB Host:
-:linux-phytec-imx:`tree/v6.18.20-2.0.0-phy/arch/arm64/boot/dts/freescale/imx95-phyflex-libra-rdk.dts#L538`
-
 .. include:: /bsp/peripherals/usb-device.rsti
+
+.. include:: /bsp/peripherals/usb-device-uboot.rsti
 
 .. include:: /bsp/peripherals/video.rsti
 

--- a/source/bsp/peripherals/usb-device-uboot.rsti
+++ b/source/bsp/peripherals/usb-device-uboot.rsti
@@ -38,6 +38,6 @@ To share only the first partition of the eMMC with the host instead, run:
 
    u-boot=> ums 0 |emmcdev-uboot|:1
 
-The ums command will run until it is terminated with CTRL+C, the device is
+The ``ums`` command will run until it is terminated with :kbd:`CTRL+C`, the device is
 ejected on the host, or the USB cable is unplugged. Only then will it return to
 the U-Boot console.

--- a/source/bsp/peripherals/usb-device-uboot.rsti
+++ b/source/bsp/peripherals/usb-device-uboot.rsti
@@ -1,0 +1,43 @@
+U-Boot also has support for USB device, there it is called USB mass storage
+(ums). When the USB device port of the board is connected to a USB-A host port
+on the host, a partition on a storage medium on the board or also the complete
+storage medium can be shared to the host via ums.
+
+For this, make sure that USB is first initialized correctly. If USB has not been
+used in U-Boot before, first run ``usb start``, which triggers the necessary usb
+initialization functions.
+
+.. code-block::
+
+   u-boot=> usb start
+
+Then stop the usb host implementation. For boards with dual-role (OTG) ports,
+the usb start function will trigger not only the general initialization of USB,
+but also the initialization of the port in host mode. This will include the
+activation of the VBUS voltage that is supplied by the USB host port. For UMS,
+the port needs to run in device mode though. For that the VBUS voltage needs to
+be disabled on the board.
+
+.. code-block::
+
+   u-boot=> usb stop
+
+If the board is booted via serial downloader boot, the USB port is already
+initialized in device mode, so these earlier steps are not necessary.
+
+Finally the storage medium on the board can be shared with the host with the
+``ums`` command. In this example we share the whole eMMC with the host.
+
+.. code-block::
+
+   u-boot=> ums 0 |emmcdev-uboot|
+
+To share only the first partition of the eMMC with the host instead, run:
+
+.. code-block::
+
+   u-boot=> ums 0 |emmcdev-uboot|:1
+
+The ums command will run until it is terminated with CTRL+C, the device is
+ejected on the host, or the USB cable is unplugged. Only then will it return to
+the U-Boot console.

--- a/source/bsp/peripherals/usb-host.rsti
+++ b/source/bsp/peripherals/usb-host.rsti
@@ -3,3 +3,17 @@ USB-related device drivers must be enabled in the kernel configuration on
 demand. Due to udev, all mass storage devices connected get unique IDs and can
 be found in ``/dev/disk/by-id``. These IDs can be used in ``/etc/fstab`` to mount the
 different USB memory devices in different ways.
+
+In U-Boot USB mass storage devices will not automatically be detected on insertion.
+Instead USB devices will be probed once when USB is started.
+
+.. code-block::
+
+   u-boot=> usb start
+
+If USB is already started and a new device is plugged in, USB needs to be
+restarted to trigger the device detection again.
+
+.. code-block::
+
+   u-boot=> usb reset


### PR DESCRIPTION
rework imx95 usb chapter:
- add doc for usb host and usb device (ums) in U-Boot
- split the USB chapter and document functionality for the two port types (USB-A and USB-C)