### PR TITLE
bsp: imx-common: netboot_fit: add doc about nfs_eth_dev variable

### DIFF
--- a/source/bsp/imx-common/development/netboot_fit.rsti
+++ b/source/bsp/imx-common/development/netboot_fit.rsti
@@ -73,12 +73,16 @@ To use DHCP for booting from a network:
       u-boot=> env set ip_dyn true
       u-boot=> env save
 
-When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
-be set. If addresses different from the PHYTEC provided defaults are desired,
-they can be set in the U-Boot environment:
+When not using DHCP (ip_dyn set to false), which is the default for our NXP
+BSPs, U-Boot needs ipaddr, serverip and nfs_eth_dev to be set.
+nfs_eth_dev describes the name of the ethernet interface in Linux before any
+renaming to the endx naming scheme is applied. By default this should be set to
+the SoM Ethernet in the board environment. If values different from the PHYTEC
+provided defaults are desired, these variables can be set in the U-Boot environment:
 
    .. code-block:: console
 
       u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
       u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env set nfs_eth_dev eth<x>
       u-boot=> env save

--- a/source/bsp/imx8/imx8mm/pd25.1.0.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.0.rst
@@ -316,8 +316,48 @@ Separate the config names by hash symbols. For example:
 
       host:~$ dumpimage -l fitImage
 
-.. include:: /bsp/imx-common/development/netboot_fit.rsti
-   :start-after: .. network-settings-on-target-marker
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/bsp/imx8/imx8mm/pd25.1.1.rst
+++ b/source/bsp/imx8/imx8mm/pd25.1.1.rst
@@ -309,7 +309,52 @@ After saving the changes, follow the remaining steps from |ref-build-uboot|.
 .. _imx8mm-pd25.1.1-host-net-setup:
 
 .. include:: /bsp/development/host_network_setup.rsti
+
 .. include:: /bsp/imx-common/development/netboot_fit.rsti
+   :end-before: .. network-settings-on-target-marker
+
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
+++ b/source/bsp/imx8/imx8mp-fpsc/alpha1.rst
@@ -335,8 +335,48 @@ Separate the config names by hashtag. For example:
 
       host:~$ dumpimage -l fitImage
 
-.. include:: /bsp/imx-common/development/netboot_fit.rsti
-   :start-after: .. network-settings-on-target-marker
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.0_nxp.rst
@@ -334,8 +334,48 @@ Separate the config names by hashtag. For example:
 
       host:~$ dumpimage -l fitImage
 
-.. include:: /bsp/imx-common/development/netboot_fit.rsti
-   :start-after: .. network-settings-on-target-marker
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
+++ b/source/bsp/imx8/imx8mp/pd24.1.1_nxp.rst
@@ -321,8 +321,48 @@ Separate the config names by hashtag. For example:
 
       host:~$ dumpimage -l fitImage
 
-.. include:: /bsp/imx-common/development/netboot_fit.rsti
-   :start-after: .. network-settings-on-target-marker
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/bsp/imx9/imx95-fpsc/alpha1.rst
+++ b/source/bsp/imx9/imx95-fpsc/alpha1.rst
@@ -344,8 +344,48 @@ Separate the config names by hashtag. For example:
 
       host:~$ dumpimage -l fitImage
 
-.. include:: /bsp/imx-common/development/netboot_fit.rsti
-   :start-after: .. network-settings-on-target-marker
+Network Settings on Target
+..........................
+
+To customize the targets ethernet configuration, please follow the description
+here: |ref-network|
+
+Booting from an Embedded Board
+..............................
+
+Boot the board into the U-boot prompt and press any key to hold.
+
+*  To boot from a network, call:
+
+   .. code-block:: console
+
+      u-boot=> setenv boot_targets ethernet
+      u-boot=> bootflow scan -lb
+
+To persistently boot from network, save the environment after setting
+boot_targets to ethernet.
+
+   .. code-block:: console
+
+      u-boot=> env set boot_targets "ethernet"
+      u-boot=> env save
+
+To use DHCP for booting from a network:
+
+   .. code-block:: console
+
+      u-boot=> env set ip_dyn true
+      u-boot=> env save
+
+When not using DHCP (ip_dyn set to false), U-Boot needs ipaddr and serverip to
+be set. If addresses different from the PHYTEC provided defaults are desired,
+they can be set in the U-Boot environment:
+
+   .. code-block:: console
+
+      u-boot=> env set ipaddr <xxx.xxx.xxx.xxx>
+      u-boot=> env set serverip <xxx.xxx.xxx.xxx>
+      u-boot=> env save
 
 .. include:: /bsp/imx-common/development/development_manifests.rsti
 

--- a/source/yocto/include/poky-bitbake/bsp-customization/ampliphy-boot.rsti
+++ b/source/yocto/include/poky-bitbake/bsp-customization/ampliphy-boot.rsti
@@ -110,8 +110,8 @@ Used Variables:
    variable. If unset, default is ``overlays.txt``.
 *  **serverip**: IP addr of the tftp and nfs server. Only used if ip_dyn is set for
    static IPs.
-*  **nfs_eth_dev**: Can be used to set the nfs ethernet interface. If unset,
-   eth0 will be used as default.
+*  **nfs_eth_dev**: If ip_dyn is set for static IPs, this must be used to set
+   the ethernet interface.
 
 spi_boot_fit
 ^^^^^^^^^^^^


### PR DESCRIPTION
Add documentation about the nfs_eth_dev variable that needs to be set, if static IPs are used, for ampliphy-boot to know which ethernet interface should be used to mount the rootfs. Since this is ampliphy-boot specific, this does not apply for some older BSPs. Move the part of the documentation include into those BSP manuals.